### PR TITLE
Add CFO content cluster, restructure homepage, accessibility pass (Month 2)

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -116,11 +116,13 @@ export default function AboutPage() {
       />
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero Section */}
       <section className="pt-32 pb-20 bg-gradient-to-b from-slate-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Our Story</p>
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Our Story</p>
             <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">
               Built by an Operator,<br />for Founders
             </h1>
@@ -331,7 +333,7 @@ export default function AboutPage() {
           </p>
           <a
             href="/contact"
-            className="inline-flex items-center bg-accent-400 text-primary-900 px-8 py-4 rounded-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg btn-premium"
+            className="inline-flex items-center bg-accent-400 text-primary-900 px-8 py-4 rounded-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg"
           >
             Request a Strategy Call
             <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -340,6 +342,8 @@ export default function AboutPage() {
           </a>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/blog/[slug]/page.js
+++ b/app/blog/[slug]/page.js
@@ -123,7 +123,7 @@ export default async function BlogPost({ params }) {
   // Route the end-of-post CTA to the service the post actually supports:
   // finance-tagged posts sell the Fractional CFO service unless an explicitly
   // technical tag overrides (e.g. technical due-diligence, CTO cost guides).
-  const FINANCE_TAGS = ['Finance', 'Startup Finance', 'Financial Modeling', 'Fundraising', 'Cash Management', 'Unit Economics', 'Data Room', 'Metrics']
+  const FINANCE_TAGS = ['Fractional CFO', 'Finance', 'Startup Finance', 'Financial Modeling', 'Fundraising', 'Cash Management', 'Unit Economics', 'Data Room', 'Metrics']
   const TECH_OVERRIDE_TAGS = ['Fractional CTO', 'Technical Leadership', 'Infrastructure']
   const postTags = post.tags ?? []
   const isFinancePost =
@@ -156,6 +156,8 @@ export default async function BlogPost({ params }) {
       />
 
       <Navigation />
+
+      <main id="main-content">
 
       {/* Article Header */}
       <article className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
@@ -249,6 +251,8 @@ export default async function BlogPost({ params }) {
         <h2 className="text-3xl font-bold text-slate-900 mb-8">Comments</h2>
         <GiscusComments />
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -41,6 +41,8 @@ export default function BlogPage() {
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero Section */}
       <section className="pt-32 pb-12 bg-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -74,7 +76,7 @@ export default function BlogPage() {
                           {tag}
                         </span>
                       ))}
-                      <span className="text-xs text-slate-400 ml-auto">{post.readTime}</span>
+                      <span className="text-xs text-slate-500 ml-auto">{post.readTime}</span>
                     </div>
 
                     <h2 className="text-lg font-semibold text-slate-900 mb-2 group-hover:text-primary-600 transition-colors leading-snug">
@@ -106,6 +108,8 @@ export default function BlogPage() {
           </a>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -1,0 +1,144 @@
+import Navigation from '../components/Navigation'
+import Footer from '../components/Footer'
+
+export const metadata = {
+  title: 'Case Studies | Fractional CTO & CFO Client Outcomes',
+  description: 'How Codenest scaled Rungway from 5 to 1,000+ concurrent users, modernised payment infrastructure at Opayo, and delivered a compliant MVP for AstraZeneca.',
+  openGraph: {
+    title: 'Codenest Case Studies — Client Outcomes',
+    description: 'Startup outcomes, backed by enterprise-grade experience. Rungway, Opayo by Elavon, AstraZeneca.',
+    type: 'website',
+    url: 'https://codenest.uk/case-studies/',
+    images: [
+      {
+        url: '/img/og-default.png',
+        width: 1200,
+        height: 630,
+        alt: 'Codenest - Fractional CTO & CFO for UK startups',
+      },
+    ],
+  },
+  alternates: {
+    canonical: 'https://codenest.uk/case-studies/',
+  },
+}
+
+const caseStudies = [
+  {
+    title: "Rungway: Scaling a Social Mentoring Platform",
+    challenge: "A London-based HR-tech startup needed fractional CTO support to scale their social mentoring platform. The system could only handle 5 concurrent users before experiencing severe performance degradation — completely inadequate for their UK enterprise client base.",
+    solution: "As Rungway's interim CTO, our founder delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
+    results: ["Scaled from 5 to 1000+ concurrent users", "Zero-downtime database migration", "Modern DevOps foundations established", "Event-driven microservices architecture"],
+    tags: ["Backend Architecture", "AWS", "DevOps", "Scalability", "Microservices"],
+    image: "/img/photos/case-rungway.jpg",
+    imageAlt: "Data analytics dashboard showing platform scalability metrics"
+  },
+  {
+    title: "Opayo by Elavon: Payment Platform Transformation",
+    challenge: "Leading UK fintech payment provider needed Kubernetes consulting to modernize their infrastructure and integrate new payment channels (Apple Pay, Google Pay) while maintaining 100% uptime for critical transaction processing across Europe.",
+    solution: "Working inside the Opayo platform team, our founder orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
+    results: ["Accelerated releases from every 2 weeks to multiple times per day", "Contributed to 10% revenue increase through faster feature delivery", "Reduced CI pipeline failures through automated testing", "Successfully integrated Apple Pay and Google Pay"],
+    tags: ["Payment Systems", "AWS EKS", "Kubernetes", "Terraform", "GitOps", "Team Leadership"],
+    image: "/img/photos/case-opayo.jpg",
+    imageAlt: "Secure payment processing and mobile payment integration"
+  },
+  {
+    title: "AstraZeneca: Drug Delivery Tracking System MVP",
+    challenge: "AstraZeneca needed to replace manual spreadsheet-based drug delivery tracking with a modern web-based tool to improve efficiency and accelerate time-to-market for pharmaceutical products. The system required integration with existing workflows while maintaining regulatory compliance.",
+    solution: "Our founder built a production-grade web application with REST APIs and automated CI/CD pipelines, collaborating closely with stakeholders and business analysts to define requirements and align delivery with business goals — architecting scalable deployments on Kubernetes using Docker and Jenkins (config-as-code), and establishing robust testing practices with JUnit and Spock.",
+    results: ["Accelerated delivery by 40% compared to manual processes", "Cut deployment errors by 30% through automated pipelines", "Improved stakeholder confidence through transparent roadmap planning", "Delivered production-ready MVP on Kubernetes infrastructure"],
+    tags: ["Healthcare", "Team Leadership", "Kubernetes", "CI/CD", "REST APIs", "Stakeholder Management"],
+    image: "/img/photos/case-astrazeneca.jpg",
+    imageAlt: "Healthcare technology and pharmaceutical tracking systems"
+  }
+]
+
+export default function CaseStudiesPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Navigation />
+
+      <main id="main-content">
+        <section className="pt-40 pb-24 bg-white">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center mb-20">
+              <p className="text-sm uppercase tracking-[0.2em] text-accent-600 mb-4 font-medium">Proven Track Record</p>
+              <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Case Studies</h1>
+              <p className="text-xl text-slate-600 max-w-3xl mx-auto">
+                Startup outcomes, backed by enterprise-grade experience — deep, hands-on collaboration at every stage
+              </p>
+            </div>
+
+            <div className="space-y-12">
+              {caseStudies.map((study, index) => (
+                <div key={index} className="group bg-white rounded-3xl shadow-lg overflow-hidden border border-slate-200 hover:shadow-2xl hover:border-accent-200 transition-all duration-300">
+                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-0">
+                    <div className={`relative h-80 lg:h-auto overflow-hidden ${index % 2 === 0 ? 'lg:order-1' : 'lg:order-2'}`}>
+                      <img
+                        src={study.image}
+                        alt={study.imageAlt || study.title}
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                        width={600}
+                        height={400}
+                      />
+                      {/* Index badge */}
+                      <div className="absolute top-4 left-4 w-10 h-10 bg-white/90 backdrop-blur-sm rounded-full flex items-center justify-center shadow-md">
+                        <span className="text-sm font-bold text-primary-600">{String(index + 1).padStart(2, '0')}</span>
+                      </div>
+                    </div>
+                    <div className={`p-10 lg:p-12 ${index % 2 === 0 ? 'lg:order-2' : 'lg:order-1'}`}>
+                      <h2 className="text-3xl font-bold text-slate-900 mb-4 group-hover:text-primary-700 transition-colors">{study.title}</h2>
+                      <div className="space-y-6">
+                        <div>
+                          <h3 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">Challenge</h3>
+                          <p className="text-slate-600">{study.challenge}</p>
+                        </div>
+                        <div>
+                          <h3 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">Solution</h3>
+                          <p className="text-slate-600">{study.solution}</p>
+                        </div>
+                        <div>
+                          <h3 className="text-sm font-semibold text-accent-600 uppercase tracking-wide mb-3">Results</h3>
+                          <ul className="space-y-2">
+                            {study.results.map((result, i) => (
+                              <li key={i} className="flex items-start">
+                                <svg className="w-5 h-5 text-accent-500 mt-0.5 mr-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                                <span className="text-slate-700 font-medium">{result}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                        <div className="flex flex-wrap gap-2 pt-2">
+                          {study.tags.map((tag, i) => (
+                            <span key={i} className="px-2 py-1 bg-primary-50 text-primary-700 rounded text-xs font-medium">
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="text-center mt-16">
+              <a
+                href="/contact"
+                className="inline-block bg-accent-400 text-primary-900 px-8 py-4 rounded-lg text-base font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg"
+              >
+                Request a Strategy Call
+              </a>
+              <p className="text-sm text-slate-500 mt-3">Free 30 minutes. No sales pitch.</p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/app/cofounder/page.js
+++ b/app/cofounder/page.js
@@ -143,6 +143,8 @@ export default function CofounderPage() {
 
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero Section */}
       <section className="pt-32 pb-20 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white relative overflow-hidden">
         {/* Background decoration */}
@@ -362,6 +364,8 @@ export default function CofounderPage() {
           </p>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/components/Button.js
+++ b/app/components/Button.js
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+
+// The single source of truth for CTA styling (BRANDING.md §6).
+// variant="primary": gold fill — the one conversion action per screen.
+// variant="secondary": slate outline, gold on hover.
+const VARIANTS = {
+  primary:
+    'inline-block bg-accent-400 text-primary-900 font-semibold rounded-lg shadow-gold hover:bg-accent-500 hover:shadow-gold-lg transition-all text-center',
+  secondary:
+    'inline-block border-2 border-slate-300 text-slate-700 font-semibold rounded-lg hover:border-accent-400 hover:text-primary-700 transition-all text-center',
+}
+
+const SIZES = {
+  md: 'px-6 py-3 text-sm',
+  lg: 'px-8 py-4 text-base',
+}
+
+export default function Button({ href, variant = 'primary', size = 'lg', className = '', children, ...rest }) {
+  const classes = `${VARIANTS[variant]} ${SIZES[size]} ${className}`.trim()
+  const isInternalPage = href.startsWith('/') && !href.includes('#')
+  if (isInternalPage) {
+    return (
+      <Link href={href} className={classes} {...rest}>
+        {children}
+      </Link>
+    )
+  }
+  return (
+    <a href={href} className={classes} {...rest}>
+      {children}
+    </a>
+  )
+}

--- a/app/components/ContactForm.js
+++ b/app/components/ContactForm.js
@@ -342,22 +342,20 @@ const ContactForm = () => {
           />
         </div>
 
-        <div>
-          <label className="block text-sm font-semibold text-slate-700 mb-3">
+        <fieldset>
+          <legend className="block text-sm font-semibold text-slate-700 mb-3">
             What are you looking for?
-          </label>
-          {/* Hidden input to ensure engagement value is sent to EmailJS */}
-          <input type="hidden" name="engagement" value={formData.engagement} />
+          </legend>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {[
-              { value: 'fractional', label: 'Fractional CTO/CFO', desc: 'Part-time leadership' },
-              { value: 'project', label: 'Project Work', desc: 'MVP or specific build' },
-              { value: 'advisory', label: 'Advisory', desc: 'Strategic guidance' },
-              { value: 'cofounder', label: 'Co-founder Fit', desc: 'Deeper partnership' },
+              { value: 'fractional-cto', label: 'Fractional CTO', desc: 'Technology leadership' },
+              { value: 'fractional-cfo', label: 'Fractional CFO', desc: 'Finance leadership' },
+              { value: 'both', label: 'Both / Not sure yet', desc: 'Integrated or exploring' },
+              { value: 'cofounder', label: 'Co-founder Partnership', desc: 'Deeper commitment' },
             ].map((option) => (
               <label
                 key={option.value}
-                className={`relative flex items-start p-3 rounded-xl border-2 cursor-pointer transition-all ${
+                className={`relative flex items-start p-3 rounded-xl border-2 cursor-pointer transition-all has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary-500 has-[:focus-visible]:ring-offset-2 ${
                   formData.engagement === option.value
                     ? 'border-primary-500 bg-primary-50'
                     : 'border-slate-200 hover:border-slate-300 bg-white'
@@ -365,6 +363,7 @@ const ContactForm = () => {
               >
                 <input
                   type="radio"
+                  name="engagement"
                   value={option.value}
                   checked={formData.engagement === option.value}
                   onChange={(e) => handleChange({ target: { name: 'engagement', value: e.target.value } })}
@@ -386,7 +385,7 @@ const ContactForm = () => {
               </label>
             ))}
           </div>
-        </div>
+        </fieldset>
 
         <div>
           <label htmlFor="message" className="block text-sm font-semibold text-slate-700 mb-2">

--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -26,8 +26,8 @@ export default function Footer() {
               <li><Link href="/services" className="text-slate-400 hover:text-accent-400 transition-colors">All Services</Link></li>
               <li><Link href="/services/fractional-cto" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CTO</Link></li>
               <li><Link href="/services/fractional-cfo" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CFO</Link></li>
-              <li><Link href="/#services" className="text-slate-400 hover:text-accent-400 transition-colors">0-to-1 Product Builds</Link></li>
-              <li><Link href="/#services" className="text-slate-400 hover:text-accent-400 transition-colors">AI & Data Engineering</Link></li>
+              <li><Link href="/services" className="text-slate-400 hover:text-accent-400 transition-colors">0-to-1 Product Builds</Link></li>
+              <li><Link href="/services" className="text-slate-400 hover:text-accent-400 transition-colors">AI & Data Engineering</Link></li>
             </ul>
           </div>
           <div>
@@ -35,6 +35,7 @@ export default function Footer() {
             <ul className="space-y-2 text-sm">
               <li><Link href="/guides" className="text-slate-400 hover:text-accent-400 transition-colors">All Guides</Link></li>
               <li><Link href="/guides/fractional-cto-guide" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CTO Guide</Link></li>
+              <li><Link href="/guides/fractional-cfo-guide" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CFO Guide</Link></li>
               <li><Link href="/guides/fractional-cto-vs-full-time" className="text-slate-400 hover:text-accent-400 transition-colors">CTO vs Full-Time</Link></li>
               <li><Link href="/guides/fractional-cto-vs-agency" className="text-slate-400 hover:text-accent-400 transition-colors">CTO vs Agency</Link></li>
               <li><Link href="/guides/technical-cofounder-alternatives" className="text-slate-400 hover:text-accent-400 transition-colors">Co-founder Alternatives</Link></li>
@@ -44,7 +45,7 @@ export default function Footer() {
           <div>
             <h4 className="font-semibold mb-4">Company</h4>
             <ul className="space-y-2 text-sm">
-              <li><a href="/#case-studies" className="text-slate-400 hover:text-accent-400 transition-colors">Client Partnerships</a></li>
+              <li><a href="/case-studies" className="text-slate-400 hover:text-accent-400 transition-colors">Client Partnerships</a></li>
               <li><a href="/#how-we-work" className="text-slate-400 hover:text-accent-400 transition-colors">Our Methodology</a></li>
               <li><a href="/about" className="text-slate-400 hover:text-accent-400 transition-colors">Our Story</a></li>
               <li><Link href="/blog" className="text-slate-400 hover:text-accent-400 transition-colors">Insights</Link></li>

--- a/app/components/Navigation.js
+++ b/app/components/Navigation.js
@@ -25,7 +25,7 @@ export default function Navigation() {
     <>
       {/* Skip to main content link for accessibility */}
       <a
-        href="#home"
+        href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-accent-500 text-primary-900 px-4 py-2 rounded-lg z-[100] font-semibold"
       >
         Skip to main content
@@ -40,7 +40,7 @@ export default function Navigation() {
       >
         <a
           href={contactHref}
-          className="flex items-center gap-2 bg-accent-400 text-primary-900 px-6 py-3 rounded-full text-sm font-semibold shadow-gold hover:shadow-gold-lg hover:bg-accent-500 transition-all btn-premium cta-pulse"
+          className="flex items-center gap-2 bg-accent-400 text-primary-900 px-6 py-3 rounded-full text-sm font-semibold shadow-gold hover:shadow-gold-lg hover:bg-accent-500 transition-all"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
@@ -58,7 +58,7 @@ export default function Navigation() {
         <div className="bg-white/95 backdrop-blur-sm border-t border-slate-200 px-4 py-3 safe-area-bottom">
           <a
             href={contactHref}
-            className="flex items-center justify-center gap-2 bg-accent-400 text-primary-900 w-full py-3.5 rounded-xl text-base font-semibold shadow-gold hover:bg-accent-500 transition-all cta-pulse"
+            className="flex items-center justify-center gap-2 bg-accent-400 text-primary-900 w-full py-3.5 rounded-xl text-base font-semibold shadow-gold hover:bg-accent-500 transition-all"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
@@ -86,10 +86,10 @@ export default function Navigation() {
             <div className="ml-10 flex items-baseline space-x-1">
               <Link href="/services/fractional-cto" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CTO</Link>
               <Link href="/services/fractional-cfo" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CFO</Link>
-              <a href="/#case-studies" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Case Studies</a>
+              <a href="/case-studies" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Case Studies</a>
               <a href="/about" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">About</a>
               <a href="/blog" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Blog</a>
-              <a href={contactHref} className="bg-accent-400 text-primary-900 px-6 py-2.5 ml-2 rounded-lg text-sm font-semibold hover:bg-accent-500 transition-all shadow-sm hover:shadow-gold btn-premium cta-pulse">Request a Strategy Call</a>
+              <a href={contactHref} className="bg-accent-400 text-primary-900 px-6 py-2.5 ml-2 rounded-lg text-sm font-semibold hover:bg-accent-500 transition-all shadow-sm hover:shadow-gold">Request a Strategy Call</a>
             </div>
           </div>
 
@@ -115,7 +115,7 @@ export default function Navigation() {
             <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-slate-100">
               <Link href="/services/fractional-cto" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Fractional CTO</Link>
               <Link href="/services/fractional-cfo" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Fractional CFO</Link>
-              <a href="/#case-studies" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Case Studies</a>
+              <a href="/case-studies" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Case Studies</a>
               <a href="/about" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">About</a>
               <a href="/blog" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Blog</a>
               <a href={contactHref} onClick={() => setIsMenuOpen(false)} className="bg-accent-400 text-primary-900 font-semibold block px-3 py-2 text-base rounded-lg hover:bg-accent-500 transition-all shadow-sm">Request a Strategy Call</a>

--- a/app/components/ServiceCard.js
+++ b/app/components/ServiceCard.js
@@ -1,12 +1,13 @@
 import Image from 'next/image'
+import Link from 'next/link'
 
 export default function ServiceCard({ service, priority = false }) {
   const isTech = service.track === 'technical'
-  const trackColor = isTech ? 'primary' : 'accent'
   const trackBorderClass = isTech ? 'service-card-tech' : 'service-card-financial'
+  const href = service.href || (isTech ? '/services/fractional-cto' : '/services/fractional-cfo')
 
   return (
-    <div className={`group bg-white border border-slate-200 rounded-xl hover:shadow-xl transition-all duration-300 overflow-hidden h-full flex flex-col card-lift ${trackBorderClass}`}>
+    <Link href={href} className={`group bg-white border border-slate-200 rounded-xl hover:shadow-xl transition-all duration-300 overflow-hidden h-full flex flex-col card-lift ${trackBorderClass}`}>
       {/* Image Section with warm overlay */}
       <div className="relative h-56 overflow-hidden img-warm-overlay">
         <Image
@@ -28,13 +29,13 @@ export default function ServiceCard({ service, priority = false }) {
         </div>
 
         <div className="absolute bottom-5 left-5 right-5">
-          <h3 className="font-serif text-xl font-bold text-white drop-shadow-lg">{service.title}</h3>
+          <h3 className="text-xl font-bold text-white drop-shadow-lg">{service.title}</h3>
         </div>
       </div>
 
       {/* Content Section */}
       <div className="p-6 flex flex-col flex-grow">
-        <p className={`${isTech ? 'text-primary-600' : 'text-accent-500'} font-semibold text-sm mb-2`}>{service.benefit}</p>
+        <p className={`${isTech ? 'text-primary-600' : 'text-accent-700'} font-semibold text-sm mb-2`}>{service.benefit}</p>
         <p className="text-slate-600 text-sm leading-relaxed mb-5">{service.description}</p>
 
         {/* Outcomes with track-colored checkmarks */}
@@ -52,6 +53,6 @@ export default function ServiceCard({ service, priority = false }) {
 
       {/* Bottom accent bar */}
       <div className={`h-1 ${isTech ? 'bg-gradient-to-r from-primary-600 to-primary-400' : 'bg-gold-gradient'} opacity-0 group-hover:opacity-100 transition-opacity duration-300`} />
-    </div>
+    </Link>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,23 +16,6 @@
 }
 
 @layer components {
-  /* Premium button with gold shimmer effect */
-  .btn-premium {
-    @apply relative overflow-hidden;
-  }
-
-  .btn-premium::before {
-    content: '';
-    @apply absolute inset-0 opacity-0 transition-opacity duration-300;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
-    transform: translateX(-100%);
-  }
-
-  .btn-premium:hover::before {
-    @apply opacity-100;
-    animation: btnShimmer 0.6s ease-out;
-  }
-
   /* Gold accent underline for links */
   .link-gold {
     @apply relative;
@@ -118,36 +101,9 @@
     -webkit-text-fill-color: transparent;
     background-clip: text;
   }
-
-  /* Subtle focus ring with gold */
-  .focus-gold:focus {
-    @apply outline-none ring-2 ring-accent-400 ring-offset-2;
-  }
-}
-
-@keyframes btnShimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
 }
 
 /* Subtle pulse animation for CTAs */
-@keyframes ctaPulse {
-  0%, 100% {
-    box-shadow: 0 4px 14px 0 rgba(212, 175, 55, 0.3);
-  }
-  50% {
-    box-shadow: 0 4px 20px 0 rgba(212, 175, 55, 0.5);
-  }
-}
-
-.cta-pulse {
-  animation: ctaPulse 2s ease-in-out infinite;
-}
-
 /* Attention-grabbing bounce for sticky CTA */
 @keyframes subtleBounce {
   0%, 100% {
@@ -218,14 +174,17 @@
   opacity: 0;
 }
 
-/* Section reveal on scroll (requires JS intersection observer) */
-.reveal-section {
-  opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-}
 
-.reveal-section.revealed {
-  opacity: 1;
-  transform: translateY(0);
+/* Respect users who opt out of motion */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/app/guides/fractional-cfo-guide/page.js
+++ b/app/guides/fractional-cfo-guide/page.js
@@ -1,0 +1,612 @@
+import Link from 'next/link'
+import Navigation from '../../components/Navigation'
+import Footer from '../../components/Footer'
+
+export const metadata = {
+  title: 'The Complete Guide to Fractional CFO Services UK',
+  description: 'Everything UK founders need to know about fractional CFO services: what they do, costs, when to hire, fractional CFO vs accountant, and how to choose the right one for your startup.',
+  keywords: ['fractional CFO guide', 'what is a fractional CFO', 'fractional CFO cost UK', 'when to hire a fractional CFO', 'fractional CFO vs accountant', 'part-time CFO startup', 'fractional CFO services UK'],
+  openGraph: {
+    title: 'The Complete Guide to Fractional CFO Services UK',
+    description: 'Everything UK founders need to know about fractional CFO services: what they do, costs, when to hire, and how to choose.',
+    type: 'article',
+    url: 'https://codenest.uk/guides/fractional-cfo-guide/',
+    images: [
+      {
+        url: '/img/og-default.png',
+        width: 1200,
+        height: 630,
+        alt: 'Codenest - Fractional CTO & CFO for UK startups',
+      },
+    ],
+  },
+  alternates: {
+    canonical: 'https://codenest.uk/guides/fractional-cfo-guide/',
+  },
+}
+
+export default function FractionalCFOGuidePage() {
+  const tableOfContents = [
+    { id: 'what-is', title: 'What is a Fractional CFO?' },
+    { id: 'responsibilities', title: 'What Does a Fractional CFO Do?' },
+    { id: 'when-to-hire', title: 'When Should You Hire a Fractional CFO?' },
+    { id: 'costs', title: 'How Much Does a Fractional CFO Cost?' },
+    { id: 'vs-full-time', title: 'Fractional CFO vs Full-Time CFO' },
+    { id: 'vs-accountant', title: 'Fractional CFO vs Accountant vs Controller' },
+    { id: 'how-to-choose', title: 'How to Choose a Fractional CFO' },
+    { id: 'working-together', title: 'Working with a Fractional CFO' },
+    { id: 'faq', title: 'Frequently Asked Questions' },
+  ]
+
+  const faqs = [
+    {
+      question: 'How much does a fractional CFO cost in the UK?',
+      answer: 'Most UK fractional CFO engagements fall roughly between £2,000 and £12,000 per month depending on intensity, from light-touch advisory through to two or three days per week. Codenest Fractional CFO engagements start from £2,500 per month. A full-time CFO, by comparison, typically costs £150,000-£250,000+ in salary alone, plus equity, benefits and recruitment fees.'
+    },
+    {
+      question: 'What is the difference between a fractional CFO and an accountant?',
+      answer: 'An accountant looks backwards: statutory accounts, corporation tax, VAT and payroll compliance. A fractional CFO looks forwards: financial models, runway and cash management, fundraising, pricing and board reporting. Most startups need both, and a fractional CFO builds on the records your accountant keeps rather than replacing them.'
+    },
+    {
+      question: 'How many hours per week does a fractional CFO work?',
+      answer: 'Typically between half a day and three days per week, depending on stage and workload. Many engagements start light and scale up around a fundraise, then settle back into a steady monthly rhythm of reporting, reforecasting and board support.'
+    },
+    {
+      question: 'When should a startup hire a fractional CFO?',
+      answer: 'The most common triggers are preparing to raise, deploying a fresh round with discipline, runway pressure, and growing board or investor reporting demands. If financial questions are consuming founder time or going unanswered, it is usually time to bring in part-time finance leadership.'
+    },
+    {
+      question: 'Can a fractional CFO help with fundraising?',
+      answer: 'Yes. For most early-stage engagements it is the core of the role. A fractional CFO builds the financial model, prepares the data room, stress-tests your assumptions before investors do, and helps you answer diligence questions with confidence.'
+    },
+  ]
+
+  // Structured data
+  const articleSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'The Complete Guide to Fractional CFO Services UK',
+    description: 'Everything UK founders need to know about fractional CFO services.',
+    author: {
+      '@type': 'Organization',
+      name: 'Codenest',
+      url: 'https://codenest.uk'
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Codenest',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://codenest.uk/img/companylogo.png'
+      }
+    },
+    datePublished: '2026-08-04',
+    dateModified: '2026-08-04',
+    mainEntityOfPage: 'https://codenest.uk/guides/fractional-cfo-guide/'
+  }
+
+  const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map(faq => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer
+      }
+    }))
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+
+      <Navigation />
+
+      <main id="main-content">
+
+        {/* Hero */}
+        <section className="pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center">
+              <span className="inline-block px-4 py-2 bg-accent-50 text-accent-700 rounded-full text-sm font-medium mb-6">
+                Complete Guide
+              </span>
+              <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-bold text-slate-900 mb-6">
+                The Complete Guide to<br />Fractional CFO Services in the UK
+              </h1>
+              <p className="text-xl text-slate-600 max-w-2xl mx-auto mb-8">
+                Everything UK founders need to know about hiring a fractional CFO: what they do, what they cost, when to bring one in, and how to choose the right one.
+              </p>
+              <p className="text-sm text-slate-500">
+                Updated August 2026 &middot; 15 min read
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Main Content */}
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-12">
+            {/* Table of Contents - Sidebar */}
+            <aside className="lg:col-span-1">
+              <div className="sticky top-24 bg-slate-50 rounded-2xl p-6 border border-slate-200">
+                <h2 className="font-bold text-slate-900 mb-4">Contents</h2>
+                <nav className="space-y-2">
+                  {tableOfContents.map((item) => (
+                    <a
+                      key={item.id}
+                      href={`#${item.id}`}
+                      className="block text-sm text-slate-600 hover:text-primary-600 transition-colors py-1"
+                    >
+                      {item.title}
+                    </a>
+                  ))}
+                </nav>
+              </div>
+            </aside>
+
+            {/* Article Content */}
+            <article className="lg:col-span-3 prose prose-lg prose-slate max-w-none">
+
+              {/* What is a Fractional CFO */}
+              <section id="what-is" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  What is a Fractional CFO?
+                </h2>
+                <p>
+                  A <strong>fractional CFO</strong> is a senior finance executive who provides part-time strategic financial leadership to companies that need the judgement of a Chief Financial Officer without the cost of a full-time hire.
+                </p>
+                <p>
+                  The key word is <em>strategic</em>. A fractional CFO is not a bookkeeper and not a replacement for your accountant. Bookkeeping and accounting record what has already happened; a fractional CFO is concerned with what happens next — how long your cash lasts, what your next round needs to look like, whether your pricing supports the business you are building, and what the board should be told and when.
+                </p>
+                <p>
+                  Like a fractional CTO, a fractional CFO is embedded rather than advisory-only. They own the financial model, sit in board meetings, field investor questions, and take accountability for the quality of your numbers — typically for one to three days a week rather than five.
+                </p>
+                <p>
+                  The model has become a natural fit for UK startups between pre-seed and Series A: the financial workload at that stage is genuinely executive-level, but it is not yet a five-day-a-week job. Fractional finance leadership is one of the two executive seats Codenest provides — you can read exactly what an engagement includes on our <Link href="/services/fractional-cfo" className="text-primary-600 hover:text-primary-700 font-medium">Fractional CFO services page</Link>.
+                </p>
+                <div className="bg-primary-50 border border-primary-200 rounded-xl p-6 my-8 not-prose">
+                  <p className="font-semibold text-primary-900 mb-2">Key Point</p>
+                  <p className="text-primary-800">
+                    A fractional CFO typically works between half a day and three days per week, costs 60-80% less than a full-time hire, and can usually start within a couple of weeks — rather than the months a full-time executive search takes.
+                  </p>
+                </div>
+              </section>
+
+              {/* What Does a Fractional CFO Do */}
+              <section id="responsibilities" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  What Does a Fractional CFO Do?
+                </h2>
+                <p>
+                  The responsibilities of a fractional CFO flex with your stage and situation, but for a pre-seed to Series A startup they typically cover five areas:
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Financial Modelling &amp; FP&amp;A</h3>
+                <ul>
+                  <li>Building and maintaining a three-statement financial model founders can actually use</li>
+                  <li>Budgeting, and monthly budget-versus-actuals reviews</li>
+                  <li>Scenario and sensitivity analysis — what happens if sales slip a quarter, or a hire is delayed</li>
+                  <li>Defining the KPIs that matter for your business model, and reporting them consistently</li>
+                  <li>Modelling the cash impact of hiring plans and major spend decisions before they are made</li>
+                </ul>
+                <p className="mt-4">
+                  <Link href="/blog/financial-modeling-seed-stage-startups" className="text-primary-600 hover:text-primary-700 font-medium">
+                    Related reading: Financial modelling for seed-stage startups →
+                  </Link>
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Cash &amp; Runway Management</h3>
+                <ul>
+                  <li>A 13-week rolling cash flow, so short-term cash is never a surprise</li>
+                  <li>Burn tracking and runway scenarios under different growth and spend assumptions</li>
+                  <li>Working-capital management — debtor chasing, creditor terms, VAT timing</li>
+                  <li>Cost reviews and supplier renegotiation when runway needs extending</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Fundraising Support &amp; Data Rooms</h3>
+                <ul>
+                  <li>Sizing and timing the raise against your milestones and runway</li>
+                  <li>Preparing a model that survives investor diligence, with assumptions you can defend</li>
+                  <li>Building and managing the data room before investors ask for it</li>
+                  <li>Supporting term-sheet review and cap-table modelling alongside your lawyers</li>
+                  <li>Preparing founders for the financial questions investors will ask</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Board &amp; Investor Reporting</h3>
+                <ul>
+                  <li>A monthly management accounts and KPI pack, produced on a reliable rhythm</li>
+                  <li>Owning the financial section of the board pack — and the narrative around the numbers</li>
+                  <li>Regular investor updates that build confidence between rounds</li>
+                  <li>Grant, covenant or R&amp;D-claim reporting where relevant</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Unit Economics &amp; Pricing</h3>
+                <ul>
+                  <li>Customer acquisition cost, lifetime value and payback period — measured, not guessed</li>
+                  <li>Contribution margin by product, plan or customer segment</li>
+                  <li>Pricing structure and pricing-change analysis grounded in margin and willingness to pay</li>
+                  <li>Discounting policy, so sales flexibility does not quietly erode the model</li>
+                </ul>
+              </section>
+
+              {/* When to Hire */}
+              <section id="when-to-hire" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  When Should You Hire a Fractional CFO?
+                </h2>
+                <p>
+                  Most founders bring in a fractional CFO in response to one of five triggers:
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">You&apos;re Preparing to Raise</h3>
+                <p>
+                  This is the most common trigger, and the one with the clearest payoff. Investors will diligence your numbers: the model, the assumptions behind it, historical performance and the data room. A fractional CFO gets all of that investor-ready — ideally starting three to six months before you go out, so the numbers shape the raise rather than scramble after it.
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">You&apos;ve Just Closed a Round</h3>
+                <p>
+                  New capital demands new discipline. The plan you pitched needs to become a budget; the investors who wired the money expect regular reporting; and spend decisions now carry someone else&apos;s money. A fractional CFO turns post-raise good intentions into a working financial operating rhythm.
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Runway Is Under Pressure</h3>
+                <p>
+                  When cash is tight, precision matters. A fractional CFO replaces a vague sense of &quot;about a year left&quot; with a 13-week cash flow, runway scenarios, and a clear-eyed view of which costs to cut, defer or renegotiate — and how those choices trade off against growth.
+                </p>
+                <p>
+                  <Link href="/tools/runway-calculator" className="text-primary-600 hover:text-primary-700 font-medium">
+                    Not sure where you stand? Use our free runway calculator →
+                  </Link>
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Board Reporting Is Getting Demanding</h3>
+                <p>
+                  Once institutional investors join your cap table, expectations change. Monthly management accounts, a proper board pack, and answers that hold up to scrutiny become the baseline. A fractional CFO takes that burden off the founders and raises the standard at the same time.
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">You&apos;re Making Pricing and Unit-Economics Decisions</h3>
+                <p>
+                  Pricing changes, discount policies, and which customers to pursue are finance questions as much as commercial ones. If those calls are being made on instinct rather than margin analysis, a fractional CFO pays for themselves quickly.
+                </p>
+
+                <div className="bg-accent-50 border border-accent-200 rounded-xl p-6 my-8 not-prose">
+                  <p className="font-semibold text-accent-900 mb-2">Signs You Need a Fractional CFO</p>
+                  <ul className="text-accent-800 space-y-1 text-sm">
+                    <li>• You can&apos;t state this month&apos;s burn or your runway without opening several spreadsheets</li>
+                    <li>• Investor questions about your numbers take days to answer</li>
+                    <li>• The financial model was built for the last raise and hasn&apos;t been touched since</li>
+                    <li>• Pricing is set by gut feel rather than margin analysis</li>
+                    <li>• The board pack is assembled the night before the meeting</li>
+                  </ul>
+                </div>
+              </section>
+
+              {/* Costs */}
+              <section id="costs" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  How Much Does a Fractional CFO Cost?
+                </h2>
+                <p>
+                  UK fractional CFO pricing varies with experience, sector and — above all — intensity. Most engagements fall roughly between £2,000 and £12,000 per month:
+                </p>
+
+                <div className="overflow-x-auto my-8 not-prose">
+                  <table className="w-full border-collapse">
+                    <thead>
+                      <tr className="bg-slate-100">
+                        <th className="border border-slate-300 px-4 py-3 text-left font-semibold">Engagement Level</th>
+                        <th className="border border-slate-300 px-4 py-3 text-left font-semibold">Typical Commitment</th>
+                        <th className="border border-slate-300 px-4 py-3 text-left font-semibold">Monthly Cost</th>
+                        <th className="border border-slate-300 px-4 py-3 text-left font-semibold">Annual Equivalent</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td className="border border-slate-300 px-4 py-3">Light-Touch Advisory</td>
+                        <td className="border border-slate-300 px-4 py-3">A few hours per week</td>
+                        <td className="border border-slate-300 px-4 py-3">£2,000-£3,500</td>
+                        <td className="border border-slate-300 px-4 py-3">£24,000-£42,000</td>
+                      </tr>
+                      <tr className="bg-slate-50">
+                        <td className="border border-slate-300 px-4 py-3">Standard</td>
+                        <td className="border border-slate-300 px-4 py-3">Around one day per week</td>
+                        <td className="border border-slate-300 px-4 py-3">£3,500-£6,000</td>
+                        <td className="border border-slate-300 px-4 py-3">£42,000-£72,000</td>
+                      </tr>
+                      <tr>
+                        <td className="border border-slate-300 px-4 py-3">Intensive</td>
+                        <td className="border border-slate-300 px-4 py-3">Two to three days per week</td>
+                        <td className="border border-slate-300 px-4 py-3">£6,000-£12,000</td>
+                        <td className="border border-slate-300 px-4 py-3">£72,000-£144,000</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <p>
+                  Codenest Fractional CFO engagements start from £2,500 per month — see the <Link href="/services/fractional-cfo" className="text-primary-600 hover:text-primary-700 font-medium">Fractional CFO services page</Link> for what each engagement includes.
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Cost Comparison: Fractional vs Full-Time</h3>
+                <p>
+                  A full-time CFO in the UK typically costs:
+                </p>
+                <ul>
+                  <li><strong>Base salary:</strong> £150,000-£250,000+</li>
+                  <li><strong>Employer&apos;s National Insurance:</strong> £20,000-£35,000</li>
+                  <li><strong>Pension contributions:</strong> £5,000-£12,000</li>
+                  <li><strong>Benefits:</strong> £5,000-£15,000</li>
+                  <li><strong>Equity:</strong> typically 0.5-2% (immediate dilution)</li>
+                  <li><strong>Recruitment fees:</strong> £35,000-£75,000 one-off, often 25-30% of base salary</li>
+                </ul>
+                <p>
+                  <strong>Total Year 1:</strong> roughly £210,000-£360,000+ plus equity dilution.
+                </p>
+                <p>
+                  A fractional CFO at around one day per week costs £48,000-£96,000 a year — typically <strong>60-80% less</strong> than the all-in cost of a full-time hire, with no equity dilution, no recruitment fees, and no severance exposure if your needs change.
+                </p>
+              </section>
+
+              {/* vs Full-Time */}
+              <section id="vs-full-time" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  Fractional CFO vs Full-Time CFO
+                </h2>
+
+                <div className="overflow-x-auto my-8 not-prose">
+                  <table className="w-full border-collapse">
+                    <thead>
+                      <tr className="bg-slate-100">
+                        <th className="border border-slate-300 px-4 py-3 text-left font-semibold">Factor</th>
+                        <th className="border border-slate-300 px-4 py-3 text-left font-semibold">Fractional CFO</th>
+                        <th className="border border-slate-300 px-4 py-3 text-left font-semibold">Full-Time CFO</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td className="border border-slate-300 px-4 py-3 font-medium">Cost</td>
+                        <td className="border border-slate-300 px-4 py-3">£24k-£144k/year</td>
+                        <td className="border border-slate-300 px-4 py-3">£215k-£350k+/year all-in</td>
+                      </tr>
+                      <tr className="bg-slate-50">
+                        <td className="border border-slate-300 px-4 py-3 font-medium">Equity</td>
+                        <td className="border border-slate-300 px-4 py-3">None typically</td>
+                        <td className="border border-slate-300 px-4 py-3">0.5-2%</td>
+                      </tr>
+                      <tr>
+                        <td className="border border-slate-300 px-4 py-3 font-medium">Time to Start</td>
+                        <td className="border border-slate-300 px-4 py-3">1-2 weeks</td>
+                        <td className="border border-slate-300 px-4 py-3">3-6 months</td>
+                      </tr>
+                      <tr className="bg-slate-50">
+                        <td className="border border-slate-300 px-4 py-3 font-medium">Availability</td>
+                        <td className="border border-slate-300 px-4 py-3">Half a day to 3 days/week</td>
+                        <td className="border border-slate-300 px-4 py-3">Full-time</td>
+                      </tr>
+                      <tr>
+                        <td className="border border-slate-300 px-4 py-3 font-medium">Flexibility</td>
+                        <td className="border border-slate-300 px-4 py-3">Scale up and down around a raise</td>
+                        <td className="border border-slate-300 px-4 py-3">Fixed commitment</td>
+                      </tr>
+                      <tr className="bg-slate-50">
+                        <td className="border border-slate-300 px-4 py-3 font-medium">Risk</td>
+                        <td className="border border-slate-300 px-4 py-3">Low (monthly terms)</td>
+                        <td className="border border-slate-300 px-4 py-3">High (severance, rehiring)</td>
+                      </tr>
+                      <tr>
+                        <td className="border border-slate-300 px-4 py-3 font-medium">Best For</td>
+                        <td className="border border-slate-300 px-4 py-3">Pre-seed to Series A</td>
+                        <td className="border border-slate-300 px-4 py-3">Series B+ or complex finance operations</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <p>
+                  <strong>Choose fractional when:</strong> the finance workload is strategic but not yet a five-day-a-week job, you raise every 12-24 months rather than run continuous corporate-finance activity, or your runway means every senior hire has to justify itself.
+                </p>
+                <p>
+                  <strong>Choose full-time when:</strong> you have a finance team that needs daily executive leadership, you are running M&amp;A, international expansion or complex revenue operations, or post-Series B governance genuinely demands a full-time seat at the table.
+                </p>
+                <p>
+                  The honest answer for most pre-seed to Series A startups is that the full-time question simply arrives later. A good fractional CFO will tell you when you have outgrown them — and help you hire their replacement.
+                </p>
+              </section>
+
+              {/* vs Accountant vs Controller */}
+              <section id="vs-accountant" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  Fractional CFO vs Accountant vs Financial Controller
+                </h2>
+                <p>
+                  These three roles are often confused, and the confusion is expensive in both directions — founders either pay CFO rates for bookkeeping, or expect strategic finance from an accountant who was never hired to provide it. The distinction is about time horizon:
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Accountant — Historical &amp; Compliance</h3>
+                <ul>
+                  <li><strong>Answers:</strong> what happened, and are we compliant?</li>
+                  <li><strong>Covers:</strong> statutory accounts, corporation tax, VAT returns, payroll, Companies House filings</li>
+                  <li><strong>Cadence:</strong> monthly to annually, deadline-driven</li>
+                  <li><strong>Typical cost:</strong> a few hundred pounds a month outsourced at early stage</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Financial Controller — Operational</h3>
+                <ul>
+                  <li><strong>Answers:</strong> are the numbers right, and is the machine running?</li>
+                  <li><strong>Covers:</strong> bookkeeping oversight, month-end close, invoicing and collections, spend controls, management accounts production</li>
+                  <li><strong>Cadence:</strong> daily to monthly</li>
+                  <li><strong>Typically arrives:</strong> once transaction volume outgrows the founder-plus-accountant setup</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Fractional CFO — Strategic &amp; Forward-Looking</h3>
+                <ul>
+                  <li><strong>Answers:</strong> where are we going, and can we afford to get there?</li>
+                  <li><strong>Covers:</strong> financial modelling, runway scenarios, fundraising and data rooms, pricing and unit economics, board narrative</li>
+                  <li><strong>Cadence:</strong> weekly rhythm, quarterly deep work, intense around a raise</li>
+                  <li><strong>Typically arrives:</strong> pre-seed to Series A, usually triggered by a raise or a round just closed</li>
+                </ul>
+
+                <div className="bg-slate-100 border border-slate-200 rounded-xl p-6 my-8 not-prose">
+                  <p className="font-semibold text-slate-900 mb-2">They Complement, Not Compete</p>
+                  <p className="text-slate-700">
+                    A fractional CFO does not replace your accountant — they build on the records your accountant keeps and will usually work with them directly. At pre-seed and seed, an outsourced accountant plus a fractional CFO covers both the compliance and the strategy; a controller tends to join later, as transaction volume grows.
+                  </p>
+                </div>
+              </section>
+
+              {/* How to Choose */}
+              <section id="how-to-choose" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  How to Choose a Fractional CFO
+                </h2>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Green Flags</h3>
+                <ul>
+                  <li><strong>Sector experience</strong> — They know your business model&apos;s economics, whether that is fintech, healthtech or B2B SaaS</li>
+                  <li><strong>Stage fit</strong> — Pre-seed to Series A finance is a different craft from corporate finance; scrappy data and fast decisions should not faze them</li>
+                  <li><strong>Fundraising track record</strong> — They have supported rounds like the one you are planning and know what UK investors actually ask</li>
+                  <li><strong>Hands-on with models</strong> — They build and maintain the model themselves, rather than reviewing someone else&apos;s work from a distance</li>
+                  <li><strong>Plain-English communication</strong> — They make the numbers clearer, not more intimidating; you will spend hours together, so chemistry matters</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Red Flags</h3>
+                <ul>
+                  <li><strong>Compliance background rebadged</strong> — A career in historical reporting does not automatically translate into forward-looking strategy</li>
+                  <li><strong>Template models</strong> — If every model they show ends in the same hockey stick, the assumptions are decoration, not analysis</li>
+                  <li><strong>Overcommitted</strong> — Too many concurrent clients means your board week gets whatever attention is left over</li>
+                  <li><strong>Can&apos;t face investors</strong> — If they cannot defend the model in a diligence conversation, you will be doing it alone</li>
+                  <li><strong>Equity-first pricing</strong> — Fractional engagements should be cash-based; significant equity is for full-time commitment</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Questions to Ask</h3>
+                <ol>
+                  <li>&quot;Which fundraises have you supported at our stage, and what was your role in them?&quot;</li>
+                  <li>&quot;Walk me through a model you built. Which three assumptions mattered most, and how did you test them?&quot;</li>
+                  <li>&quot;How would you approach our cash position and runway in your first 30 days?&quot;</li>
+                  <li>&quot;What does a monthly reporting rhythm look like with you — what do we get, and when?&quot;</li>
+                  <li>&quot;What would make you advise us not to raise?&quot;</li>
+                </ol>
+                <p>
+                  That last question matters. A fractional CFO&apos;s job is to tell you the truth about your numbers, including when the truth is inconvenient. Anyone who treats every situation as raise-ready is selling, not advising.
+                </p>
+              </section>
+
+              {/* Working Together */}
+              <section id="working-together" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  Working with a Fractional CFO
+                </h2>
+                <p>
+                  A well-run fractional CFO engagement has a predictable shape. Here is what to expect — and what to insist on.
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">The First 30 Days: Diagnostic</h3>
+                <p>
+                  The engagement should open with a clear-eyed review of where you stand:
+                </p>
+                <ul>
+                  <li>Cash position and a first-cut 13-week cash flow</li>
+                  <li>Review (or rebuild) of the financial model and its assumptions</li>
+                  <li>A baseline for reporting: what the board and investors currently see, and what they should</li>
+                  <li>Quick wins — cost anomalies, billing gaps, working-capital timing</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">The Ongoing Cadence</h3>
+                <ul>
+                  <li><strong>Weekly:</strong> a founder sync, plus async availability for decisions that cannot wait</li>
+                  <li><strong>Monthly:</strong> management accounts, KPI pack and budget-versus-actuals review</li>
+                  <li><strong>Quarterly:</strong> reforecast and a strategic review of runway, hiring and pricing</li>
+                  <li><strong>Around a raise:</strong> intensity increases — model, data room, investor Q&amp;A support</li>
+                </ul>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">The Deliverables You Should Expect</h3>
+                <ul>
+                  <li>A three-statement financial model you own and understand</li>
+                  <li>A 13-week cash flow, maintained, with runway scenarios</li>
+                  <li>A monthly board and investor pack produced on time</li>
+                  <li>An investor-ready data room, kept current between rounds</li>
+                  <li>Documented unit economics and pricing analysis</li>
+                </ul>
+                <p className="mt-4">
+                  <Link href="/blog/building-your-first-data-room" className="text-primary-600 hover:text-primary-700 font-medium">
+                    Related reading: Building your first data room →
+                  </Link>
+                </p>
+
+                <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Tools and Ownership</h3>
+                <p>
+                  Expect the work to live in tools you control: your accounting platform (typically Xero or QuickBooks), spreadsheet models shared in your own drive, and dashboards built on your data. Everything should be documented and owned by the company — if the engagement ends, the model, the data room and the reporting rhythm stay with you. A fractional CFO who keeps the model as a black box has built a dependency, not a finance function.
+                </p>
+
+                <div className="bg-slate-100 border border-slate-200 rounded-xl p-6 my-8 not-prose">
+                  <p className="font-semibold text-slate-900 mb-2">Also Hiring Technical Leadership?</p>
+                  <p className="text-slate-700">
+                    Many founders face the technical and financial leadership gaps at the same time — and the two searches follow the same logic.{' '}
+                    <Link href="/guides/fractional-cto-guide" className="text-primary-600 hover:text-primary-700 font-medium">
+                      Read the Complete Guide to Fractional CTO Services →
+                    </Link>
+                  </p>
+                </div>
+              </section>
+
+              {/* FAQ */}
+              <section id="faq" className="scroll-mt-24 mb-16">
+                <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+                  Frequently Asked Questions
+                </h2>
+                <div className="space-y-6 not-prose">
+                  {faqs.map((faq, index) => (
+                    <details key={index} className="group bg-slate-50 rounded-xl p-6 border border-slate-200">
+                      <summary className="font-semibold text-lg text-slate-900 cursor-pointer list-none flex items-center justify-between">
+                        {faq.question}
+                        <svg className="w-5 h-5 text-slate-400 group-open:rotate-180 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </summary>
+                      <p className="mt-4 text-slate-600">{faq.answer}</p>
+                    </details>
+                  ))}
+                </div>
+              </section>
+
+              {/* CTA */}
+              <section className="bg-gradient-to-r from-primary-600 to-primary-700 rounded-2xl p-8 text-center not-prose">
+                <h2 className="text-2xl md:text-3xl font-bold text-white mb-4">
+                  Need a Fractional CFO?
+                </h2>
+                <p className="text-primary-100 mb-6 max-w-xl mx-auto">
+                  Codenest provides Fractional CFO services for UK startups from pre-seed to Series A — financial modelling, runway management, fundraising support and board reporting, from £2,500 per month.
+                </p>
+                <Link
+                  href="/contact"
+                  className="inline-block bg-accent-400 text-primary-900 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-accent-500 transition-all"
+                >
+                  Request a Strategy Call
+                </Link>
+                <p className="text-primary-100 text-sm mt-4">
+                  Free 30-minute consultation &middot; 100% confidential &middot;{' '}
+                  <Link href="/services/fractional-cfo" className="underline hover:text-white">
+                    Explore Fractional CFO Services
+                  </Link>
+                </p>
+              </section>
+
+            </article>
+          </div>
+        </div>
+
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/app/guides/fractional-cto-guide/page.js
+++ b/app/guides/fractional-cto-guide/page.js
@@ -3,11 +3,11 @@ import Navigation from '../../components/Navigation'
 import Footer from '../../components/Footer'
 
 export const metadata = {
-  title: 'The Complete Guide to Fractional CTO Services UK (2025)',
+  title: 'The Complete Guide to Fractional CTO Services UK',
   description: 'Everything UK founders need to know about fractional CTO services: costs, benefits, when to hire, what to expect, and how to choose the right fractional CTO for your startup.',
   keywords: ['fractional CTO guide', 'what is a fractional CTO', 'fractional CTO cost UK', 'when to hire fractional CTO', 'fractional CTO vs full-time CTO', 'part-time CTO startup', 'CTO as a service UK'],
   openGraph: {
-    title: 'The Complete Guide to Fractional CTO Services UK (2025)',
+    title: 'The Complete Guide to Fractional CTO Services UK',
     description: 'Everything UK founders need to know about fractional CTO services: costs, benefits, when to hire, and how to choose.',
     type: 'article',
     url: 'https://codenest.uk/guides/fractional-cto-guide/',
@@ -70,7 +70,7 @@ export default function FractionalCTOGuidePage() {
   const articleSchema = {
     '@context': 'https://schema.org',
     '@type': 'Article',
-    headline: 'The Complete Guide to Fractional CTO Services UK (2025)',
+    headline: 'The Complete Guide to Fractional CTO Services UK',
     description: 'Everything UK founders need to know about fractional CTO services.',
     author: {
       '@type': 'Organization',
@@ -86,7 +86,7 @@ export default function FractionalCTOGuidePage() {
       }
     },
     datePublished: '2025-01-13',
-    dateModified: '2025-01-13',
+    dateModified: '2026-08-04',
     mainEntityOfPage: 'https://codenest.uk/guides/fractional-cto-guide/'
   }
 
@@ -116,6 +116,8 @@ export default function FractionalCTOGuidePage() {
 
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero */}
       <section className="pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -130,7 +132,7 @@ export default function FractionalCTOGuidePage() {
               Everything UK founders need to know about hiring a fractional CTO: costs, benefits, timing, and how to make it work for your startup.
             </p>
             <p className="text-sm text-slate-500">
-              Updated January 2025 &middot; 15 min read
+              Updated August 2026 &middot; 15 min read
             </p>
           </div>
         </div>
@@ -571,6 +573,8 @@ export default function FractionalCTOGuidePage() {
           </article>
         </div>
       </div>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/guides/fractional-cto-vs-agency/page.js
+++ b/app/guides/fractional-cto-vs-agency/page.js
@@ -41,6 +41,8 @@ export default function FractionalVsAgencyPage() {
     <div className="min-h-screen bg-white">
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero */}
       <section className="pt-32 pb-16 bg-gradient-to-b from-accent-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -245,6 +247,8 @@ export default function FractionalVsAgencyPage() {
           </div>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/guides/fractional-cto-vs-full-time/page.js
+++ b/app/guides/fractional-cto-vs-full-time/page.js
@@ -41,6 +41,8 @@ export default function FractionalVsFullTimePage() {
     <div className="min-h-screen bg-white">
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero */}
       <section className="pt-32 pb-16 bg-gradient-to-b from-slate-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -311,6 +313,8 @@ export default function FractionalVsFullTimePage() {
           </div>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/guides/page.js
+++ b/app/guides/page.js
@@ -26,6 +26,12 @@ export const metadata = {
 
 const guides = [
   {
+    title: 'The Complete Guide to Fractional CFO Services',
+    href: '/guides/fractional-cfo-guide',
+    description: 'What a fractional CFO does, when to hire one, UK costs, and how they differ from accountants and controllers.',
+    tag: 'Guide',
+  },
+  {
     title: 'The Complete Guide to Fractional CTO Services',
     href: '/guides/fractional-cto-guide',
     description: 'What a fractional CTO does, when you need one, costs, and how to choose — the full picture for UK founders.',

--- a/app/guides/technical-cofounder-alternatives/page.js
+++ b/app/guides/technical-cofounder-alternatives/page.js
@@ -99,6 +99,8 @@ export default function TechnicalCofounderAlternativesPage() {
     <div className="min-h-screen bg-white">
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero */}
       <section className="pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -274,6 +276,8 @@ export default function TechnicalCofounderAlternativesPage() {
           </div>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/page.js
+++ b/app/page.js
@@ -1,98 +1,26 @@
 import Image from 'next/image'
+import Link from 'next/link'
+import Button from './components/Button'
 import Navigation from './components/Navigation'
 import ContactForm from './components/ContactForm'
 import Footer from './components/Footer'
-import ServiceCard from './components/ServiceCard'
 import Testimonials from './components/Testimonials'
 
 export default function Home() {
-  const services = [
-    // Technical Services
-    {
-      title: "Fractional CTO",
-      benefit: "Executive-level technical leadership at a fraction of the cost",
-      description: "Make confident architecture decisions, build the right team, and become investor-ready. Strategic guidance for fintech, healthtech, and SaaS startups across the UK.",
-      image: "/img/photos/service-cto.jpg",
-      outcomes: ["Save 60-80% vs full-time CTO", "Investor-ready in weeks", "Scale your team confidently"],
-      track: "technical"
-    },
-    {
-      title: "Fractional CFO",
-      benefit: "FP&A and strategic finance leadership",
-      description: "Financial planning & analysis, business strategy, and investor-ready reporting. The financial discipline of a high-growth company — without the overhead.",
-      image: "/img/photos/service-diligence.jpg",
-      outcomes: ["Financial modeling & forecasting", "Business strategy development", "Investor-ready reporting"],
-      track: "business"
-    },
-    {
-      title: "0-to-1 Product Builds",
-      benefit: "Launch your MVP in weeks, not months",
-      description: "Go from idea to production-ready product with a system built to scale. No rebuilding later, no technical debt from day one.",
-      image: "/img/photos/service-product.jpg",
-      outcomes: ["8-12 week delivery", "Built to handle growth", "Full ownership handover"],
-      track: "technical"
-    },
-    {
-      title: "Financial Modeling",
-      benefit: "Know your numbers before investors ask",
-      description: "3-statement models, unit economics, and scenario planning. Financial models that stand up to due diligence scrutiny.",
-      image: "/img/photos/infrastructure.jpg",
-      outcomes: ["3-statement models", "Unit economics analysis", "Scenario planning"],
-      track: "business"
-    },
-    {
-      title: "AI & Data Engineering",
-      benefit: "Turn AI experiments into production revenue",
-      description: "Move beyond prototypes. We build production-grade LLM applications, ML pipelines, and data infrastructure that actually scale.",
-      image: "/img/photos/service-ai.jpg",
-      outcomes: ["Production-ready AI", "Cost-optimized inference", "Scalable data pipelines"],
-      track: "technical"
-    },
-    {
-      title: "Fundraising Support",
-      benefit: "Close your round with confidence",
-      description: "Pitch deck financial sections, data room preparation, and investor Q&A coaching. We've helped startups raise from pre-seed to Series A.",
-      image: "/img/photos/hero-team.jpg",
-      outcomes: ["Data room ready", "Financial due diligence prep", "Valuation support"],
-      track: "business"
-    },
-    {
-      title: "DevOps & Platform Engineering",
-      benefit: "Deploy daily with zero downtime",
-      description: "Automated infrastructure, CI/CD pipelines, and GitOps workflows. Ship confidently and iterate fast from day one.",
-      image: "/img/photos/infrastructure.jpg",
-      outcomes: ["Automated deployments", "Infrastructure as code", "Zero-downtime releases"],
-      track: "technical"
-    }
-  ]
 
+  // Teaser data only — the full case studies live at /case-studies
   const caseStudies = [
     {
       title: "Rungway: Scaling a Social Mentoring Platform",
-      challenge: "A London-based HR-tech startup needed fractional CTO support to scale their social mentoring platform. The system could only handle 5 concurrent users before experiencing severe performance degradation — completely inadequate for their UK enterprise client base.",
-      solution: "As Rungway's interim CTO, our founder delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
-      results: ["Scaled from 5 to 1000+ concurrent users", "Zero-downtime database migration", "Modern DevOps foundations established", "Event-driven microservices architecture"],
-      tags: ["Backend Architecture", "AWS", "DevOps", "Scalability", "Microservices"],
-      image: "/img/photos/case-rungway.jpg",
-      imageAlt: "Data analytics dashboard showing platform scalability metrics"
+      results: ["Scaled from 5 to 1000+ concurrent users"]
     },
     {
       title: "Opayo by Elavon: Payment Platform Transformation",
-      challenge: "Leading UK fintech payment provider needed Kubernetes consulting to modernize their infrastructure and integrate new payment channels (Apple Pay, Google Pay) while maintaining 100% uptime for critical transaction processing across Europe.",
-      solution: "Working inside the Opayo platform team, our founder orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
-      results: ["Accelerated releases from every 2 weeks to multiple times per day", "Contributed to 10% revenue increase through faster feature delivery", "Reduced CI pipeline failures through automated testing", "Successfully integrated Apple Pay and Google Pay"],
-      tags: ["Payment Systems", "AWS EKS", "Kubernetes", "Terraform", "GitOps", "Team Leadership"],
-      image: "/img/photos/case-opayo.jpg",
-      imageAlt: "Secure payment processing and mobile payment integration"
+      results: ["Releases accelerated from fortnightly to multiple times per day"]
     },
     {
       title: "AstraZeneca: Drug Delivery Tracking System MVP",
-      challenge: "AstraZeneca needed to replace manual spreadsheet-based drug delivery tracking with a modern web-based tool to improve efficiency and accelerate time-to-market for pharmaceutical products. The system required integration with existing workflows while maintaining regulatory compliance.",
-      solution: "Our founder built a production-grade web application with REST APIs and automated CI/CD pipelines, collaborating closely with stakeholders and business analysts to define requirements and align delivery with business goals — architecting scalable deployments on Kubernetes using Docker and Jenkins (config-as-code), and establishing robust testing practices with JUnit and Spock.",
-      results: ["Accelerated delivery by 40% compared to manual processes", "Cut deployment errors by 30% through automated pipelines", "Improved stakeholder confidence through transparent roadmap planning", "Delivered production-ready MVP on Kubernetes infrastructure"],
-      tags: ["Healthcare", "Team Leadership", "Kubernetes", "CI/CD", "REST APIs", "Stakeholder Management"],
-      image: "/img/photos/case-astrazeneca.jpg",
-      imageAlt: "Healthcare technology and pharmaceutical tracking systems"
+      results: ["Production-ready MVP delivered on Kubernetes infrastructure"]
     }
   ]
 
@@ -111,32 +39,8 @@ export default function Home() {
       answer: "Yes. Many startups need both CTO and CFO guidance but can't justify two executive hires. We offer integrated leadership covering technology architecture, financial planning, and investor relations."
     },
     {
-      question: "Do you work with non-technical founders?",
-      answer: "Absolutely. Many of our clients are first-time founders without technical or financial backgrounds. We excel at translating complex concepts into clear business terms."
-    },
-    {
       question: "What's your pricing model?",
-      answer: "We work on retainer for fractional leadership (monthly commitment) and fixed-fee for defined projects like MVP builds or financial modeling. Investment varies based on scope and intensity — typically 60-80% less than equivalent full-time hires."
-    },
-    {
-      question: "Can you help with fundraising?",
-      answer: "Yes. We prepare financial models, data rooms, and due diligence materials. We've supported raises from pre-seed through Series A across fintech, healthtech, and B2B SaaS."
-    },
-    {
-      question: "What's the difference between FP&A and accounting?",
-      answer: "Accountants handle compliance and historical reporting. FP&A is forward-looking: financial modeling, forecasting, unit economics, pricing strategy, and investor communications. We provide strategic finance leadership, not bookkeeping."
-    },
-    {
-      question: "What's your tech stack expertise?",
-      answer: "We specialize in cloud-native architectures (AWS, GCP), Kubernetes, Terraform, Python, Java, Postgres/Mysql, Gitops, and modern data/ML stacks. But our real value is in architectural thinking — we choose the right tools for your specific needs."
-    },
-    {
-      question: "Do you offer ongoing support after delivery?",
-      answer: "Yes. We offer retainer arrangements for post-launch support, scaling assistance, and continued technical and financial leadership. Many clients transition from intensive builds to lighter advisory after launch."
-    },
-    {
-      question: "What makes you different from a dev shop?",
-      answer: "Dev shops execute your specifications. We provide strategic leadership first — helping you figure out what to build, how to fund it, and how to set up your team for long-term success."
+      answer: "We work on retainer for fractional leadership (monthly commitment) and fixed-fee for defined projects like MVP builds or financial modeling. Fractional engagements start from £2,500 per month (CFO) and £3,000 per month (CTO) — typically 60-80% less than equivalent full-time hires."
     }
   ]
 
@@ -213,12 +117,14 @@ export default function Home() {
       />
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero Section */}
       <section id="home" className="pt-44 pb-32 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-20 items-center">
             <div>
-              <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-8 font-medium animate-hero-1">
+              <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-8 font-medium animate-hero-1">
                 Fractional CTO &amp; CFO for UK Startups
               </p>
               <h1 className="font-serif text-5xl md:text-6xl font-normal text-slate-900 leading-[1.1] mb-6 animate-hero-2">
@@ -258,12 +164,8 @@ export default function Home() {
                 </li>
               </ul>
               <div className="flex flex-col sm:flex-row gap-4 animate-hero-4">
-                <a href="#contact" className="bg-accent-400 text-primary-900 px-8 py-4 rounded-lg text-base font-semibold hover:bg-accent-500 transition-all text-center shadow-gold hover:shadow-gold-lg btn-premium cta-pulse">
-                  Request a Strategy Call
-                </a>
-                <a href="#case-studies" className="border-2 border-slate-300 text-slate-700 px-8 py-4 rounded-lg text-base font-semibold hover:border-accent-400 hover:text-primary-700 transition-all text-center">
-                  View Case Studies
-                </a>
+                <Button href="#contact">Request a Strategy Call</Button>
+                <Button href="#case-studies" variant="secondary">View Case Studies</Button>
               </div>
             </div>
             <div className="relative animate-hero-image">
@@ -289,6 +191,124 @@ export default function Home() {
         </div>
       </section>
 
+      {/* Two Tracks Section */}
+      <section className="py-24 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Integrated Partnership</p>
+            <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Your Fractional CTO &amp; CFO</h2>
+            <p className="text-xl text-slate-600 max-w-3xl mx-auto">
+              Most startups need both CTO and CFO guidance. We deliver integrated leadership — not siloed consulting.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            {/* Strategy Track - Listed First */}
+            <div className="bg-gradient-to-br from-accent-50 to-white border border-accent-200 rounded-xl p-10 hover:border-accent-400 hover:shadow-gold transition-all card-lift relative overflow-hidden">
+              {/* Gold accent decoration */}
+              <div className="absolute top-0 right-0 w-32 h-32 bg-gold-gradient opacity-5 rounded-bl-full" />
+              <div className="w-14 h-14 bg-accent-400 rounded-lg flex items-center justify-center mb-6 shadow-gold relative">
+                <svg className="w-8 h-8 text-primary-900" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+              </div>
+              <h3 className="text-2xl font-bold text-slate-900 mb-4 relative">Fractional CFO</h3>
+              <p className="text-slate-600 mb-6 leading-relaxed relative">
+                Strategic finance, FP&A, and the financial discipline that makes your startup investable.
+              </p>
+              <ul className="space-y-3 mb-8 relative">
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Business Strategy & Planning
+                </li>
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Financial Modeling & FP&A
+                </li>
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Fundraising & Investor Relations
+                </li>
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Due Diligence Preparation
+                </li>
+              </ul>
+              <a href="/services/fractional-cfo" className="inline-flex items-center text-accent-700 hover:text-accent-800 font-semibold link-gold relative">
+                Explore Fractional CFO Services
+                <svg className="w-5 h-5 ml-2 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                </svg>
+              </a>
+            </div>
+
+            {/* Technical Track */}
+            <div className="bg-gradient-to-br from-primary-50 to-white border border-primary-200 rounded-xl p-10 hover:border-primary-400 hover:shadow-lg transition-all card-lift">
+              <div className="w-14 h-14 bg-primary-600 rounded-lg flex items-center justify-center mb-6">
+                <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                </svg>
+              </div>
+              <h3 className="text-2xl font-bold text-slate-900 mb-4">Fractional CTO</h3>
+              <p className="text-slate-600 mb-6 leading-relaxed">
+                Architecture decisions, engineering team building, and infrastructure that scales from day one.
+              </p>
+              <ul className="space-y-3 mb-8">
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Technical Strategy &amp; Architecture
+                </li>
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  0-to-1 Product Builds
+                </li>
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  AI & Data Engineering
+                </li>
+                <li className="flex items-center text-slate-700">
+                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  DevOps & Platform Engineering
+                </li>
+              </ul>
+              <a href="/services/fractional-cto" className="inline-flex items-center text-primary-600 hover:text-primary-700 font-semibold">
+                Explore Fractional CTO Services
+                <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div className="mt-12 text-center space-y-2">
+            <p className="text-slate-600">
+              Also need delivery capacity? Explore{' '}
+              <Link href="/services" className="text-primary-600 hover:text-primary-700 font-medium">all services</Link>
+              {' '}including 0-to-1 product builds and AI engineering.
+            </p>
+            <p className="text-slate-600">
+              Building something exceptional? For the right opportunity, we also consider{' '}
+              <a href="/cofounder" className="text-primary-600 hover:text-primary-700 font-medium">co-founder partnerships</a>.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* Social Proof - Client Logos */}
       <section className="py-12 bg-slate-50/50 border-y border-slate-100">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -303,7 +323,7 @@ export default function Home() {
               />
               <div>
                 <span className="text-lg font-semibold text-slate-700 group-hover:text-slate-900 transition-colors">Rungway</span>
-                <p className="text-xs text-slate-400">HR Tech</p>
+                <p className="text-xs text-slate-500">HR Tech</p>
               </div>
             </div>
 
@@ -360,370 +380,32 @@ export default function Home() {
         </div>
       </section>
 
-      <Testimonials />
-
-      {/* Two Tracks Section */}
-      <section className="py-24 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Integrated Partnership</p>
-            <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Your Fractional CTO &amp; CFO</h2>
-            <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-              Most startups need both CTO and CFO guidance. We deliver integrated leadership — not siloed consulting.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            {/* Strategy Track - Listed First */}
-            <div className="bg-gradient-to-br from-accent-50 to-white border border-accent-200 rounded-xl p-10 hover:border-accent-400 hover:shadow-gold transition-all card-lift relative overflow-hidden">
-              {/* Gold accent decoration */}
-              <div className="absolute top-0 right-0 w-32 h-32 bg-gold-gradient opacity-5 rounded-bl-full" />
-              <div className="w-14 h-14 bg-accent-400 rounded-lg flex items-center justify-center mb-6 shadow-gold relative">
-                <svg className="w-8 h-8 text-primary-900" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                </svg>
-              </div>
-              <h3 className="text-2xl font-bold text-slate-900 mb-4 relative">Fractional CFO</h3>
-              <p className="text-slate-600 mb-6 leading-relaxed relative">
-                Strategic finance, FP&A, and the financial discipline that makes your startup investable.
-              </p>
-              <ul className="space-y-3 mb-8 relative">
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Business Strategy & Planning
-                </li>
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Financial Modeling & FP&A
-                </li>
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Fundraising & Investor Relations
-                </li>
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Due Diligence Preparation
-                </li>
-              </ul>
-              <a href="/services/fractional-cfo" className="inline-flex items-center text-accent-500 hover:text-accent-600 font-semibold link-gold relative">
-                Explore Fractional CFO Services
-                <svg className="w-5 h-5 ml-2 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-                </svg>
-              </a>
-            </div>
-
-            {/* Technical Track */}
-            <div className="bg-gradient-to-br from-primary-50 to-white border border-primary-200 rounded-xl p-10 hover:border-primary-400 hover:shadow-lg transition-all card-lift">
-              <div className="w-14 h-14 bg-primary-600 rounded-lg flex items-center justify-center mb-6">
-                <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                </svg>
-              </div>
-              <h3 className="text-2xl font-bold text-slate-900 mb-4">Fractional CTO</h3>
-              <p className="text-slate-600 mb-6 leading-relaxed">
-                Architecture decisions, engineering team building, and infrastructure that scales from day one.
-              </p>
-              <ul className="space-y-3 mb-8">
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Technical Strategy &amp; Architecture
-                </li>
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  0-to-1 Product Builds
-                </li>
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  AI & Data Engineering
-                </li>
-                <li className="flex items-center text-slate-700">
-                  <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  DevOps & Platform Engineering
-                </li>
-              </ul>
-              <a href="/services/fractional-cto" className="inline-flex items-center text-primary-600 hover:text-primary-700 font-semibold">
-                Explore Fractional CTO Services
-                <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-                </svg>
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Who We Serve Section */}
-      <section className="py-24 bg-slate-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Selective Partnerships</p>
-            <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Built for Ambitious Founders</h2>
-            <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-              We partner with a limited number of high-potential startups across these sectors
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div className="bg-white border border-slate-200 rounded-xl p-8 hover:border-primary-300 hover:shadow-lg transition-all">
-              <div className="w-12 h-12 bg-accent-100 rounded-lg flex items-center justify-center mb-5">
-                <svg className="w-8 h-8 text-accent-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </div>
-              <h3 className="text-2xl font-bold text-slate-900 mb-4">Fintech Startups</h3>
-              <p className="text-slate-600 leading-relaxed mb-4">
-                Technical and financial leadership for fintech startups. We help you build compliant platforms, develop investor-ready financial models, and navigate FCA requirements.
-              </p>
-              <ul className="space-y-2 text-sm text-slate-700">
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  PCI-DSS compliant architecture
-                </li>
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Financial modeling for investors
-                </li>
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  FCA regulatory guidance
-                </li>
-              </ul>
-            </div>
-
-            <div className="bg-white border border-slate-200 rounded-xl p-8 hover:border-primary-300 hover:shadow-lg transition-all">
-              <div className="w-12 h-12 bg-accent-100 rounded-lg flex items-center justify-center mb-5">
-                <svg className="w-8 h-8 text-accent-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                </svg>
-              </div>
-              <h3 className="text-2xl font-bold text-slate-900 mb-4">Healthtech Startups</h3>
-              <p className="text-slate-600 leading-relaxed mb-4">
-                Technical and financial leadership for healthcare startups. We build compliant platforms, prepare fundraising materials, and help you scale sustainably in a regulated market.
-              </p>
-              <ul className="space-y-2 text-sm text-slate-700">
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  GDPR & data protection
-                </li>
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Investor due diligence prep
-                </li>
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Unit economics analysis
-                </li>
-              </ul>
-            </div>
-
-            <div className="bg-white border border-slate-200 rounded-xl p-8 hover:border-primary-300 hover:shadow-lg transition-all">
-              <div className="w-12 h-12 bg-accent-100 rounded-lg flex items-center justify-center mb-5">
-                <svg className="w-8 h-8 text-accent-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
-                </svg>
-              </div>
-              <h3 className="text-2xl font-bold text-slate-900 mb-4">SaaS & B2B Platforms</h3>
-              <p className="text-slate-600 leading-relaxed mb-4">
-                Technical and financial leadership for B2B SaaS companies. We help you build scalable platforms, model SaaS metrics, and prepare for your next funding round.
-              </p>
-              <ul className="space-y-2 text-sm text-slate-700">
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Multi-tenant architecture
-                </li>
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  SaaS metrics & forecasting
-                </li>
-                <li className="flex items-start">
-                  <svg className="w-4 h-4 text-accent-600 mt-1 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  Fundraising support
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <div className="mt-12 text-center">
-            <p className="text-slate-600 mb-6">
-              Based in London, serving ambitious founders across the UK tech ecosystem
-            </p>
-            <a href="#contact" className="inline-flex items-center text-primary-600 hover:text-primary-700 font-semibold">
-              Discuss your sector-specific needs
-              <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* Services Section */}
-      <section id="services" className="py-24 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-20">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Bespoke Engagements</p>
-            <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Advisory & Implementation</h2>
-            <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-              Hands-on leadership from strategy through execution — not just advice from the sidelines
-            </p>
-          </div>
-
-          {/* Technical Services */}
-          <div className="mb-16">
-            <h3 className="font-serif text-2xl font-bold text-slate-900 mb-8 flex items-center">
-              <span className="w-10 h-10 bg-primary-600 rounded-lg flex items-center justify-center mr-4">
-                <svg className="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                </svg>
-              </span>
-              Fractional CTO Services
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-              {services.filter(s => s.track === 'technical').map((service, index) => (
-                <ServiceCard key={index} service={service} priority={index < 2} />
-              ))}
-            </div>
-          </div>
-
-          {/* Financial Services */}
-          <div>
-            <h3 className="font-serif text-2xl font-bold text-slate-900 mb-8 flex items-center">
-              <span className="w-10 h-10 bg-accent-500 rounded-lg flex items-center justify-center mr-4">
-                <svg className="w-5 h-5 text-primary-900" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                </svg>
-              </span>
-              Fractional CFO Services
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-              {services.filter(s => s.track === 'business').map((service, index) => (
-                <ServiceCard key={index} service={service} priority={false} />
-              ))}
-            </div>
-          </div>
-
-          {/* Co-founder mention */}
-          <div className="mt-16 pt-12 border-t border-slate-200 text-center">
-            <p className="text-slate-600">
-              Building something exceptional? For the right opportunity, we also consider{' '}
-              <a href="/cofounder" className="text-primary-600 hover:text-primary-700 font-medium">co-founder partnerships</a>.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* Case Studies Section */}
+      {/* Case Studies Teaser */}
       <section id="case-studies" className="py-24 bg-slate-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-20">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Proven Track Record</p>
-            <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Client Partnerships</h2>
+          <div className="text-center mb-16">
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Proven Track Record</p>
+            <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Case Studies</h2>
             <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-              Startup outcomes, backed by enterprise-grade experience — deep, hands-on collaboration at every stage
+              Startup outcomes, backed by enterprise-grade experience
             </p>
           </div>
-
-          <div className="space-y-12">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {caseStudies.map((study, index) => (
-              <div key={index} className="group bg-white rounded-3xl shadow-lg overflow-hidden border border-slate-200 hover:shadow-2xl hover:border-accent-200 transition-all duration-300">
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-0">
-                  <div className={`relative h-80 lg:h-auto overflow-hidden ${index % 2 === 0 ? 'lg:order-1' : 'lg:order-2'}`}>
-                    <img
-                      src={study.image}
-                      alt={study.imageAlt || study.title}
-                      className="w-full h-full object-cover filter grayscale group-hover:grayscale-0 group-hover:scale-105 transition-all duration-700"
-                      loading="lazy"
-                      width={600}
-                      height={400}
-                    />
-                    {/* Warm overlay */}
-                    <div className="absolute inset-0 bg-gradient-to-br from-accent-400/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-                    {/* Index badge */}
-                    <div className="absolute top-4 left-4 w-10 h-10 bg-white/90 backdrop-blur-sm rounded-full flex items-center justify-center shadow-md">
-                      <span className="text-sm font-bold text-primary-600">{String(index + 1).padStart(2, '0')}</span>
-                    </div>
-                  </div>
-                  <div className={`p-10 lg:p-12 ${index % 2 === 0 ? 'lg:order-2' : 'lg:order-1'}`}>
-                    <h3 className="text-3xl font-bold text-slate-900 mb-4 group-hover:text-primary-700 transition-colors">{study.title}</h3>
-                    <div className="space-y-6">
-                      <div>
-                        <h4 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">Challenge</h4>
-                        <p className="text-slate-600">{study.challenge}</p>
-                      </div>
-                      <div>
-                        <h4 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">Solution</h4>
-                        <p className="text-slate-600">{study.solution}</p>
-                      </div>
-                      <div>
-                        <h4 className="text-sm font-semibold text-accent-500 uppercase tracking-wide mb-3">Results</h4>
-                        <ul className="space-y-2">
-                          {study.results.map((result, i) => (
-                            <li key={i} className="flex items-start group">
-                              <svg className="w-5 h-5 text-accent-500 mt-0.5 mr-3 flex-shrink-0 group-hover:scale-110 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                              </svg>
-                              <span className="text-slate-700 font-medium">{result}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                      <div className="flex flex-wrap gap-2 pt-2">
-                        {study.tags.map((tag, i) => (
-                          <span key={i} className="px-2 py-1 bg-primary-50 text-primary-700 rounded text-xs font-medium">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <Link key={index} href="/case-studies" className="group">
+                <article className="bg-white rounded-xl border border-slate-200 p-8 hover:shadow-lg hover:border-accent-200 transition-all h-full flex flex-col">
+                  <span className="text-sm font-bold text-primary-600 mb-4">{String(index + 1).padStart(2, '0')}</span>
+                  <h3 className="text-xl font-semibold text-slate-900 mb-3 group-hover:text-primary-700 transition-colors leading-snug">{study.title}</h3>
+                  <p className="text-slate-600 text-sm mb-4 flex-grow">{study.results[0]}</p>
+                  <span className="inline-flex items-center text-sm font-semibold text-accent-700 group-hover:text-accent-800">
+                    Read the case study
+                    <svg className="w-4 h-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                    </svg>
+                  </span>
+                </article>
+              </Link>
             ))}
-          </div>
-
-          <div className="text-center mt-12">
-            <p className="text-slate-600 mb-4">Want to see more examples of our work?</p>
-            <a href="#contact" className="inline-flex items-center text-primary-600 hover:text-primary-700 font-semibold">
-              Let's discuss your project
-              <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-            </a>
           </div>
         </div>
       </section>
@@ -732,7 +414,7 @@ export default function Home() {
       <section id="how-we-work" className="py-24 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Our Methodology</p>
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Our Methodology</p>
             <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">The Partnership Journey</h2>
             <p className="text-xl text-slate-600 max-w-3xl mx-auto">
               A structured, transparent process from discovery to delivery — and beyond.
@@ -778,7 +460,7 @@ export default function Home() {
           </div>
 
           <div className="text-center mt-12">
-            <a href="#contact" className="inline-flex items-center bg-accent-400 text-primary-900 px-8 py-4 rounded-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg btn-premium">
+            <a href="#contact" className="inline-flex items-center bg-accent-400 text-primary-900 px-8 py-4 rounded-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg">
               Request a Strategy Call
               <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
@@ -788,323 +470,12 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Why Founders Choose Us - Comparison Section */}
-      <section className="py-24 bg-slate-900 text-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-400 mb-4 font-medium">The Right Partner</p>
-            <h2 className="font-serif text-4xl md:text-5xl font-bold text-white mb-6">Why Founders Choose Us</h2>
-            <p className="text-xl text-slate-300 max-w-3xl mx-auto">
-              Not every model works for every stage. Here's how we compare.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-            {/* Full-time Exec */}
-            <div className="bg-slate-800/50 rounded-xl p-6 border border-slate-700">
-              <h3 className="text-lg font-bold text-slate-400 mb-4">Full-time CTO/CFO</h3>
-              <ul className="space-y-3 text-sm">
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">£150-250k+ annual cost</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">3-6 month hiring process</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">Equity dilution required</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-amber-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                  </svg>
-                  <span className="text-slate-400">Often overkill for early stage</span>
-                </li>
-              </ul>
-              <p className="text-xs text-slate-500 mt-4">Best for: Post-Series B</p>
-            </div>
-
-            {/* Dev Shop */}
-            <div className="bg-slate-800/50 rounded-xl p-6 border border-slate-700">
-              <h3 className="text-lg font-bold text-slate-400 mb-4">Dev Shop / Agency</h3>
-              <ul className="space-y-3 text-sm">
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">Executes specs, not strategy</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">No skin in the game</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">Junior devs on your project</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">No investor credibility</span>
-                </li>
-              </ul>
-              <p className="text-xs text-slate-500 mt-4">Best for: Defined feature work</p>
-            </div>
-
-            {/* Solo Freelancer */}
-            <div className="bg-slate-800/50 rounded-xl p-6 border border-slate-700">
-              <h3 className="text-lg font-bold text-slate-400 mb-4">Solo Freelancer</h3>
-              <ul className="space-y-3 text-sm">
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-amber-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                  </svg>
-                  <span className="text-slate-400">Limited capacity</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">Rarely has exec experience</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">Tech or finance — rarely both</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-red-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="text-slate-400">Task execution, not strategy</span>
-                </li>
-              </ul>
-              <p className="text-xs text-slate-500 mt-4">Best for: Specific technical tasks</p>
-            </div>
-
-            {/* Codenest - Highlighted */}
-            <div className="bg-gradient-to-br from-accent-500/20 to-accent-600/10 rounded-xl p-6 border-2 border-accent-400 relative">
-              <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-1 bg-accent-400 text-primary-900 text-xs font-bold rounded-full">
-                BEST FIT
-              </div>
-              <h3 className="text-lg font-bold text-accent-400 mb-4">Codenest</h3>
-              <ul className="space-y-3 text-sm">
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-accent-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span className="text-white">60-80% cost savings</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-accent-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span className="text-white">Start in 1-2 weeks</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-accent-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span className="text-white">Big 4 + startup experience</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-accent-400 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span className="text-white">Tech + finance integrated</span>
-                </li>
-              </ul>
-              <p className="text-xs text-accent-300 mt-4">Best for: Pre-seed to Series A</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Beyond Advisory - Co-founder Section */}
-      <section id="cofounder" className="py-24 bg-gradient-to-b from-slate-50 to-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <p className="text-sm uppercase tracking-[0.2em] text-slate-400 mb-4 font-medium">Exceptional Opportunities</p>
-            <h2 className="font-serif text-3xl md:text-4xl font-bold text-slate-900 mb-4">
-              Beyond Advisory: Co-founder Partnerships
-            </h2>
-            <p className="text-lg text-slate-600 max-w-2xl mx-auto">
-              Most of our work is fractional — time-bound, cash-based, designed to make you self-sufficient. But occasionally, we meet a founder building something we can't stop thinking about.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-12">
-            {/* What we consider */}
-            <div className="bg-white rounded-2xl p-8 border border-slate-200 shadow-sm">
-              <h3 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-3">
-                <span className="w-8 h-8 bg-primary-100 rounded-lg flex items-center justify-center">
-                  <svg className="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-                  </svg>
-                </span>
-                For the right opportunity
-              </h3>
-              <ul className="space-y-3">
-                <li className="flex items-start gap-3 text-slate-600">
-                  <svg className="w-5 h-5 text-primary-500 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>Technical co-founder roles</span>
-                </li>
-                <li className="flex items-start gap-3 text-slate-600">
-                  <svg className="w-5 h-5 text-primary-500 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>Equity-based partnerships</span>
-                </li>
-                <li className="flex items-start gap-3 text-slate-600">
-                  <svg className="w-5 h-5 text-primary-500 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>Long-term commitment (2-5+ years)</span>
-                </li>
-                <li className="flex items-start gap-3 text-slate-600">
-                  <svg className="w-5 h-5 text-primary-500 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>Full technical leadership & ownership</span>
-                </li>
-              </ul>
-            </div>
-
-            {/* What makes it right */}
-            <div className="bg-white rounded-2xl p-8 border border-slate-200 shadow-sm">
-              <h3 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-3">
-                <span className="w-8 h-8 bg-accent-100 rounded-lg flex items-center justify-center">
-                  <svg className="w-4 h-4 text-accent-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-                  </svg>
-                </span>
-                What makes it "right"
-              </h3>
-              <ul className="space-y-3">
-                <li className="flex items-start gap-3 text-slate-600">
-                  <span className="w-5 h-5 flex items-center justify-center text-accent-500 font-bold flex-shrink-0">1</span>
-                  <span>Strong founder-market fit</span>
-                </li>
-                <li className="flex items-start gap-3 text-slate-600">
-                  <span className="w-5 h-5 flex items-center justify-center text-accent-500 font-bold flex-shrink-0">2</span>
-                  <span>Problem I'm genuinely passionate about</span>
-                </li>
-                <li className="flex items-start gap-3 text-slate-600">
-                  <span className="w-5 h-5 flex items-center justify-center text-accent-500 font-bold flex-shrink-0">3</span>
-                  <span>Clear path to meaningful scale</span>
-                </li>
-                <li className="flex items-start gap-3 text-slate-600">
-                  <span className="w-5 h-5 flex items-center justify-center text-accent-500 font-bold flex-shrink-0">4</span>
-                  <span>Values and vision alignment</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          {/* CTA and Note */}
-          <div className="text-center">
-            <a
-              href="#contact"
-              className="inline-flex items-center gap-2 bg-slate-900 text-white px-8 py-4 rounded-xl font-semibold hover:bg-slate-800 transition-all shadow-lg hover:shadow-xl mb-6"
-            >
-              Start a Confidential Conversation
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-            </a>
-            <p className="text-sm text-slate-500 max-w-md mx-auto">
-              <strong className="text-slate-700">Note:</strong> I take on at most one co-founder role per year. Most conversations start as advisory engagements — it's the best way to test working chemistry.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* Secondary CTA */}
-      <section className="py-20 bg-primary-600 relative overflow-hidden">
-        {/* Gold accent decorations */}
-        <div className="absolute top-0 left-0 w-64 h-64 bg-accent-400 opacity-5 rounded-full -translate-x-1/2 -translate-y-1/2" />
-        <div className="absolute bottom-0 right-0 w-96 h-96 bg-accent-400 opacity-5 rounded-full translate-x-1/3 translate-y-1/3" />
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative">
-          <p className="text-sm uppercase tracking-[0.2em] text-accent-400 mb-4 font-medium">Limited Availability</p>
-          <h2 className="font-serif text-3xl md:text-4xl font-bold text-white mb-4">
-            Ready to Partner?
-          </h2>
-          <p className="text-xl text-primary-200 mb-8 max-w-2xl mx-auto">
-            We take on a limited number of new partnerships each quarter. Request a confidential strategy session to explore fit.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
-              href="#contact"
-              className="bg-accent-400 text-primary-900 px-10 py-4 rounded-xl text-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg text-center btn-premium"
-            >
-              Request a Strategy Call
-            </a>
-            <a
-              href="/blog"
-              className="border-2 border-accent-400/50 text-white px-8 py-4 rounded-xl text-lg font-semibold hover:bg-accent-400/10 hover:border-accent-400 transition-all text-center"
-            >
-              Read Our Insights
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* Featured Insights Section */}
-      <section className="py-16 bg-white">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-10">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-3 font-medium">Resources</p>
-            <h2 className="font-serif text-2xl md:text-3xl font-bold text-slate-900">Featured Insights</h2>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <a href="/blog/fractional-cto-vs-full-time-cto-uk-startups" className="group p-5 bg-slate-50 rounded-xl hover:bg-slate-100 transition-colors">
-              <span className="text-xs font-medium text-accent-600 uppercase tracking-wide">Guide</span>
-              <h3 className="text-lg font-semibold text-slate-900 mt-2 group-hover:text-primary-600 transition-colors">Fractional vs Full-Time CTO: The Real Cost Analysis</h3>
-              <p className="text-sm text-slate-600 mt-2">Beyond salary: hidden costs and strategic trade-offs for UK startups.</p>
-            </a>
-            <a href="/blog/financial-modeling-seed-stage-startups" className="group p-5 bg-slate-50 rounded-xl hover:bg-slate-100 transition-colors">
-              <span className="text-xs font-medium text-accent-600 uppercase tracking-wide">Finance</span>
-              <h3 className="text-lg font-semibold text-slate-900 mt-2 group-hover:text-primary-600 transition-colors">Financial Modeling for Seed-Stage Startups</h3>
-              <p className="text-sm text-slate-600 mt-2">What investors actually want to see in your financial model.</p>
-            </a>
-            <a href="/blog/investor-due-diligence-what-to-expect" className="group p-5 bg-slate-50 rounded-xl hover:bg-slate-100 transition-colors">
-              <span className="text-xs font-medium text-accent-600 uppercase tracking-wide">Fundraising</span>
-              <h3 className="text-lg font-semibold text-slate-900 mt-2 group-hover:text-primary-600 transition-colors">What Investors Look for in Due Diligence</h3>
-              <p className="text-sm text-slate-600 mt-2">Prepare your data room and avoid common pitfalls.</p>
-            </a>
-          </div>
-          <div className="text-center mt-8">
-            <a href="/blog" className="text-primary-600 hover:text-primary-700 font-medium inline-flex items-center gap-2">
-              View all insights
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-            </a>
-          </div>
-        </div>
-      </section>
-
+      <Testimonials />
       {/* FAQ Section */}
       <section className="py-24 bg-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Got questions?</p>
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Got questions?</p>
             <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-4">Common Questions</h2>
             <p className="text-slate-600">Everything you need to know about working with us</p>
           </div>
@@ -1151,7 +522,7 @@ export default function Home() {
 
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative">
           <div className="text-center mb-16">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-500 mb-4 font-medium">Start the conversation</p>
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Start the conversation</p>
             <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Let's Talk</h2>
             <p className="text-xl text-slate-600 max-w-2xl mx-auto">
               No sales pitch — just an honest discussion about your needs.
@@ -1185,6 +556,8 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/refer/page.js
+++ b/app/refer/page.js
@@ -110,6 +110,8 @@ export default function ReferralPage() {
     <div className="min-h-screen bg-white">
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero Section */}
       <section className="pt-32 pb-20 bg-gradient-to-br from-slate-900 to-slate-800 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -485,6 +487,8 @@ I'll leave you both to connect.
           </div>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/services/fractional-cfo/page.js
+++ b/app/services/fractional-cfo/page.js
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Navigation from '../../components/Navigation'
+import Button from '../../components/Button'
 import Footer from '../../components/Footer'
 
 export const metadata = {
@@ -97,6 +98,10 @@ export default function FractionalCFOPage() {
       question: "Can you help us prepare for due diligence?",
       answer: "Absolutely. Due diligence preparation is one of our core strengths. We ensure your financials, projections, and data room are investor-ready and can withstand scrutiny."
     },
+    {
+      question: "Can you help with fundraising?",
+      answer: "Yes. We prepare financial models, data rooms, and due diligence materials. We've supported raises from pre-seed through Series A across fintech, healthtech, and B2B SaaS."
+    },
   ]
 
   // FAQ Schema for rich snippets
@@ -145,6 +150,8 @@ export default function FractionalCFOPage() {
 
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero Section */}
       <section className="pt-40 pb-24 bg-gradient-to-b from-accent-50 to-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -156,16 +163,15 @@ export default function FractionalCFOPage() {
               <h1 className="font-serif text-5xl md:text-6xl font-bold text-slate-900 leading-tight mb-6">
                 Fractional CFO Services
               </h1>
-              <p className="text-xl text-slate-600 mb-8 leading-relaxed">
+              <p className="text-xl text-slate-600 mb-4 leading-relaxed">
                 FP&A, financial modeling, and investor-ready reporting from a part-time CFO. The financial discipline of a high-growth company — without the overhead.
               </p>
+              <p className="text-sm font-medium text-slate-700 mb-8">
+                Engagements from £2,500/month &middot; typically 60-80% less than a full-time CFO
+              </p>
               <div className="flex flex-col sm:flex-row gap-4">
-                <a href="/contact" className="bg-accent-500 text-primary-900 px-8 py-4 rounded-xl text-lg font-semibold hover:bg-accent-600 transition-all shadow-lg hover:shadow-xl text-center">
-                  Request a Strategy Call
-                </a>
-                <a href="/#case-studies" className="border-2 border-primary-600 text-primary-700 px-8 py-4 rounded-2xl text-lg font-semibold hover:border-primary-700 hover:bg-primary-50 transition-all text-center">
-                  See Our Results
-                </a>
+                <Button href="/contact">Request a Strategy Call</Button>
+                <Button href="/case-studies" variant="secondary">See Our Results</Button>
               </div>
             </div>
             <div className="relative">
@@ -289,7 +295,11 @@ export default function FractionalCFOPage() {
           {/* Related resources */}
           <div className="mt-12 p-6 bg-accent-50 rounded-2xl border border-accent-100 text-center">
             <p className="text-slate-700">
-              Not sure when you&apos;ll need to raise? Try our free{' '}
+              New to strategic finance? Read{' '}
+              <Link href="/guides/fractional-cfo-guide" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+                The Complete Guide to Fractional CFO Services
+              </Link>.
+              {' '}Not sure when you&apos;ll need to raise? Try our free{' '}
               <Link href="/tools/runway-calculator" className="font-semibold text-accent-700 hover:text-accent-800 underline">
                 Startup Runway Calculator
               </Link>{' '}
@@ -319,6 +329,8 @@ export default function FractionalCFOPage() {
           </a>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import Navigation from '../../components/Navigation'
+import Button from '../../components/Button'
 import Footer from '../../components/Footer'
 
 export const metadata = {
@@ -96,6 +97,22 @@ export default function FractionalCTOPage() {
       question: "Can you help us hire a full-time CTO eventually?",
       answer: "Yes. Part of our role is building the foundation for your permanent leadership. We help define the role, source candidates, and ensure a smooth transition when you're ready."
     },
+    {
+      question: "Do you work with non-technical founders?",
+      answer: "Absolutely. Many of our clients are first-time founders without technical backgrounds. We excel at translating complex concepts into clear business terms."
+    },
+    {
+      question: "What's your tech stack expertise?",
+      answer: "We specialize in cloud-native architectures (AWS, GCP), Kubernetes, Terraform, Python, Java, Postgres/MySQL, GitOps, and modern data/ML stacks. But our real value is in architectural thinking — we choose the right tools for your specific needs."
+    },
+    {
+      question: "What makes you different from a dev shop?",
+      answer: "Dev shops execute your specifications. We provide strategic leadership first — helping you figure out what to build, how to fund it, and how to set up your team for long-term success."
+    },
+    {
+      question: "Do you offer ongoing support after delivery?",
+      answer: "Yes. We offer retainer arrangements for post-launch support, scaling assistance, and continued technical leadership. Many clients transition from intensive builds to lighter advisory after launch."
+    },
   ]
 
   // FAQ Schema for rich snippets
@@ -144,6 +161,8 @@ export default function FractionalCTOPage() {
 
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero Section */}
       <section className="pt-40 pb-24 bg-gradient-to-b from-primary-50 to-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -155,16 +174,15 @@ export default function FractionalCTOPage() {
               <h1 className="font-serif text-5xl md:text-6xl font-bold text-slate-900 leading-tight mb-6">
                 Fractional CTO Services
               </h1>
-              <p className="text-xl text-slate-600 mb-8 leading-relaxed">
+              <p className="text-xl text-slate-600 mb-4 leading-relaxed">
                 Engineering rigour and technical leadership for ambitious startups. Make confident architecture decisions, build the right team, and become investor-ready — without the overhead.
               </p>
+              <p className="text-sm font-medium text-slate-700 mb-8">
+                Engagements from £3,000/month &middot; typically 60-80% less than a full-time CTO
+              </p>
               <div className="flex flex-col sm:flex-row gap-4">
-                <a href="/contact" className="bg-accent-500 text-primary-900 px-8 py-4 rounded-xl text-lg font-semibold hover:bg-accent-600 transition-all shadow-lg hover:shadow-xl text-center">
-                  Request a Strategy Call
-                </a>
-                <a href="/#case-studies" className="border-2 border-primary-600 text-primary-700 px-8 py-4 rounded-xl text-lg font-semibold hover:border-primary-700 hover:bg-primary-50 transition-all text-center">
-                  View Client Outcomes
-                </a>
+                <Button href="/contact">Request a Strategy Call</Button>
+                <Button href="/case-studies" variant="secondary">View Client Outcomes</Button>
               </div>
             </div>
             <div className="relative">
@@ -322,6 +340,8 @@ export default function FractionalCTOPage() {
           </a>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/app/services/page.js
+++ b/app/services/page.js
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import Navigation from '../components/Navigation'
+import ServiceCard from '../components/ServiceCard'
 import Footer from '../components/Footer'
 
 export const metadata = {
@@ -51,7 +52,69 @@ const tracks = [
   },
 ]
 
+const services =
+[
+    // Technical Services
+    {
+      title: "Fractional CTO",
+      benefit: "Executive-level technical leadership at a fraction of the cost",
+      description: "Make confident architecture decisions, build the right team, and become investor-ready. Strategic guidance for fintech, healthtech, and SaaS startups across the UK.",
+      image: "/img/photos/service-cto.jpg",
+      outcomes: ["Save 60-80% vs full-time CTO", "Investor-ready in weeks", "Scale your team confidently"],
+      track: "technical"
+    },
+    {
+      title: "Fractional CFO",
+      benefit: "FP&A and strategic finance leadership",
+      description: "Financial planning & analysis, business strategy, and investor-ready reporting. The financial discipline of a high-growth company — without the overhead.",
+      image: "/img/photos/service-diligence.jpg",
+      outcomes: ["Financial modeling & forecasting", "Business strategy development", "Investor-ready reporting"],
+      track: "business"
+    },
+    {
+      title: "0-to-1 Product Builds",
+      benefit: "Launch your MVP in weeks, not months",
+      description: "Go from idea to production-ready product with a system built to scale. No rebuilding later, no technical debt from day one.",
+      image: "/img/photos/service-product.jpg",
+      outcomes: ["8-12 week delivery", "Built to handle growth", "Full ownership handover"],
+      track: "technical"
+    },
+    {
+      title: "Financial Modeling",
+      benefit: "Know your numbers before investors ask",
+      description: "3-statement models, unit economics, and scenario planning. Financial models that stand up to due diligence scrutiny.",
+      image: "/img/photos/infrastructure.jpg",
+      outcomes: ["3-statement models", "Unit economics analysis", "Scenario planning"],
+      track: "business"
+    },
+    {
+      title: "AI & Data Engineering",
+      benefit: "Turn AI experiments into production revenue",
+      description: "Move beyond prototypes. We build production-grade LLM applications, ML pipelines, and data infrastructure that actually scale.",
+      image: "/img/photos/service-ai.jpg",
+      outcomes: ["Production-ready AI", "Cost-optimized inference", "Scalable data pipelines"],
+      track: "technical"
+    },
+    {
+      title: "Fundraising Support",
+      benefit: "Close your round with confidence",
+      description: "Pitch deck financial sections, data room preparation, and investor Q&A coaching. We've helped startups raise from pre-seed to Series A.",
+      image: "/img/photos/hero-team.jpg",
+      outcomes: ["Data room ready", "Financial due diligence prep", "Valuation support"],
+      track: "business"
+    },
+    {
+      title: "DevOps & Platform Engineering",
+      benefit: "Deploy daily with zero downtime",
+      description: "Automated infrastructure, CI/CD pipelines, and GitOps workflows. Ship confidently and iterate fast from day one.",
+      image: "/img/photos/infrastructure.jpg",
+      outcomes: ["Automated deployments", "Infrastructure as code", "Zero-downtime releases"],
+      track: "technical"
+    }
+  ]
+
 export default function ServicesPage() {
+
   return (
     <div className="min-h-screen bg-white">
       <Navigation />
@@ -107,6 +170,25 @@ export default function ServicesPage() {
                   </Link>
                 </div>
               ))}
+            </div>
+
+            <div className="mt-20">
+              <div className="text-center mb-12">
+                <h2 className="font-serif text-3xl md:text-4xl font-bold text-slate-900 mb-4">Advisory &amp; Implementation</h2>
+                <p className="text-lg text-slate-600 max-w-3xl mx-auto">
+                  Hands-on leadership from strategy through execution — not just advice from the sidelines
+                </p>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-4">
+                {services.filter(s => s.track === 'technical').map((service, index) => (
+                  <ServiceCard key={service.title} service={service} priority={false} />
+                ))}
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                {services.filter(s => s.track === 'business').map((service, index) => (
+                  <ServiceCard key={service.title} service={service} priority={false} />
+                ))}
+              </div>
             </div>
 
             <div className="mt-16 text-center">

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -130,6 +130,12 @@ export default function sitemap() {
   // ============================================
   const otherPages = [
     {
+      url: withSlash('/case-studies'),
+      lastModified: getFileModDate(path.join(process.cwd(), 'app/case-studies/page.js')),
+      changeFrequency: 'monthly',
+      priority: 0.85,
+    },
+    {
       url: withSlash('/contact'),
       lastModified: getFileModDate(path.join(process.cwd(), 'app/contact/page.js')),
       changeFrequency: 'monthly',

--- a/app/tools/runway-calculator/RunwayCalculator.js
+++ b/app/tools/runway-calculator/RunwayCalculator.js
@@ -1,12 +1,15 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import emailjs from '@emailjs/browser'
 
 export default function RunwayCalculator() {
   const [cashOnHand, setCashOnHand] = useState(500000)
   const [monthlyBurn, setMonthlyBurn] = useState(30000)
   const [monthlyRevenue, setMonthlyRevenue] = useState(5000)
   const [expectedGrowth, setExpectedGrowth] = useState(10)
+  const [leadEmail, setLeadEmail] = useState('')
+  const [emailStatus, setEmailStatus] = useState({ state: 'idle', message: '' })
 
   const [results, setResults] = useState(null)
 
@@ -94,6 +97,40 @@ export default function RunwayCalculator() {
       zeroDate,
       projections
     })
+  }
+
+  const sendProjection = async (e) => {
+    e.preventDefault()
+    if (!results || !leadEmail) return
+    setEmailStatus({ state: 'sending', message: '' })
+    const summary = [
+      `Runway summary requested from the Codenest calculator`,
+      `Cash on hand: ${formatCurrency(cashOnHand)}`,
+      `Monthly burn: ${formatCurrency(monthlyBurn)}`,
+      `Monthly revenue: ${formatCurrency(monthlyRevenue)} (growth ${expectedGrowth}%/month)`,
+      results.runwayMonths === Infinity
+        ? 'Status: cash flow positive'
+        : `Runway: ${results.runwayMonths} months (cash-out ${formatDate(results.zeroDate)}; start fundraising by ${results.fundraiseDate ? formatDate(results.fundraiseDate) : 'now'})`,
+    ].join('\n')
+    try {
+      await emailjs.send(
+        process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID,
+        process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID,
+        {
+          name: 'Runway Calculator Lead',
+          email: leadEmail,
+          company: '',
+          engagement: 'fractional-cfo',
+          message: summary,
+        },
+        process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY
+      )
+      setEmailStatus({ state: 'sent', message: "Done — we'll send your 12-month projection to your inbox." })
+      setLeadEmail('')
+    } catch (error) {
+      console.error('EmailJS Error:', error)
+      setEmailStatus({ state: 'error', message: 'Sorry, that didn\'t send. Please try again or email hello@codenest.uk.' })
+    }
   }
 
   const formatCurrency = (amount) => {
@@ -269,6 +306,44 @@ export default function RunwayCalculator() {
               </div>
             </div>
           )}
+
+          {/* Email capture — CFO-intent lead */}
+          <div className="bg-accent-50 rounded-2xl p-8 border border-accent-200">
+            <h3 className="text-lg font-bold text-slate-900 mb-2">Email me my 12-month projection</h3>
+            <p className="text-sm text-slate-600 mb-4">
+              We&apos;ll send this summary to your inbox — and if you want help extending your runway, our fractional CFO service covers burn-rate optimisation and cash management.
+            </p>
+            {emailStatus.state === 'sent' ? (
+              <p className="text-sm font-medium text-green-700">{emailStatus.message}</p>
+            ) : (
+              <form onSubmit={sendProjection} className="flex flex-col sm:flex-row gap-3">
+                <label htmlFor="lead-email" className="sr-only">Email address</label>
+                <input
+                  id="lead-email"
+                  type="email"
+                  required
+                  value={leadEmail}
+                  onChange={(e) => setLeadEmail(e.target.value)}
+                  placeholder="you@company.com"
+                  className="flex-1 px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-slate-900"
+                />
+                <button
+                  type="submit"
+                  disabled={emailStatus.state === 'sending'}
+                  className={`px-6 py-3 rounded-lg font-semibold transition-all ${
+                    emailStatus.state === 'sending'
+                      ? 'bg-slate-400 text-white cursor-not-allowed'
+                      : 'bg-accent-400 text-primary-900 hover:bg-accent-500 shadow-gold'
+                  }`}
+                >
+                  {emailStatus.state === 'sending' ? 'Sending...' : 'Send My Projection'}
+                </button>
+              </form>
+            )}
+            {emailStatus.state === 'error' && (
+              <p className="text-sm font-medium text-red-700 mt-2">{emailStatus.message}</p>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/app/tools/runway-calculator/page.js
+++ b/app/tools/runway-calculator/page.js
@@ -30,6 +30,8 @@ export default function RunwayCalculatorPage() {
     <div className="min-h-screen bg-white">
       <Navigation />
 
+      <main id="main-content">
+
       {/* Hero */}
       <section className="pt-32 pb-12 bg-gradient-to-b from-accent-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -150,6 +152,8 @@ export default function RunwayCalculatorPage() {
           </a>
         </div>
       </section>
+
+      </main>
 
       <Footer />
     </div>

--- a/content/blog/fractional-cfo-vs-accountant-vs-controller.md
+++ b/content/blog/fractional-cfo-vs-accountant-vs-controller.md
@@ -1,0 +1,138 @@
+---
+title: 'Fractional CFO vs Accountant vs Financial Controller: What Your Startup Actually Needs'
+description: 'Accountant, financial controller, or fractional CFO? What each role does, what it costs in the UK, and which your startup needs from pre-seed to Series A.'
+date: '2026-08-04'
+author: 'Ankit Rana'
+readTime: '8 min read'
+tags: ['Fractional CFO', 'Startup Finance', 'Hiring']
+---
+
+# Fractional CFO vs Accountant vs Financial Controller: What Your Startup Actually Needs
+
+Your accountant is doing a good job. VAT returns go in on time, payroll runs without drama, year-end accounts are filed before the deadline. Then an investor asks for a three-year financial model with scenario analysis — and there's silence.
+
+This is the moment many founders discover that "finance person" is not one job. It's three distinct roles, and they answer three different questions:
+
+- An **accountant** tells you what happened — and keeps you compliant.
+- A **financial controller** tells you what's happening — and makes the numbers reliable.
+- A **fractional CFO** tells you what should happen next — and helps you fund it.
+
+Hire the wrong one and you'll pay for skills you don't need while the gap that actually hurts stays open. Here's how the three roles differ, what each typically costs in the UK, and which your startup needs at each stage from pre-seed to Series A.
+
+## What an Accountant Actually Does
+
+An accountant is your compliance layer. The job is to record what happened accurately and keep you on the right side of HMRC and Companies House.
+
+For a typical early-stage startup, that means:
+
+- **Bookkeeping** — recording transactions, reconciling bank feeds, keeping the ledger clean
+- **VAT** — registration, quarterly returns, Making Tax Digital compliance
+- **Year-end accounts** — statutory accounts for Companies House and your Corporation Tax return
+- **Payroll** — payslips, PAYE and pension auto-enrolment for your first hires
+- **Tax matters** — salary versus dividends, R&D relief claims, SEIS/EIS paperwork (with many practices)
+
+**Typical UK cost:** £150-£500 per month for an early-stage startup, depending on transaction volume and whether payroll is included.
+
+The limitation isn't quality — it's orientation. Accountancy is historical by design. A good accountant will tell you exactly what last quarter looked like. They won't tell you whether you can afford two more engineers, what your burn multiple signals to a seed investor, or how a pricing change flows through your forecast. That's not their training, their engagement letter, or their price point.
+
+## What a Financial Controller Does
+
+A financial controller owns operational finance: the numbers being right, on time, every month.
+
+Typical scope:
+
+- **Month-end close** — a repeatable process that closes the books to a deadline
+- **Management accounts** — monthly P&L, balance sheet and cash flow, with commentary
+- **Processes and controls** — approval workflows, expense policy, revenue recognition done properly
+- **Systems** — the accounting stack, billing integrations, reporting automation
+- **Managing the bookkeeping** — whether it sits in-house or with your accountant
+
+**Typical UK cost:** £50,000-£80,000 a year for a full-time hire, or day rates if you engage one fractionally for a day or two a week.
+
+Controllers are precision people, and that's both their value and their boundary. A controller makes your numbers trustworthy; they don't decide what to do with them. Fundraising strategy, scenario modelling, board narrative and capital allocation all sit outside the role — which matters, because that's the layer founders most often think they're buying.
+
+## What a Fractional CFO Does
+
+A CFO is the forward-looking layer: strategy, capital, and the decisions that determine whether the company is still here in eighteen months. A fractional CFO delivers that part-time, on a retainer, so you get the seniority without the full-time cost. We've written a [complete guide to fractional CFOs](/guides/fractional-cfo-guide) if you want the role in depth; the short version of the scope is:
+
+- **Financial modelling** — a three-statement model with scenarios you can defend in a term-sheet negotiation (here's [how to build a financial model for a seed-stage startup](/blog/financial-modeling-seed-stage-startups))
+- **FP&A** — budgets, reforecasts, budget-versus-actuals, unit economics
+- **Fundraising** — raise strategy, investor materials, data room preparation, due diligence support
+- **Board and investor work** — board packs, metrics, the narrative behind the numbers
+- **Cash and runway** — burn management, hiring plans, scenario planning
+
+**Typical UK cost:** £2,000-£12,000 per month depending on intensity — a couple of days a month at the low end, several days a week at the top. Codenest engagements start from £2,500 per month. We've broken down [what a fractional CFO costs in the UK](/blog/how-much-does-fractional-cfo-cost-uk), including what pushes the price up or down, in a separate post.
+
+## The Three Roles at a Glance
+
+| | Accountant | Financial Controller | Fractional CFO |
+|---|---|---|---|
+| **Orientation** | Historical | Operational | Forward-looking |
+| **Core question** | What happened, and are we compliant? | Are the numbers right, and on time? | What should we do next, and can we afford it? |
+| **Typical work** | Bookkeeping, VAT, year-end accounts, payroll | Month-end close, management accounts, processes and controls | Modelling, FP&A, fundraising, board work |
+| **Typical UK cost** | £150-£500/month | £50k-£80k full-time, or fractional day rates | £2,000-£12,000/month by intensity |
+| **First needed** | From incorporation | Usually post-Series A | Around your first serious raise |
+
+## Which Do You Need at Each Stage?
+
+### Pre-seed: an accountant only
+
+Before institutional money, your finance needs are compliance and visibility. A decent accountant plus a disciplined founder covers both: books reconciled monthly, VAT and payroll handled, and a simple view of burn — our [runway calculator](/tools/runway-calculator) gives you the one number that matters most at this stage.
+
+Resist buying more than this. A CFO with no raise to run and nothing to model is an expensive comfort blanket.
+
+### Raising seed: accountant + fractional CFO
+
+The seed raise is where forward-looking finance starts deciding outcomes. Investors want a credible model, defensible unit economics, and a clear account of how their money converts into milestones. Your accountant can't produce that, and a controller wouldn't either. This is the classic entry point for a fractional CFO — often a few days a month in the run-up to the raise, scaling up around due diligence.
+
+You still don't need a controller. At seed-stage transaction volumes, the accountant keeps the books and the CFO builds on top of them.
+
+### Post-Series A: add a controller
+
+After Series A the operational load changes character. Revenue recognition gets complicated, the board expects a monthly pack on a deadline, headcount grows, and an audit is somewhere on the horizon. That's controller work. Adding one — full-time or fractional — frees your CFO from month-end mechanics so their time goes on strategy, and gives your reporting the reliability that Series B diligence will test.
+
+Notice the pattern: **the roles stack; they don't replace each other.** You'll still have an accountant at Series B. You add layers as the questions get harder.
+
+## Common Mistakes
+
+**1. Hiring a controller and expecting strategy**
+
+"Controller" sounds senior, and the title sits close enough to CFO that founders conflate the two. Then they're frustrated when their controller produces immaculate management accounts but no fundraising model, no scenario plan, and no view on pricing. That isn't underperformance — it's the role working exactly as designed. If your question is "what should we do?", you've hired for the wrong layer.
+
+**2. Expecting your accountant to build investor models**
+
+Ask a compliance-focused practice for "projections" and you'll usually get a template extrapolation — last year plus a growth rate — because building operating models isn't what accountancy training covers. It looks fine until an investor opens the spreadsheet, changes an assumption, and watches nothing flow through. A model that fails that test costs you credibility at the precise moment you're asking for money.
+
+**3. Buying seniority to fix messy books**
+
+A fractional CFO working from unreconciled ledgers spends expensive hours on clean-up an accountant should have done for a fraction of the rate. Sequence matters: accountant first, always. Strategy built on bad data is just confident guessing.
+
+**4. Going full-time too early**
+
+Before Series A there's rarely a full-time CFO's worth of work — fundraising is intense but episodic. A full-time hire at that stage buys idle capacity with runway. Scale a fractional engagement up and down instead, and revisit once the operational load genuinely justifies the seat.
+
+## When You Need More Than One
+
+The roles are complements, not substitutes, and each one's output is another's input. The accountant's clean books are the raw material for the controller's management accounts. The controller's reliable actuals are what make the CFO's forecasts worth anything — every reforecast starts from what actually happened. And the CFO defines what management information the business needs, which the controller then produces month after month.
+
+In practice the stack evolves like this:
+
+- **Pre-seed:** accountant
+- **Seed to Series A:** accountant + fractional CFO
+- **Post-Series A:** accountant + controller + CFO (fractional or full-time)
+
+Where two roles could overlap — who owns the management accounts, who runs payroll queries — assign ownership explicitly. Ambiguity between finance roles produces duplicated work at best and unowned numbers at worst.
+
+## The Bottom Line
+
+Match the role to the question you need answered:
+
+- **"Are we compliant, and what happened?"** — accountant, £150-£500 per month. Every startup needs one from day one.
+- **"Are the numbers right, every month?"** — financial controller. Usually a post-Series A addition.
+- **"What should we do next, and how do we fund it?"** — fractional CFO. From your first serious raise.
+
+Sequence them in that order, and don't expect any of them to do the others' jobs. The titles get used interchangeably; the skills aren't.
+
+---
+
+*Not sure which role your startup actually needs first? Our [fractional CFO services](/services/fractional-cfo) start from £2,500 per month and are designed to work alongside your existing accountant — [get in touch](/contact) for a straight answer.*

--- a/content/blog/how-much-does-fractional-cfo-cost-uk.md
+++ b/content/blog/how-much-does-fractional-cfo-cost-uk.md
@@ -1,0 +1,211 @@
+---
+title: 'How Much Does a Fractional CFO Cost in the UK? 2026 Pricing Guide'
+description: 'Complete UK pricing guide for fractional CFO services in 2026. Retainer ranges, day rates, full-time cost comparisons, and how to budget at every stage.'
+date: '2026-08-04'
+author: 'Ankit Rana'
+readTime: '7 min read'
+tags: ['Fractional CFO', 'Pricing', 'Startup Finance']
+---
+
+# How Much Does a Fractional CFO Cost in the UK? 2026 Pricing Guide
+
+If you're considering fractional CFO support for your startup, the first question is usually: "What does it cost?"
+
+The short answer: **£2,000-£12,000 per month** depending on engagement level and experience. But let's break down what you get at each tier and how to think about the investment.
+
+Still weighing whether you need one at all? Start with [When Should You Hire a Fractional CFO?](/blog/when-to-hire-fractional-cfo) — this guide assumes you've decided financial leadership matters and want to budget for it.
+
+## Fractional CFO Pricing Tiers
+
+### Light-Touch Advisory: £2,000-£3,500/month
+**~2-4 hours per week**
+
+Best for:
+- Pre-seed startups that need runway visibility and a monthly reporting rhythm
+- Founders with a bookkeeper and accountant in place, but no strategy layer above them
+- A senior sense-check before significant financial decisions
+
+What's included:
+- Monthly review of management accounts with commentary
+- A rolling runway and cash model, kept current
+- Monthly strategic call with the founder
+- Async availability for questions
+- Input on major decisions: hires, pricing changes, big contracts
+
+What's not included:
+- Hands-on transactional work (invoicing, payroll, bookkeeping)
+- Weekly presence in the business
+- Leading a fundraise end to end
+
+### Standard: £3,500-£6,000/month
+**~1 day per week**
+
+Best for:
+- Seed-stage startups preparing to raise in the next 6-12 months
+- Companies with monthly board or investor reporting obligations
+- Founders who need unit economics defined and tracked properly
+
+What's included:
+- Everything in Light-Touch Advisory, plus:
+- Ownership of the monthly board pack
+- Building and maintaining the financial model
+- Unit economics tracking and analysis
+- Fundraise preparation: model, metrics, data room
+- Managing the bookkeeper and accountant relationship
+
+What's not included:
+- Daily availability
+- Running the full finance function single-handedly
+
+### Intensive: £6,000-£12,000/month
+**2-3 days per week**
+
+Best for:
+- Series A preparation or a live fundraise
+- Post-raise scaling with rapid hiring and spend
+- Companies in regulated sectors with heavier reporting demands
+- Building out the first in-house finance hires
+
+What's included:
+- Everything in Standard, plus:
+- Due diligence management during a raise
+- Attending investor and board meetings
+- Hiring and structuring the finance team
+- Scenario planning and cash management
+- Finance systems selection and implementation oversight
+
+## Day Rates vs Monthly Retainers
+
+Senior fractional CFOs in the UK typically charge **£800-£1,500 per day** when engaged on a day-rate basis. Day rates suit defined projects — a fundraise model build, a due diligence sprint, a pricing review. Monthly retainers usually offer better value for ongoing work because the CFO carries context between sessions rather than rebuilding it each time.
+
+If a monthly retainer divided by the days delivered works out far below market day rates, ask what's actually included. If it works out far above, ask the same question.
+
+## Cost Comparison: Fractional vs Full-Time
+
+Here's why the fractional model makes financial sense for most early-stage startups. Figures are indicative for a senior UK hire:
+
+| Cost Component | Fractional CFO | Full-Time CFO |
+|---------------|---------------|---------------|
+| Annual Fee/Salary | £24,000-£144,000 | £150,000-£250,000+ |
+| Employer NI | £0 | £18,000-£30,000 |
+| Pension | £0 | £5,000-£10,000 |
+| Benefits | £0 | £5,000-£15,000 |
+| Recruitment Fee | £0 | £30,000-£60,000 |
+| Equity | 0% | 0.5-2% |
+| Time to Start | 1-2 weeks | 3-6 months |
+| **Year 1 Total** | **£24,000-£144,000** | **£210,000-£360,000+** |
+
+For a typical seed-stage engagement at £3,500 per month — £42,000 per year — the Year 1 difference is well over £150,000, before counting equity dilution or the three to six months the role sits empty while you recruit.
+
+## What Affects Pricing?
+
+### 1. Experience and Qualification
+
+A qualified accountant (ACA, ACCA, CIMA) who has also operated through startup fundraises commands higher rates than either credential alone. You're paying for:
+
+- Pattern recognition (they've seen your cash position, your board dynamics, your raise before)
+- Investor credibility (their presence in diligence changes the conversation)
+- Judgement under uncertainty, not just correct bookkeeping
+
+### 2. Sector Specialisation
+
+Specialists in regulated or complexity-heavy sectors (fintech, healthtech, B2B SaaS with tricky revenue recognition) typically charge premium rates because:
+
+- Regulatory reporting mistakes are expensive to unwind
+- Sector-specific metrics and benchmarks accelerate investor conversations
+- Fewer people combine the finance skills with the domain knowledge
+
+### 3. Engagement Intensity
+
+More days per week means higher total cost, but often better value per day. Intensive engagements offer deeper context, faster decisions, and a CFO who behaves like part of the leadership team rather than a visitor.
+
+### 4. Location
+
+London-based fractional CFOs typically charge 10-20% more than those elsewhere in the UK, reflecting cost of living, proximity to the investor ecosystem, and in-person availability for board meetings.
+
+## How to Budget for a Fractional CFO
+
+### Pre-Seed (£100k-£500k raised)
+**Budget: £2,000-£3,500/month**
+
+You're validating the business and every month of runway counts. A light-touch engagement provides:
+- A credible runway model from day one
+- Clean monthly numbers investors can trust
+- A senior voice before irreversible financial decisions
+
+### Seed (£500k-£2M raised)
+**Budget: £3,500-£6,000/month**
+
+You're deploying capital and reporting to investors. A standard engagement provides:
+- Board-ready reporting every month
+- Unit economics you can defend
+- Fundraise preparation well before you need it
+
+### Series A (£2M-£10M raised)
+**Budget: £6,000-£12,000/month**
+
+You're scaling spend and headcount fast. An intensive engagement provides:
+- Due diligence leadership through the raise
+- Budgeting, controls, and variance reporting post-raise
+- A finance function designed before you hire it
+
+## ROI of a Fractional CFO
+
+The value isn't just the saving versus a full-time hire. It's in:
+
+**Mistakes avoided:**
+- Running out of cash without warning — the most preventable startup failure, and a rolling cash model costs a fraction of an emergency bridge round
+- Stalled due diligence — inconsistent numbers delay rounds, and delayed rounds sometimes die
+- Underpricing — margin given away quietly, month after month, is invisible without proper analysis
+
+**Efficiency gained:**
+- Faster month-end close and board pack preparation
+- Sharper supplier and contract negotiations
+- Founder hours returned to product and customers
+
+**Opportunities captured:**
+- Credibility with investors when your numbers withstand scrutiny
+- Levers identified to [extend your runway](/blog/extending-startup-runway-practical-guide) before you're forced to
+- Better terms, because prepared founders negotiate from strength
+
+## Questions to Ask About Pricing
+
+When evaluating fractional CFO options, ask:
+
+1. **"What's included in your retainer?"**
+   Ensure you understand the scope, the deliverables, and the hours behind the number.
+
+2. **"Who actually does the work?"**
+   Some firms sell a senior name and deliver a junior team. Know whose judgement you're buying.
+
+3. **"How do you work with our accountant and bookkeeper?"**
+   A fractional CFO complements compliance and bookkeeping — they shouldn't be duplicating (or billing for) work you already pay for.
+
+4. **"What happens in a fundraise month?"**
+   Diligence periods spike the workload. Agree upfront how overflow is handled and priced.
+
+5. **"Do you take equity?"**
+   Most fractional CFOs work on a cash retainer with a 30-day notice period. Be wary of equity-first pricing at this stage — it's rarely the cheapest option once you model the dilution.
+
+## The Bottom Line
+
+Fractional CFO services in the UK typically cost:
+
+- **Light-Touch Advisory:** £2,000-£3,500/month
+- **Standard (~1 day/week):** £3,500-£6,000/month
+- **Intensive (2-3 days/week):** £6,000-£12,000/month
+
+As a reference point, Codenest fractional CFO engagements start from £2,500 per month. For most pre-seed to Series A startups, the fractional model represents **60-80% savings** versus a full-time CFO hire, with:
+
+- Zero equity dilution
+- Zero recruitment fees
+- Flexible, monthly commitment
+- A start date measured in weeks, not months
+
+For the full picture of what the role covers at each stage, read our [complete fractional CFO guide](/guides/fractional-cfo-guide).
+
+The question isn't whether you can afford a fractional CFO — it's whether you can afford to keep making financial decisions without one.
+
+---
+
+*Want to work out the right engagement level for your stage? Explore our [fractional CFO services](/services/fractional-cfo), model your burn with the free [Startup Runway Calculator](/tools/runway-calculator), or [get in touch](/contact) to talk through your numbers.*

--- a/content/blog/how-much-does-fractional-cto-cost-uk.md
+++ b/content/blog/how-much-does-fractional-cto-cost-uk.md
@@ -1,13 +1,13 @@
 ---
-title: 'How Much Does a Fractional CTO Cost in the UK? 2025 Pricing Guide'
-description: 'Complete UK pricing guide for fractional CTO services in 2025. Understand retainer costs, engagement levels, and how to budget for part-time technical leadership.'
-date: '2025-01-06'
+title: 'How Much Does a Fractional CTO Cost in the UK? 2026 Pricing Guide'
+description: 'Complete UK pricing guide for fractional CTO services in 2026. Understand retainer costs, engagement levels, and how to budget for part-time technical leadership.'
+date: '2026-08-04'
 author: 'Ankit Rana'
 readTime: '7 min read'
 tags: ['Fractional CTO', 'Pricing', 'Budgeting']
 ---
 
-# How Much Does a Fractional CTO Cost in the UK? 2025 Pricing Guide
+# How Much Does a Fractional CTO Cost in the UK? 2026 Pricing Guide
 
 If you're considering fractional CTO support for your startup, the first question is usually: "What does it cost?"
 

--- a/content/blog/non-technical-founder-hiring-developers.md
+++ b/content/blog/non-technical-founder-hiring-developers.md
@@ -1,13 +1,13 @@
 ---
-title: "Non-Technical Founder's Guide to Hiring Developers in 2025"
+title: "Non-Technical Founder's Guide to Hiring Developers in 2026"
 description: "How to hire developers when you are not technical yourself. Practical guide covering where to find developers, how to evaluate them, and what to pay."
-date: '2025-01-02'
+date: '2026-08-04'
 author: 'Ankit Rana'
 readTime: '11 min read'
 tags: ['Hiring', 'Team Building', 'Non-Technical Founders']
 ---
 
-# Non-Technical Founder's Guide to Hiring Developers in 2025
+# Non-Technical Founder's Guide to Hiring Developers in 2026
 
 You've got a great idea and maybe even some funding. Now you need developers to build it. But how do you hire technical people when you're not technical yourself?
 
@@ -192,7 +192,7 @@ Even without technical knowledge, these questions reveal a lot:
 - Honesty about limitations
 - Enthusiasm for your problem
 
-## Salary Benchmarks (UK, 2025)
+## Salary Benchmarks (UK, 2026)
 
 | Role | Junior | Mid | Senior |
 |------|--------|-----|--------|

--- a/content/blog/when-to-hire-fractional-cfo.md
+++ b/content/blog/when-to-hire-fractional-cfo.md
@@ -1,0 +1,109 @@
+---
+title: 'When Should You Hire a Fractional CFO? 7 Signs Your Startup Is Ready'
+description: 'Not sure if your startup needs a fractional CFO? Seven clear signs you are ready, from fundraising plans and runway anxiety to investor reporting burden.'
+date: '2026-08-04'
+author: 'Ankit Rana'
+readTime: '8 min read'
+tags: ['Fractional CFO', 'Hiring', 'Startup Finance']
+---
+
+# When Should You Hire a Fractional CFO? 7 Signs Your Startup Is Ready
+
+The question isn't whether your startup needs financial leadership — every funded company does. The question is whether you need it full-time, or whether a fractional CFO gives you what you need at your stage.
+
+Here are seven clear signs that your startup is ready for a fractional CFO.
+
+## 1. You're Preparing to Raise in the Next 6-12 Months
+
+A fundraise is won or lost months before the first investor meeting. Investors will ask you to walk through your financial model, defend your assumptions, justify the amount you're raising, and show what the money buys in milestones. Then diligence begins: historical accounts, forecast integrity, contracts, the cap table.
+
+**The problem:** Fundraise readiness takes months to build. If the model gets assembled the week before outreach, it shows — and what investors actually want to see in a [seed-stage financial model](/blog/financial-modeling-seed-stage-startups) is rarely what founders build unprompted.
+
+**A fractional CFO helps by:** Building a three-statement model that survives scrutiny, assembling the data room early, pressure-testing your raise amount against a real milestone plan, and joining investor meetings as the credible voice on the numbers.
+
+## 2. You Can't Answer Unit-Economics Questions
+
+Try these:
+
+- What's your CAC payback period?
+- What's your gross margin — and where does it land at scale?
+- Which customer segment is actually profitable?
+- What's your LTV based on, beyond hope?
+
+If the honest answer is "I'd be guessing", you're not alone — but you are exposed.
+
+**The problem:** Without unit economics, you can't tell whether growth is building value or destroying it. Every pound of marketing spend, every discount, every new hire is a decision made blind.
+
+**A fractional CFO helps by:** Defining the metrics that actually fit your business model, instrumenting them so they update monthly rather than annually, and turning them into decisions — which channel to fund, which segment to drop, which price to change.
+
+## 3. You Worry About Runway but Don't Have a Cash Model
+
+You check the bank balance more often than you'd admit. Asked how many months of runway you have, you give a different answer depending on the day — because the number lives in your head, not in a model.
+
+**The problem:** Runway anxiety without a cash model produces the worst of both worlds: constant low-level stress, and no early warning when something actually changes. Hiring decisions feel like gambles because nobody has modelled what they do to the cash-out date.
+
+**A fractional CFO helps by:** Building a rolling 13-week cash flow forecast and a 12-18 month runway model with base, stretch, and downside scenarios. Anxiety becomes a number with a date attached — and a plan for moving both.
+
+## 4. Board and Investor Reporting Has Become a Burden
+
+You raised, and now you owe monthly or quarterly updates. Each one is a night-before scramble: exporting from the accounting system, reconciling spreadsheets, rebuilding charts, hoping this month's figures use the same definitions as last month's.
+
+**The problem:** Inconsistent reporting does more damage than founders realise. When a metric changes definition between board packs, investors notice — and start quietly discounting everything else in the pack.
+
+**A fractional CFO helps by:** Establishing a monthly close rhythm, building a standing board pack with consistent KPI definitions, and writing the narrative that connects the numbers to strategy — so reporting becomes a strength investors remember at the next round.
+
+## 5. Pricing Decisions Are Made on Gut Feel
+
+Your price was set at launch by looking at what similar products charge, and hasn't been seriously revisited since. Discounts get approved deal by deal, because closing feels better than holding the line.
+
+**The problem:** Pricing is the highest-leverage lever in your business — a small change flows almost entirely to gross margin. Underpricing is endemic among technical founders, and it compounds: every mispriced customer is margin given away for the life of the contract.
+
+**A fractional CFO helps by:** Analysing cost-to-serve and margin by segment, aligning your pricing structure with the value metric customers actually care about, setting a discount policy with limits, and testing price changes with data instead of nerve.
+
+## 6. You've Just Raised and Need Post-Raise Discipline
+
+The money landed. Now the model you pitched has to become an operating budget, a hiring plan, and spending controls — because the board that funded the plan expects to see performance against it.
+
+**The problem:** Post-raise spend creep is quiet and cumulative: tools, contractors, salaries, travel. Without a budget and variance reporting, you discover the overspend months later, as missing runway.
+
+**A fractional CFO helps by:** Converting the pitch model into a real operating budget, putting approval controls around spend, reporting plan-versus-actual monthly, and making sure the raise lasts as long as the plan said it would.
+
+## 7. Finance Admin Is Consuming Founder Time
+
+Invoicing, payroll queries, chasing late payers, VAT deadlines, expense approvals. Hours every week that should go to product and customers are going to administration — and it grows with headcount.
+
+**The problem:** Founder time is the scarcest resource in the company, and finance admin expands to fill it. But be honest about the diagnosis: most of this is bookkeeping and compliance work, and a fractional CFO is not a cheaper bookkeeper.
+
+**A fractional CFO helps by:** Designing the finance function so admin runs without you — the right bookkeeper, accountant, and tooling, with clear handoffs — while reserving the CFO layer for what it's for: decisions, reporting, and strategy.
+
+## What About the Cost?
+
+The comparison that matters isn't fractional versus nothing — it's fractional versus full-time:
+
+| | Fractional CFO | Full-Time CFO |
+|---|---|---|
+| Typical Annual Cost | £24k-£144k | £210k-£360k+ all-in |
+| Equity | 0% | 0.5-2% |
+| Time to Start | 1-2 weeks | 3-6 months |
+
+UK fractional CFO retainers typically run £2,000-£3,500 per month for light-touch advisory, £3,500-£6,000 for around a day a week, and £6,000-£12,000 for two to three days. A full-time CFO costs £150,000-£250,000+ in salary alone, plus equity, plus a three-to-six-month hiring process. For the full breakdown by stage, read our [2026 pricing guide](/blog/how-much-does-fractional-cfo-cost-uk).
+
+## When a Fractional CFO Isn't Right
+
+To be fair, fractional isn't always the answer. You might not need one yet — or might need something else — if:
+
+- You're pre-funding with minimal transactions: a good accountant and a runway spreadsheet may be enough for now
+- What you actually need is daily transactional finance: that's a bookkeeper or financial controller, not a CFO
+- You're past Series B with multi-entity operations and need 40+ hours per week of financial leadership: that's a full-time CFO
+
+But for most pre-seed to Series A startups, fractional provides the financial leadership you need while preserving the runway you hired it to protect.
+
+## The Bottom Line
+
+If you recognised yourself in 3+ of these signs, it's probably time to explore fractional CFO support. You don't need to wait until you can afford a full-time executive — and you shouldn't wait until a failed diligence process or a missed cash crunch makes the decision for you.
+
+For a deeper look at what the role covers, how engagements are structured, and how to choose well, read our [complete fractional CFO guide](/guides/fractional-cfo-guide).
+
+---
+
+*Ready to explore fractional CFO support? Learn more about our [fractional CFO services](/services/fractional-cfo), check your numbers with the free [Startup Runway Calculator](/tools/runway-calculator), or [get in touch](/contact) to discuss your situation.*


### PR DESCRIPTION
## Summary

Follow-up to #28 (merged), completing the final **Month 2** batch from `WEBSITE_REVIEW.md`. This closes out every item in the original site review; the only remaining items are owner inputs (testimonial authenticity, Opayo timeline dates, founder photo, real stat denominators).

### CFO content cluster — the largest gap in the original review
- New **`/guides/fractional-cfo-guide`** (613 lines) mirroring the CTO guide: what a fractional CFO does, when to hire, UK costs, vs full-time, vs accountant/controller, FAQ + Article/FAQPage schemas
- Three new blog posts: **"How Much Does a Fractional CFO Cost in the UK? 2026"**, **"When Should You Hire a Fractional CFO? 7 Signs"**, **"Fractional CFO vs Accountant vs Financial Controller"**
- Pricing standardized across all four pieces (light-touch £2,000-£3,500 / ~1 day-week £3,500-£6,000 / 2-3 days £6,000-£12,000; Codenest from £2,500/month) — an inconsistency caught and fixed by the review pass
- Wired into the guides hub, footer Resources, CFO service page, and the tag-aware blog CTA router

### Homepage restructure (15 → 9 sections)
- Two-tracks (the core CTO/CFO message) now directly under the hero
- Full case studies moved to new **`/case-studies`** (nav + footer + sitemap), compact 3-card teaser left behind
- Removed from the homepage: who-we-serve, the 7-card services grid (→ `/services` hub, cards now clickable), the comparison table, the co-founder section, the secondary CTA band, Featured Insights
- FAQs trimmed to 4 general questions; the rest redistributed to their owning service pages

### Design & accessibility
- Gold eyebrows → `accent-700` (WCAG AA on white); small slate text fixed
- `cta-pulse`/`btn-premium` animations and dead CSS removed; `prefers-reduced-motion` added
- `<main id="main-content">` landmark on every page; skip link finally works sitewide
- ContactForm engagement selector rebuilt as a proper fieldset with named radios, focus rings, and **CTO/CFO-segmented options**
- New shared `Button` component (primary/secondary) adopted at hero call sites

### Conversion
- Runway calculator now captures emails ("Email me my 12-month projection", CFO-intent lead via the existing EmailJS setup)
- Visible pricing anchors on both service pages + the homepage pricing FAQ
- 2025-dated titles refreshed to 2026; CTO guide title made evergreen

## Verification
- `npm run build` passes — **40 routes** (35 before this PR)
- Built-HTML checks: pricing consistency across the cluster, tag routing (all 4 new pieces → CFO CTA), landmarks, no animation classes, single FAQPage per page
- Independent code review: 1 high (pricing tier contradiction between agent-written pieces) + 2 medium + 1 low — **all fixed and re-verified** before this commit

Note: merging deploys straight to codenest.uk via the Pages workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)