### PR TITLE
Apply owner-verified facts: testimonials, Opayo dates, tightened stats

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -65,6 +65,9 @@ every claim — write as if they will check, because they will.
    employment is framed as pedigree: "Founder track record includes…" — never
    "Trusted by…". Anonymous testimonials are labelled as discretion
    ("Founder & CEO, London fintech — name withheld under NDA"), never left ambiguous.
+   The two anonymised testimonials (fintech Series A; B2B SaaS MVP) are verified
+   genuine — owner confirmed 4 Aug 2026, real clients under NDA. Keep them; name
+   a client only with that client's permission.
 4. **Founder-led voice.** "I" for personal commitments (co-founder page, values,
    About). "We"/"Codenest" for methodology and delivery. Never "our team" for work
    done as an individual or as prior employment. Never disparage solo operators
@@ -262,3 +265,12 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
 8. **No gold text on white below AA contrast.** (4 Aug 2026.)
 9. **One FAQPage schema per page, owned by the page.** (4 Aug 2026.)
 10. **ICP phrasing is "pre-seed to Series A"** — one variant, sitewide. (4 Aug 2026.)
+11. **Opayo engagement dates: August 2019 – June 2026** — a Codenest-era engagement.
+    Elavon (US Bancorp) employment 2011-2015 is separate early-career history; never
+    date Opayo work into that window. (Owner, 4 Aug 2026.)
+12. **The two anonymised testimonials are verified genuine** (owner, 4 Aug 2026) —
+    real clients under NDA. Never delete or reword them as "placeholders"; name a
+    client only with permission.
+13. **Stat cells carry a named engagement or an offer term** — Rungway users, Opayo
+    duration, the testimonial-backed Series A, 8-12 wks MVP. No bare counts without
+    a citable denominator ("15+ startups" retired). (4 Aug 2026.)

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -58,7 +58,7 @@ export default function AboutPage() {
     {
       year: "2017-Present",
       title: "Codenest",
-      description: "Founded Codenest to provide integrated technical and financial leadership for ambitious founders. Fractional CTO and CFO for startups across fintech, healthtech, proptech, and B2B SaaS — helping them build right and raise successfully."
+      description: "Founded Codenest to provide integrated technical and financial leadership for ambitious founders. Fractional CTO and CFO for startups across fintech, healthtech, proptech, and B2B SaaS — helping them build right and raise successfully. Engagements have ranged from pre-seed MVPs to a near seven-year payment-platform transformation with Opayo by Elavon (2019-2026)."
     }
   ]
 

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -36,7 +36,7 @@ const caseStudies = [
   {
     title: "Opayo by Elavon: Payment Platform Transformation",
     challenge: "Leading UK fintech payment provider needed Kubernetes consulting to modernize their infrastructure and integrate new payment channels (Apple Pay, Google Pay) while maintaining 100% uptime for critical transaction processing across Europe.",
-    solution: "Working inside the Opayo platform team, our founder orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
+    solution: "Working inside the Opayo platform team from August 2019 to June 2026, our founder orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
     results: ["Accelerated releases from every 2 weeks to multiple times per day", "Contributed to 10% revenue increase through faster feature delivery", "Reduced CI pipeline failures through automated testing", "Successfully integrated Apple Pay and Google Pay"],
     tags: ["Payment Systems", "AWS EKS", "Kubernetes", "Terraform", "GitOps", "Team Leadership"],
     image: "/img/photos/case-opayo.jpg",

--- a/app/components/Testimonials.js
+++ b/app/components/Testimonials.js
@@ -1,7 +1,7 @@
 // Testimonial policy (BRANDING.md §2.3): only real feedback. Named attributions
 // require the client's permission; confidential ones are explicitly anonymised.
-// TODO(owner): confirm the two anonymised quotes below are genuine client
-// feedback — if not, they must be removed, not reworded.
+// Owner-verified (4 Aug 2026): the two anonymised quotes are genuine client
+// feedback published under NDA — keep them; name clients only with permission.
 const testimonials = [
   {
     quote: "They transformed our platform from handling 5 users to 1000+ concurrent users. The migration was seamless with zero downtime. Exactly the technical leadership we needed.",

--- a/app/page.js
+++ b/app/page.js
@@ -159,7 +159,7 @@ export default function Home() {
                   </svg>
                   <div>
                     <span className="font-medium">Every client diligence passed to date</span>
-                    <span className="text-slate-500 text-sm block">Technical and financial, across 15+ startups</span>
+                    <span className="text-slate-500 text-sm block">Technical and financial, from pre-seed to Series A</span>
                   </div>
                 </li>
               </ul>
@@ -347,7 +347,7 @@ export default function Home() {
 
           </div>
           <p className="text-center text-sm text-slate-600 mt-8">
-            Led by <a href="/about" className="font-semibold text-primary-700 hover:text-primary-800">Ankit Rana</a> — ex-Deloitte Digital and Elavon (US Bancorp), 15+ years building and scaling platforms.
+            Led by <a href="/about" className="font-semibold text-primary-700 hover:text-primary-800">Ankit Rana</a> — 15+ years building and scaling platforms, from early-career engineering at Deloitte Digital and Elavon (US Bancorp) to fractional CTO and CFO engagements today.
           </p>
         </div>
       </section>
@@ -365,12 +365,12 @@ export default function Home() {
               <div className="text-slate-300 text-sm md:text-base">Concurrent users scaled at Rungway</div>
             </div>
             <div className="space-y-2 group">
-              <div className="text-3xl md:text-4xl lg:text-5xl font-bold text-gold-gradient stat-number group-hover:scale-105 transition-transform">15+</div>
-              <div className="text-slate-300 text-sm md:text-base">Startups supported</div>
+              <div className="text-3xl md:text-4xl lg:text-5xl font-bold text-gold-gradient stat-number group-hover:scale-105 transition-transform">6+ yrs</div>
+              <div className="text-slate-300 text-sm md:text-base">Payments engagement at Opayo by Elavon</div>
             </div>
             <div className="space-y-2 group">
               <div className="text-3xl md:text-4xl lg:text-5xl font-bold text-gold-gradient stat-number group-hover:scale-105 transition-transform">Series A</div>
-              <div className="text-slate-300 text-sm md:text-base">Fundraises supported</div>
+              <div className="text-slate-300 text-sm md:text-base">Closed with our models and data room</div>
             </div>
             <div className="space-y-2 group">
               <div className="text-3xl md:text-4xl lg:text-5xl font-bold text-gold-gradient stat-number group-hover:scale-105 transition-transform">8-12 wks</div>

--- a/content/blog/fractional-cto-vs-full-time-cto-uk-startups.md
+++ b/content/blog/fractional-cto-vs-full-time-cto-uk-startups.md
@@ -11,7 +11,7 @@ tags: ['Fractional CTO', 'Hiring']
 
 You've built something that's gaining traction. Investors are asking about your technical roadmap. Your lead developer is great at shipping code but struggles with architecture decisions. You need technical leadership—but should you hire a full-time CTO or bring in a fractional one?
 
-This isn't just a cost question. It's a strategic decision that affects your runway, your ability to raise, and your product's long-term viability. After working with 15+ UK startups across fintech, healthtech, and B2B SaaS, here's the honest breakdown.
+This isn't just a cost question. It's a strategic decision that affects your runway, your ability to raise, and your product's long-term viability. After working with UK startups across fintech, healthtech, and B2B SaaS, here's the honest breakdown.
 
 ## The True Cost of a Full-Time CTO
 


### PR DESCRIPTION
Applies the four outstanding owner-input items flagged in `WEBSITE_REVIEW.md`. Three are now resolved; the founder photo is still pending.

## 1. Testimonials — confirmed genuine, kept

The owner verified that both anonymised quotes are real clients publishing under NDA. The `TODO(owner)` questioning their authenticity is replaced with the verification record, so a future session doesn't re-open the question or delete them as suspected placeholders.

## 2. Opayo engagement dated August 2019 – June 2026

The review flagged that the Opayo brand could be read as falling inside the **2011-2015 Elavon employment** on the About timeline. These are two distinct relationships:

| Relationship | Period | Nature |
|---|---|---|
| Deloitte Digital, Elavon (US Bancorp) | 2011-2015 | Early-career employment |
| Opayo by Elavon | Aug 2019 – Jun 2026 | Codenest client engagement |

Both the About milestone and the case study now carry explicit dates. The homepage logo strip previously placed the byline "ex-Deloitte Digital and Elavon (US Bancorp)" directly beneath the Opayo logo with no dates in that block at all — a reader stopping there had no way to tell the two Elavon relationships apart. That byline is rewritten to separate early-career engineering from the fractional engagements.

## 3. Stats tightened to citable claims

| Before | After | Why |
|---|---|---|
| `15+` / Startups supported | `6+ yrs` / Payments engagement at Opayo by Elavon | The count had no published denominator; the duration is dated and verifiable |
| `Series A` / Fundraises supported | `Series A` / Closed with our models and data room | Names the actual evidence — the fintech testimonial cites the models and data room |
| Hero bullet: "across 15+ startups" | "from pre-seed to Series A" | Same uncited count, restated as the ICP |

The identical `15+ UK startups` claim is also removed from `content/blog/fractional-cto-vs-full-time-cto-uk-startups.md`, where it had survived the earlier stats pass.

## 4. BRANDING.md standing rules 11-13

Records the Opayo dates, the testimonial verification, and the policy that a stat cell must carry a named engagement or an offer term rather than a bare count — so the retired claims don't drift back in.

## Verification

- `npm run build` passes, all 40 routes export
- Homepage stats band, About milestone, case study and logo-strip byline confirmed rendering in the dev preview
- Reviewed by a `code-reviewer` agent for date contradictions, arithmetic (Aug 2019 → Jun 2026 = 6y 10m, consistent with both "6+ yrs" and "near seven-year"), cross-file consistency and BRANDING.md rule conflicts — the two issues it found (the blog claim and the logo-strip byline) are fixed in this branch
- Repo-wide sweep confirms no uncited client-count claims remain

## Still outstanding

A real founder photo for `/about` and the homepage — the letter-avatar placeholder stays until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)