### PR TITLE
Restructure the site around two principals, not one founder

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -68,10 +68,12 @@ every claim — write as if they will check, because they will.
    The two anonymised testimonials (fintech Series A; B2B SaaS MVP) are verified
    genuine — owner confirmed 4 Aug 2026, real clients under NDA. Keep them; name
    a client only with that client's permission.
-4. **Founder-led voice.** "I" for personal commitments (co-founder page, values,
-   About). "We"/"Codenest" for methodology and delivery. Never "our team" for work
-   done as an individual or as prior employment. Never disparage solo operators
-   (bus-factor jabs) — Codenest is one.
+4. **Two principals, two seats.** Codenest is **Ankit Rana, Fractional CTO** and
+   **Michelle Rana FCCA, Fractional CFO** — not one generalist covering both.
+   Never attribute the CFO offer to Ankit or the CTO offer to Michelle, in copy or
+   in schema. "We"/"Codenest" is the default voice for methodology and delivery;
+   attribute individual track records by name ("Ankit led…", "Michelle owned…").
+   Prior employment stays framed as pedigree, never as Codenest client work.
 5. **CTA honesty.** The primary CTA is **"Request a Strategy Call"** everywhere, until
    a real scheduling tool is embedded — only then may it become "Book…"/"Schedule…".
    The form submit says "Request My Call" with the microcopy "We'll reply within
@@ -274,3 +276,15 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
 13. **Stat cells carry a named engagement or an offer term** — Rungway users, Opayo
     duration, the testimonial-backed Series A, 8-12 wks MVP. No bare counts without
     a citable denominator ("15+ startups" retired). (4 Aug 2026.)
+14. **Codenest is two people.** Ankit Rana is the Fractional CTO; Michelle Rana FCCA
+    is the Fractional CFO. Any surface that names one must be checked for whether it
+    should name both — especially `/about`, Person schema, and founder bylines.
+    (Owner, 4 Aug 2026.)
+15. **Rungway predates Codenest.** It is founder track record, not a Codenest client
+    engagement — never caption it "our client" or attribute it to Codenest as a firm.
+    (Owner, 4 Aug 2026.)
+16. **Michelle's documented strength is operational scale-up finance**, not venture
+    fundraising: multi-site P&L, budgeting and rolling forecasts, controls and
+    governance, margin and procurement, Board reporting. Do not claim VC fundraising,
+    data-room or cap-table experience for her without owner confirmation.
+    (4 Aug 2026 — pending owner input.)

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -3,11 +3,11 @@ import Footer from '../components/Footer'
 import Link from 'next/link'
 
 export const metadata = {
-  title: 'About Ankit Rana | Fractional CTO & CFO for UK Startups',
-  description: 'Meet Ankit Rana, founder of Codenest. 15+ years at Deloitte Digital, Elavon, and high-growth startups. Fractional CTO and CFO helping ambitious UK founders build and scale.',
+  title: 'Meet Our Fractional CTO & CFO',
+  description: 'Meet the two people behind Codenest: Ankit Rana, Fractional CTO with 15+ years across Deloitte Digital, Elavon and high-growth startups, and Michelle Rana FCCA, Fractional CFO who scaled a business from £35m to £165m revenue.',
   openGraph: {
-    title: 'About Ankit Rana | Codenest',
-    description: 'Meet Ankit Rana, founder of Codenest. 15+ years at Deloitte Digital, Elavon, and high-growth startups.',
+    title: 'About Codenest | Our Fractional CTO & CFO',
+    description: 'Ankit Rana, Fractional CTO, and Michelle Rana FCCA, Fractional CFO — the two executives behind Codenest.',
     type: 'website',
     url: 'https://codenest.uk/about/',
     images: [
@@ -24,42 +24,116 @@ export const metadata = {
   },
 }
 
-const personSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'Person',
-  name: 'Ankit Rana',
-  jobTitle: 'Founder, Fractional CTO & CFO',
-  worksFor: {
-    '@type': 'Organization',
-    name: 'Codenest',
-    url: 'https://codenest.uk',
-  },
-  alumniOf: [
-    { '@type': 'Organization', name: 'Deloitte Digital' },
-    { '@type': 'Organization', name: 'Elavon (US Bancorp)' },
-  ],
-  knowsAbout: ['Fractional CTO services', 'Fractional CFO services', 'Startup engineering', 'Financial modeling', 'Fundraising'],
-  sameAs: ['https://www.linkedin.com/company/codenest-ltd'],
-  url: 'https://codenest.uk/about/',
+// Two principals, two Person entities. Ankit owns the technical track and
+// Michelle the financial one — never model one person as holding both seats.
+const codenest = {
+  '@type': 'Organization',
+  name: 'Codenest',
+  url: 'https://codenest.uk',
 }
 
+const peopleSchema = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Ankit Rana',
+    jobTitle: 'Fractional CTO',
+    worksFor: codenest,
+    alumniOf: [
+      { '@type': 'Organization', name: 'Deloitte Digital' },
+      { '@type': 'Organization', name: 'Elavon (US Bancorp)' },
+    ],
+    knowsAbout: [
+      'Fractional CTO services',
+      'Startup engineering',
+      'Cloud architecture',
+      'Kubernetes',
+      'DevOps',
+      'Technical due diligence',
+    ],
+    sameAs: ['https://www.linkedin.com/in/arana198'],
+    url: 'https://codenest.uk/about/',
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Michelle Rana',
+    jobTitle: 'Fractional CFO',
+    worksFor: codenest,
+    alumniOf: [{ '@type': 'CollegeOrUniversity', name: 'University of Leicester' }],
+    hasCredential: {
+      '@type': 'EducationalOccupationalCredential',
+      credentialCategory: 'Professional Certification',
+      name: 'FCCA — Fellow, Association of Chartered Certified Accountants',
+    },
+    knowsAbout: [
+      'Fractional CFO services',
+      'Financial modelling and scenario planning',
+      'Budgeting and rolling forecasts',
+      'Financial controls and governance',
+      'Board and Executive reporting',
+      'Margin and cost optimisation',
+    ],
+    sameAs: ['https://www.linkedin.com/in/michellerana1'],
+    url: 'https://codenest.uk/about/',
+  },
+]
+
+// Tailwind cannot resolve interpolated class names, so each track's palette is
+// spelled out. Gold text stays at accent-700 or darker on light (BRANDING.md §8).
+const ACCENT_STYLES = {
+  primary: {
+    avatar: 'from-primary-600 to-primary-700',
+    role: 'text-primary-700',
+    chip: 'bg-primary-50 text-primary-700',
+    proof: 'bg-primary-50 text-primary-800 border-primary-200',
+  },
+  accent: {
+    avatar: 'from-accent-500 to-accent-700',
+    role: 'text-accent-700',
+    chip: 'bg-accent-50 text-accent-700',
+    proof: 'bg-accent-50 text-accent-800 border-accent-200',
+  },
+}
+
+const LinkedInIcon = () => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+  </svg>
+)
+
 export default function AboutPage() {
-  const milestones = [
+  const principals = [
     {
-      year: "2011-2015",
-      title: "Enterprise Foundations",
-      description: "Built scalable systems at Deloitte Digital and Elavon (US Bancorp), working on payment processors and financial services platforms. Learned what 'enterprise-grade' really means — and what startups can borrow from it."
+      name: "Ankit Rana",
+      role: "Fractional CTO",
+      initial: "A",
+      accent: "primary",
+      linkedin: "https://www.linkedin.com/in/arana198",
+      credentials: ["AWS Certified", "15+ Years Engineering", "Kubernetes & Cloud"],
+      bio: "Fifteen years building and scaling technology platforms — payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. Has led engineering teams from 5 to 50+, run a near seven-year platform transformation at Opayo by Elavon, and sat on the receiving end of technical due diligence.",
+      proof: "Scaled Rungway from 5 to 1,000+ concurrent users",
+      tracks: [
+        { year: "2011-2015", title: "Enterprise Foundations", description: "Payment processors and financial services platforms at Deloitte Digital and Elavon (US Bancorp) — learning what enterprise-grade actually costs, and what startups can borrow from it." },
+        { year: "2015-2017", title: "Scaling Startups", description: "Led engineering teams from 5 to 50+ across fintech and healthtech. Hypergrowth firsthand: the technical debt, the hiring mistakes, the architecture decisions that come back to haunt you." },
+        { year: "2019-2026", title: "Payments at Scale", description: "Platform transformation at Opayo by Elavon — AWS EKS migration, GitOps and Infrastructure as Code, moving a payments monolith to microservices without dropping a transaction." },
+      ],
     },
     {
-      year: "2015-2017",
-      title: "Scaling Startups",
-      description: "Led engineering teams from 5 to 50+ engineers across fintech and healthtech. Experienced the chaos of hypergrowth firsthand — the technical debt, the hiring mistakes, the architecture decisions that come back to haunt you."
+      name: "Michelle Rana",
+      role: "Fractional CFO",
+      initial: "M",
+      accent: "accent",
+      linkedin: "https://www.linkedin.com/in/michellerana1",
+      credentials: ["FCCA", "BSc Mathematics", "£165m P&L"],
+      bio: "Chartered accountant (FCCA) and strategic finance leader who took a multi-site business from 6 to 27 locations and £35m to £165m revenue while improving EBITDA margin by 4%. Has built and led a 20+ person finance function, owned Board and Executive reporting, and held a company's cash together through COVID-19.",
+      proof: "£35m → £165m revenue, +4% EBITDA margin",
+      tracks: [
+        { year: "2012-2014", title: "Commercial Foundations", description: "Pricing and commercial analysis at Ryder and Select Service Partners — negotiating contract hire deals over £1m and partnering with senior leaders across a £67m revenue budget." },
+        { year: "2014-2017", title: "Multi-Channel Finance", description: "Omni-channel finance manager at Oasis & Warehouse, owning reporting and budgeting for franchise, wholesale, licensing and distribution, and delivering Board packs to CEO and CFO." },
+        { year: "2017-2026", title: "Scale-Up Finance", description: "Head of Strategic Finance at Dishoom through the 6-to-27-site expansion: five-year strategic model, rolling forecasts accurate to ±3%, CapEx governance, £6m in procurement and contract improvements, and month-end close cut from 14 days to 8." },
+      ],
     },
-    {
-      year: "2017-Present",
-      title: "Codenest",
-      description: "Founded Codenest to provide integrated technical and financial leadership for ambitious founders. Fractional CTO and CFO for startups across fintech, healthtech, proptech, and B2B SaaS — helping them build right and raise successfully. Engagements have ranged from pre-seed MVPs to a near seven-year payment-platform transformation with Opayo by Elavon (2019-2026)."
-    }
   ]
 
   const values = [
@@ -101,18 +175,19 @@ export default function AboutPage() {
     }
   ]
 
+  // Two technical categories, two financial — the grid itself has to read 50/50.
   const expertise = [
     { category: "Cloud & Infrastructure", items: ["AWS", "GCP", "Kubernetes", "Terraform", "GitOps"] },
-    { category: "Engineering", items: ["Python", "Java", "Node.js", "React", "Microservices"] },
-    { category: "Data & AI", items: ["ML Pipelines", "LLM Integration", "Data Engineering", "Analytics"] },
-    { category: "Financial", items: ["Financial Modeling", "FP&A", "Unit Economics", "Fundraising"] }
+    { category: "Engineering & Data", items: ["Python", "Java", "Node.js", "Microservices", "ML & LLM Integration"] },
+    { category: "Planning & Reporting", items: ["Financial Modelling", "Rolling Forecasts", "Scenario Planning", "Board & Executive Reporting", "Unit Economics"] },
+    { category: "Controls & Commercial", items: ["Financial Controls", "Margin Optimisation", "Procurement & Cost", "CapEx Governance", "Cash Management"] }
   ]
 
   return (
     <div className="min-h-screen bg-white">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(peopleSchema) }}
       />
       <Navigation />
 
@@ -124,79 +199,78 @@ export default function AboutPage() {
           <div className="text-center mb-12">
             <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Our Story</p>
             <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">
-              Built by an Operator,<br />for Founders
+              Built by Operators,<br />for Founders
             </h1>
             <p className="text-xl text-slate-600 max-w-2xl mx-auto">
-              I've been in your shoes. Now I help ambitious founders avoid the costly mistakes I've seen — and made.
+              Codenest is two executives, not one generalist. A CTO who has scaled the systems, and a CFO who has scaled the numbers.
             </p>
           </div>
         </div>
       </section>
 
-      {/* Founder Section */}
+      {/* Principals Section */}
       <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 items-start">
-            {/* Photo/Avatar Column */}
-            <div className="lg:col-span-1">
-              <div className="sticky top-32">
-                <div className="w-48 h-48 mx-auto lg:mx-0 rounded-2xl bg-gradient-to-br from-primary-600 to-primary-700 flex items-center justify-center text-white text-6xl font-serif shadow-xl mb-6">
-                  A
-                </div>
-                <div className="text-center lg:text-left">
-                  <h2 className="text-2xl font-bold text-slate-900 mb-1">Ankit Rana</h2>
-                  <p className="text-accent-600 font-medium mb-4">Founder</p>
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+            {principals.map((person) => {
+              const style = ACCENT_STYLES[person.accent]
+              return (
+                <div key={person.name} className="bg-white rounded-2xl border border-slate-200 p-8 shadow-sm">
+                  <div className={`w-24 h-24 rounded-2xl bg-gradient-to-br ${style.avatar} flex items-center justify-center text-white text-4xl font-serif shadow-lg mb-6`}>
+                    {person.initial}
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 mb-1">{person.name}</h2>
+                  <p className={`${style.role} font-semibold mb-5`}>{person.role}</p>
 
-                  {/* Credentials */}
-                  <div className="flex flex-wrap justify-center lg:justify-start gap-2 mb-6">
-                    <span className="px-3 py-1 bg-slate-100 rounded-full text-xs font-medium text-slate-700">AWS Certified</span>
-                    <span className="px-3 py-1 bg-slate-100 rounded-full text-xs font-medium text-slate-700">15+ Years</span>
-                    <span className="px-3 py-1 bg-slate-100 rounded-full text-xs font-medium text-slate-700">Series A Experience</span>
+                  <div className="flex flex-wrap gap-2 mb-5">
+                    {person.credentials.map((credential) => (
+                      <span key={credential} className={`px-3 py-1 ${style.chip} rounded-full text-xs font-medium`}>
+                        {credential}
+                      </span>
+                    ))}
                   </div>
 
-                  {/* Social Links */}
+                  <p className="text-slate-600 leading-relaxed mb-5">{person.bio}</p>
+
+                  <p className={`text-sm font-semibold border rounded-lg px-4 py-3 mb-6 ${style.proof}`}>
+                    {person.proof}
+                  </p>
+
                   <a
-                    href="https://www.linkedin.com/in/arana198"
+                    href={person.linkedin}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-primary-600 hover:text-primary-700 font-medium"
                   >
-                    <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                    </svg>
-                    Connect on LinkedIn
+                    <LinkedInIcon />
+                    {person.name.split(' ')[0]} on LinkedIn
                   </a>
                 </div>
-              </div>
-            </div>
+              )
+            })}
+          </div>
+        </div>
+      </section>
 
-            {/* Story Column */}
-            <div className="lg:col-span-2 space-y-8">
+      {/* Story Section */}
+      <section className="py-20 bg-white border-t border-slate-100">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="space-y-8">
               <div>
-                <h3 className="text-xl font-bold text-slate-900 mb-4">The Short Version</h3>
+                <h3 className="text-xl font-bold text-slate-900 mb-4">Why We Started Codenest</h3>
                 <p className="text-slate-600 leading-relaxed mb-4">
-                  I spent 15+ years building and scaling technology platforms — from payment processors at Deloitte Digital and Elavon (US Bancorp) to startups going through hypergrowth across fintech, healthtech, and proptech. I've led engineering teams from 5 to 50+, navigated Series A due diligence, and seen firsthand what separates startups that scale from those that struggle.
+                  Too many startups fail not because of bad ideas, but because of avoidable mistakes: architecture that doesn't scale, financial models that fall apart under scrutiny, technical debt that slows everything down.
+                </p>
+                <p className="text-slate-600 leading-relaxed mb-4">
+                  We kept seeing the same patterns. Founders who needed senior guidance but couldn't justify a full-time CTO or CFO. Startups that hired dev shops and got code, but not strategy. Companies that grew revenue but couldn't answer basic questions about their unit economics.
                 </p>
                 <p className="text-slate-600 leading-relaxed">
-                  Now I help founders get it right the first time.
+                  Codenest exists to fill that gap — and to fill it properly. You get an engineer who has actually run the platform and an accountant who has actually owned the P&amp;L, rather than one generalist doing a passable impression of both.
                 </p>
               </div>
 
               <div>
-                <h3 className="text-xl font-bold text-slate-900 mb-4">Why I Started Codenest</h3>
-                <p className="text-slate-600 leading-relaxed mb-4">
-                  Too many startups fail not because of bad ideas, but because of avoidable mistakes: architecture that doesn't scale, financial models that fall apart under investor scrutiny, technical debt that slows everything down.
-                </p>
-                <p className="text-slate-600 leading-relaxed mb-4">
-                  I kept seeing the same patterns. Founders who needed senior guidance but couldn't justify a full-time CTO or CFO. Startups that hired dev shops and got code, but not strategy. Companies that raised money but couldn't answer basic questions about unit economics.
-                </p>
-                <p className="text-slate-600 leading-relaxed">
-                  Codenest exists to fill that gap. We provide the technical and financial leadership that early-stage startups need — with Big 4 rigour and the empathy of someone who's been in the founder's seat.
-                </p>
-              </div>
-
-              <div>
-                <h3 className="text-xl font-bold text-slate-900 mb-4">What I Believe</h3>
+                <h3 className="text-xl font-bold text-slate-900 mb-4">What We Believe</h3>
                 <ul className="space-y-3 text-slate-600">
                   <li className="flex items-start gap-3">
                     <svg className="w-5 h-5 text-accent-500 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -236,12 +310,11 @@ export default function AboutPage() {
                   <div>
                     <p className="text-sm font-semibold text-slate-900 mb-1">Beyond Advisory</p>
                     <p className="text-sm text-slate-600">
-                      In rare cases, for exceptional opportunities, I consider deeper partnerships — including technical co-founder roles. If you're building something truly ambitious and looking for a committed partner, not just an advisor, <a href="/contact" className="text-accent-600 font-medium hover:text-accent-700 underline">let's talk</a>.
+                      In rare cases, for exceptional opportunities, Ankit considers deeper partnerships — including technical co-founder roles. If you're building something truly ambitious and looking for a committed partner, not just an advisor, <a href="/contact" className="text-accent-700 font-medium hover:text-accent-800 underline">let's talk</a>.
                     </p>
                   </div>
                 </div>
               </div>
-            </div>
           </div>
         </div>
       </section>
@@ -250,26 +323,39 @@ export default function AboutPage() {
       <section className="py-20 bg-slate-50">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="font-serif text-3xl font-bold text-slate-900 mb-4">The Journey</h2>
-            <p className="text-slate-600">15+ years of building, breaking, and learning</p>
+            <h2 className="font-serif text-3xl font-bold text-slate-900 mb-4">Two Careers, One Practice</h2>
+            <p className="text-slate-600">Where the technical and financial track records were built</p>
           </div>
 
-          <div className="space-y-8">
-            {milestones.map((milestone, index) => (
-              <div key={index} className="flex gap-6">
-                <div className="flex-shrink-0 w-28 text-right">
-                  <span className="text-sm font-bold text-accent-600">{milestone.year}</span>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+            {principals.map((person) => {
+              const style = ACCENT_STYLES[person.accent]
+              return (
+                <div key={person.name}>
+                  <div className="mb-8">
+                    <h3 className="text-lg font-bold text-slate-900">{person.name}</h3>
+                    <p className={`${style.role} text-sm font-semibold`}>{person.role}</p>
+                  </div>
+                  <div>
+                    {person.tracks.map((milestone, index) => (
+                      <div key={milestone.year} className="flex gap-4">
+                        <div className="flex-shrink-0 w-24 text-right">
+                          <span className="text-sm font-bold text-accent-700">{milestone.year}</span>
+                        </div>
+                        <div className="flex-shrink-0 flex flex-col items-center">
+                          <div className="w-3.5 h-3.5 rounded-full bg-accent-400 border-4 border-white shadow"></div>
+                          {index < person.tracks.length - 1 && <div className="w-0.5 h-full bg-slate-200 mt-2"></div>}
+                        </div>
+                        <div className="pb-8">
+                          <h4 className="font-bold text-slate-900 mb-1">{milestone.title}</h4>
+                          <p className="text-sm text-slate-600">{milestone.description}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-                <div className="flex-shrink-0 flex flex-col items-center">
-                  <div className="w-4 h-4 rounded-full bg-accent-400 border-4 border-white shadow"></div>
-                  {index < milestones.length - 1 && <div className="w-0.5 h-full bg-slate-200 mt-2"></div>}
-                </div>
-                <div className="pb-8">
-                  <h3 className="text-lg font-bold text-slate-900 mb-2">{milestone.title}</h3>
-                  <p className="text-slate-600">{milestone.description}</p>
-                </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </div>
       </section>

--- a/app/layout.js
+++ b/app/layout.js
@@ -19,7 +19,7 @@ export const metadata = {
     default: 'Fractional CTO & Fractional CFO for UK Startups | Codenest',
     template: '%s | Codenest'
   },
-  description: 'London-based fractional CTO and CFO for UK startups. Ex-Deloitte leadership delivering technical architecture, financial modeling, and fundraising support. Trusted by pre-seed to Series A founders across fintech, healthtech, and B2B SaaS.',
+  description: 'London-based fractional CTO and CFO for UK startups. A 15-year engineering leader and a chartered accountant (FCCA), delivering technical architecture, financial modelling and commercial discipline for pre-seed to Series A founders across fintech, healthtech and B2B SaaS.',
   keywords: ['boutique startup advisory London', 'fractional CTO UK', 'fractional CFO UK', 'startup advisory London', 'executive advisory startups', 'premium tech consultancy UK', 'bespoke startup consulting', 'Big 4 startup advisory', 'GitOps consulting UK', 'Infrastructure as Code UK', 'financial modeling startups', 'MVP development UK', 'Kubernetes consulting UK', 'startup engineering UK', 'DevOps consulting UK', 'fundraising support UK', 'technical leadership UK', 'financial strategy startups', '0 to 1 product UK', 'startup technical partner UK', 'Series A preparation', 'startup due diligence UK', 'boutique consultancy UK', 'select founders UK', 'investor ready startups', 'startup scale up UK', 'technical co-founder UK', 'startup co-founder London', 'CTO co-founder', 'find technical co-founder', 'tech co-founder partnership', 'co-founder for startup UK', 'technical partner equity', 'startup equity partnership'],
   authors: [{ name: 'Codenest', url: 'https://codenest.uk' }],
   creator: 'Codenest',

--- a/app/page.js
+++ b/app/page.js
@@ -347,7 +347,7 @@ export default function Home() {
 
           </div>
           <p className="text-center text-sm text-slate-600 mt-8">
-            Led by <a href="/about" className="font-semibold text-primary-700 hover:text-primary-800">Ankit Rana</a> — 15+ years building and scaling platforms, from early-career engineering at Deloitte Digital and Elavon (US Bancorp) to fractional CTO and CFO engagements today.
+            Led by <a href="/about" className="font-semibold text-primary-700 hover:text-primary-800">Ankit Rana</a>, Fractional CTO — 15+ years across Deloitte Digital, Elavon (US Bancorp) and Opayo — and <a href="/about" className="font-semibold text-primary-700 hover:text-primary-800">Michelle Rana FCCA</a>, Fractional CFO, who took a business from &pound;35m to &pound;165m revenue while improving EBITDA margin by 4%.
           </p>
         </div>
       </section>


### PR DESCRIPTION
Codenest is **Ankit Rana (Fractional CTO)** and **Michelle Rana FCCA (Fractional CFO)**. The site was built on the assumption of a single founder covering both seats.

## The most serious problem was in structured data

`/about`'s Person schema declared:

```
name: 'Ankit Rana', jobTitle: 'Founder, Fractional CTO & CFO'
```

That told search engines one person held both roles. It is now two `Person` entities with the correct job title, credentials, `knowsAbout` and LinkedIn profile each.

## What changed on /about

| Before | After |
|---|---|
| One founder card (Ankit), sticky sidebar | Two principal cards, equal weight, colour-coded by track |
| One career timeline (Ankit's) | Two parallel tracks — "Two Careers, One Practice" |
| One `Person` schema claiming both roles | Two `Person` entities, one role each |
| "Built by an Operator, for Founders" | "Built by Operators, for Founders" |
| "The Short Version" / "Why I Started" (first-person singular) | Per-person bios + shared "Why We Started Codenest" |
| Expertise grid: 3 technical categories, 1 financial | 2 technical, 2 financial |

## Michelle's details come from her CV and nothing beyond it

Chartered accountant (FCCA), BSc Mathematics with Management. Took a multi-site business from 6 to 27 locations and £35m to £165m revenue while improving EBITDA margin by 4%; led a 20+ person finance function; rolling forecasts accurate to ±3%; month-end close cut from 14 days to 8; £6m in procurement and contract improvements.

**Deliberately not claimed:** venture fundraising, data rooms, cap tables or investor due diligence — none of which appear on her CV. Her expertise entries say "Board and Executive reporting" rather than "investor reporting" for the same reason. See the open question below.

## This also closes the CTO/CFO credibility gap

The site previously carried **no finance credential anywhere** — every proof asset was an engineering artifact. Michelle's presence is the single largest rebalancing lever. Alongside it, the homepage byline now names both principals with their own proof point, and the root meta description no longer attributes "Ex-Deloitte leadership" to the practice as a whole when only Ankit has it.

## BRANDING.md

Rule 4 previously read *"Never disparage solo operators — Codenest is one."* It now describes two principals and forbids attributing either service to the wrong person. New rules 14-16 record that Codenest is two people, that Rungway predates Codenest (founder track record, not a client engagement), and that Michelle's documented strength is operational scale-up finance rather than venture fundraising.

## Verification

- `npm run build` passes, all 40 routes export
- Two-card layout, two-track timeline and both `Person` entities confirmed rendering
- Reviewed by a `code-reviewer` agent against Michelle's CV specifically to catch fabricated claims. It found three overstatements in my first draft — "Board and **investor** reporting" (twice), "we consider technical co-founder roles" (implying Michelle offers a technical service), and "£6m procurement **savings**" narrowing the CV's "procurement/contract improvements" — all three fixed here. It also caught the stale root meta description, fixed here.
- Heading order, Tailwind JIT class resolution, WCAG AA gold-text contrast and distinguishable LinkedIn link names all verified clean

## Open question for the owner

Every blog post — including all eight CFO-topic posts — is bylined `author: 'Ankit Rana'`. Reassigning the finance posts to Michelle is a factual claim about who wrote them, so this PR leaves them untouched pending your decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)