### PR TITLE
Split bylines by principal, rebalance the hero and services page

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -283,8 +283,12 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
 15. **Rungway predates Codenest.** It is founder track record, not a Codenest client
     engagement — never caption it "our client" or attribute it to Codenest as a firm.
     (Owner, 4 Aug 2026.)
-16. **Michelle's documented strength is operational scale-up finance**, not venture
-    fundraising: multi-site P&L, budgeting and rolling forecasts, controls and
-    governance, margin and procurement, Board reporting. Do not claim VC fundraising,
-    data-room or cap-table experience for her without owner confirmation.
-    (4 Aug 2026 — pending owner input.)
+16. **Michelle covers both operational finance and fundraising.** Her CV documents the
+    operational side in detail — multi-site P&L, budgeting and rolling forecasts,
+    controls and governance, margin and procurement, Board reporting — and the owner
+    confirmed fundraising and investor due-diligence experience on top (4 Aug 2026).
+    Claim the capability; do not attach invented specifics (round sizes, named
+    investors, amounts raised) until real figures are supplied.
+17. **Never publish personal contact details.** No personal mobile numbers or personal
+    email addresses for either principal, from CVs or anywhere else — the contact form
+    and the business address are the only channels. (Owner, 4 Aug 2026.)

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -71,7 +71,8 @@ const peopleSchema = [
       'Financial modelling and scenario planning',
       'Budgeting and rolling forecasts',
       'Financial controls and governance',
-      'Board and Executive reporting',
+      'Board and investor reporting',
+      'Fundraising and investor due diligence',
       'Margin and cost optimisation',
     ],
     sameAs: ['https://www.linkedin.com/in/michellerana1'],
@@ -126,7 +127,7 @@ export default function AboutPage() {
       accent: "accent",
       linkedin: "https://www.linkedin.com/in/michellerana1",
       credentials: ["FCCA", "BSc Mathematics", "£165m P&L"],
-      bio: "Chartered accountant (FCCA) and strategic finance leader who took a multi-site business from 6 to 27 locations and £35m to £165m revenue while improving EBITDA margin by 4%. Has built and led a 20+ person finance function, owned Board and Executive reporting, and held a company's cash together through COVID-19.",
+      bio: "Chartered accountant (FCCA) and strategic finance leader who took a multi-site business from 6 to 27 locations and £35m to £165m revenue while improving EBITDA margin by 4%. Has built and led a 20+ person finance function, owned Board and investor reporting, held a company's cash together through COVID-19, and supported founders through fundraising and investor due diligence.",
       proof: "£35m → £165m revenue, +4% EBITDA margin",
       tracks: [
         { year: "2012-2014", title: "Commercial Foundations", description: "Pricing and commercial analysis at Ryder and Select Service Partners — negotiating contract hire deals over £1m and partnering with senior leaders across a £67m revenue budget." },
@@ -179,7 +180,7 @@ export default function AboutPage() {
   const expertise = [
     { category: "Cloud & Infrastructure", items: ["AWS", "GCP", "Kubernetes", "Terraform", "GitOps"] },
     { category: "Engineering & Data", items: ["Python", "Java", "Node.js", "Microservices", "ML & LLM Integration"] },
-    { category: "Planning & Reporting", items: ["Financial Modelling", "Rolling Forecasts", "Scenario Planning", "Board & Executive Reporting", "Unit Economics"] },
+    { category: "Planning & Reporting", items: ["Financial Modelling", "Rolling Forecasts", "Scenario Planning", "Board & Investor Reporting", "Fundraising Support"] },
     { category: "Controls & Commercial", items: ["Financial Controls", "Margin Optimisation", "Procurement & Cost", "CapEx Governance", "Cash Management"] }
   ]
 

--- a/app/components/Navigation.js
+++ b/app/components/Navigation.js
@@ -84,7 +84,7 @@ export default function Navigation() {
           {/* Desktop Menu — six links plus the CTA need lg; at md they overflow. */}
           <div className="hidden lg:block">
             <div className="ml-10 flex items-baseline space-x-1">
-              <Link href="/services" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Services</Link>
+              <Link href="/services" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">All Services</Link>
               <Link href="/services/fractional-cto" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CTO</Link>
               <Link href="/services/fractional-cfo" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CFO</Link>
               <a href="/case-studies" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Case Studies</a>
@@ -114,7 +114,7 @@ export default function Navigation() {
         {isMenuOpen && (
           <div id="mobile-menu" className="lg:hidden">
             <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-slate-100">
-              <Link href="/services" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Services</Link>
+              <Link href="/services" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">All Services</Link>
               <Link href="/services/fractional-cto" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Fractional CTO</Link>
               <Link href="/services/fractional-cfo" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Fractional CFO</Link>
               <a href="/case-studies" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Case Studies</a>

--- a/app/components/Navigation.js
+++ b/app/components/Navigation.js
@@ -81,20 +81,21 @@ export default function Navigation() {
             </a>
           </div>
 
-          {/* Desktop Menu */}
-          <div className="hidden md:block">
+          {/* Desktop Menu — six links plus the CTA need lg; at md they overflow. */}
+          <div className="hidden lg:block">
             <div className="ml-10 flex items-baseline space-x-1">
-              <Link href="/services/fractional-cto" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CTO</Link>
-              <Link href="/services/fractional-cfo" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CFO</Link>
-              <a href="/case-studies" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Case Studies</a>
-              <a href="/about" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">About</a>
-              <a href="/blog" className="text-slate-700 hover:text-primary-700 px-4 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Blog</a>
+              <Link href="/services" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Services</Link>
+              <Link href="/services/fractional-cto" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CTO</Link>
+              <Link href="/services/fractional-cfo" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Fractional CFO</Link>
+              <a href="/case-studies" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Case Studies</a>
+              <a href="/about" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">About</a>
+              <a href="/blog" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Blog</a>
               <a href={contactHref} className="bg-accent-400 text-primary-900 px-6 py-2.5 ml-2 rounded-lg text-sm font-semibold hover:bg-accent-500 transition-all shadow-sm hover:shadow-gold">Request a Strategy Call</a>
             </div>
           </div>
 
           {/* Mobile menu button */}
-          <div className="md:hidden">
+          <div className="lg:hidden">
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="text-slate-700 hover:text-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 rounded-lg p-2"
@@ -111,8 +112,9 @@ export default function Navigation() {
 
         {/* Mobile Menu */}
         {isMenuOpen && (
-          <div id="mobile-menu" className="md:hidden">
+          <div id="mobile-menu" className="lg:hidden">
             <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white border-t border-slate-100">
+              <Link href="/services" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Services</Link>
               <Link href="/services/fractional-cto" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Fractional CTO</Link>
               <Link href="/services/fractional-cfo" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Fractional CFO</Link>
               <a href="/case-studies" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Case Studies</a>

--- a/app/components/ServiceCard.js
+++ b/app/components/ServiceCard.js
@@ -1,35 +1,33 @@
-import Image from 'next/image'
 import Link from 'next/link'
 
-export default function ServiceCard({ service, priority = false }) {
+export default function ServiceCard({ service }) {
   const isTech = service.track === 'technical'
   const trackBorderClass = isTech ? 'service-card-tech' : 'service-card-financial'
   const href = service.href || (isTech ? '/services/fractional-cto' : '/services/fractional-cfo')
 
   return (
     <Link href={href} className={`group bg-white border border-slate-200 rounded-xl hover:shadow-xl transition-all duration-300 overflow-hidden h-full flex flex-col card-lift ${trackBorderClass}`}>
-      {/* Image Section with warm overlay */}
-      <div className="relative h-56 overflow-hidden img-warm-overlay">
-        <Image
-          src={service.image}
-          alt={`${service.title} - ${service.benefit}`}
-          fill
-          sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          className="object-cover group-hover:scale-105 transition-transform duration-500 filter grayscale group-hover:grayscale-0"
-          priority={priority}
-        />
-        {/* Gradient overlay with track-specific tint */}
-        <div className={`absolute inset-0 bg-gradient-to-t ${isTech ? 'from-primary-900/80' : 'from-accent-900/70'} via-slate-900/30 to-transparent`} />
+      {/* Track panel. Deliberately not a photograph: every stock image available
+          is an engineering scene, which mislabelled the financial services as
+          technical work. Colour carries the track instead. */}
+      <div
+        className={`relative h-56 overflow-hidden flex items-end ${
+          isTech
+            ? 'bg-gradient-to-br from-primary-800 to-primary-600'
+            : 'bg-gradient-to-br from-accent-800 to-accent-600'
+        }`}
+      >
+        <div className="absolute inset-0 bg-gradient-to-t from-black/25 to-transparent" />
 
         {/* Track indicator badge */}
         <div className="absolute top-4 right-4">
-          <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${isTech ? 'bg-primary-600 text-white' : 'bg-accent-400 text-primary-900'}`}>
+          <span className={`px-2.5 py-1 rounded-full text-xs font-semibold ${isTech ? 'bg-white text-primary-800' : 'bg-accent-400 text-primary-900'}`}>
             {isTech ? 'Technical' : 'Financial'}
           </span>
         </div>
 
-        <div className="absolute bottom-5 left-5 right-5">
-          <h3 className="text-xl font-bold text-white drop-shadow-lg">{service.title}</h3>
+        <div className="relative p-5">
+          <h3 className="text-xl font-bold text-white">{service.title}</h3>
         </div>
       </div>
 

--- a/app/page.js
+++ b/app/page.js
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import Link from 'next/link'
 import Button from './components/Button'
 import Navigation from './components/Navigation'
@@ -171,17 +170,24 @@ export default function Home() {
             <div className="relative animate-hero-image">
               {/* Premium gold frame effect */}
               <div className="absolute -inset-1 bg-gradient-to-br from-accent-400/30 via-accent-500/20 to-transparent rounded-2xl blur-sm" />
-              <div className="relative rounded-xl overflow-hidden h-[520px] img-warm-overlay ring-1 ring-accent-400/20">
-                <Image
-                  src="/img/photos/hero-team.jpg"
-                  alt="Strategic advisory session for startup founders"
-                  fill
-                  priority
-                  sizes="(max-width: 1024px) 100vw, 50vw"
-                  className="object-cover"
-                />
-                {/* Warm overlay for premium feel */}
-                <div className="absolute inset-0 bg-gradient-to-br from-accent-400/5 to-transparent mix-blend-overlay pointer-events-none" />
+              {/* Two halves, equal height: the offer is 50/50 and the hero has to
+                  show it. Real proof beats a stock photo of people at laptops. */}
+              <div className="relative rounded-xl overflow-hidden min-h-[520px] ring-1 ring-accent-400/20 shadow-xl flex flex-col">
+                <div className="flex-1 bg-primary-800 p-8 flex flex-col justify-center">
+                  <p className="text-xs uppercase tracking-[0.2em] text-accent-300 mb-4 font-semibold">Fractional CTO</p>
+                  <p className="font-serif text-4xl md:text-5xl font-bold text-white mb-3">5 &rarr; 1,000+</p>
+                  <p className="text-slate-300 text-sm mb-4">Concurrent users scaled at Rungway</p>
+                  <p className="text-slate-300 text-xs">Architecture, engineering leadership, delivery</p>
+                </div>
+
+                <div className="h-px bg-gradient-to-r from-transparent via-accent-400 to-transparent" />
+
+                <div className="flex-1 bg-white p-8 flex flex-col justify-center">
+                  <p className="text-xs uppercase tracking-[0.2em] text-accent-700 mb-4 font-semibold">Fractional CFO</p>
+                  <p className="font-serif text-3xl sm:text-4xl md:text-5xl font-bold text-slate-900 mb-3">&pound;35m &rarr; &pound;165m</p>
+                  <p className="text-slate-600 text-sm mb-4">Revenue scaled, EBITDA margin up 4%</p>
+                  <p className="text-slate-500 text-xs">Financial models, controls, fundraising</p>
+                </div>
               </div>
               {/* Gold accent decorations */}
               <div className="absolute -bottom-4 -right-4 w-24 h-24 bg-gold-gradient opacity-20 rounded-full blur-xl" />

--- a/app/services/page.js
+++ b/app/services/page.js
@@ -59,7 +59,6 @@ const services =
       title: "Fractional CTO",
       benefit: "Executive-level technical leadership at a fraction of the cost",
       description: "Make confident architecture decisions, build the right team, and become investor-ready. Strategic guidance for fintech, healthtech, and SaaS startups across the UK.",
-      image: "/img/photos/service-cto.jpg",
       outcomes: ["Save 60-80% vs full-time CTO", "Investor-ready in weeks", "Scale your team confidently"],
       track: "technical"
     },
@@ -67,7 +66,6 @@ const services =
       title: "Fractional CFO",
       benefit: "FP&A and strategic finance leadership",
       description: "Financial planning & analysis, business strategy, and investor-ready reporting. The financial discipline of a high-growth company — without the overhead.",
-      image: "/img/photos/service-diligence.jpg",
       outcomes: ["Financial modeling & forecasting", "Business strategy development", "Investor-ready reporting"],
       track: "business"
     },
@@ -75,7 +73,6 @@ const services =
       title: "0-to-1 Product Builds",
       benefit: "Launch your MVP in weeks, not months",
       description: "Go from idea to production-ready product with a system built to scale. No rebuilding later, no technical debt from day one.",
-      image: "/img/photos/service-product.jpg",
       outcomes: ["8-12 week delivery", "Built to handle growth", "Full ownership handover"],
       track: "technical"
     },
@@ -83,7 +80,6 @@ const services =
       title: "Financial Modeling",
       benefit: "Know your numbers before investors ask",
       description: "3-statement models, unit economics, and scenario planning. Financial models that stand up to due diligence scrutiny.",
-      image: "/img/photos/infrastructure.jpg",
       outcomes: ["3-statement models", "Unit economics analysis", "Scenario planning"],
       track: "business"
     },
@@ -91,7 +87,6 @@ const services =
       title: "AI & Data Engineering",
       benefit: "Turn AI experiments into production revenue",
       description: "Move beyond prototypes. We build production-grade LLM applications, ML pipelines, and data infrastructure that actually scale.",
-      image: "/img/photos/service-ai.jpg",
       outcomes: ["Production-ready AI", "Cost-optimized inference", "Scalable data pipelines"],
       track: "technical"
     },
@@ -99,7 +94,6 @@ const services =
       title: "Fundraising Support",
       benefit: "Close your round with confidence",
       description: "Pitch deck financial sections, data room preparation, and investor Q&A coaching. We've helped startups raise from pre-seed to Series A.",
-      image: "/img/photos/hero-team.jpg",
       outcomes: ["Data room ready", "Financial due diligence prep", "Valuation support"],
       track: "business"
     },
@@ -107,9 +101,15 @@ const services =
       title: "DevOps & Platform Engineering",
       benefit: "Deploy daily with zero downtime",
       description: "Automated infrastructure, CI/CD pipelines, and GitOps workflows. Ship confidently and iterate fast from day one.",
-      image: "/img/photos/infrastructure.jpg",
       outcomes: ["Automated deployments", "Infrastructure as code", "Zero-downtime releases"],
       track: "technical"
+    },
+    {
+      title: "Financial Controls & Governance",
+      benefit: "Close the books faster, with numbers you can trust",
+      description: "Month-end close discipline, purchasing and payroll controls, and CapEx governance. The financial plumbing that stops surprises reaching your board.",
+      outcomes: ["Faster, cleaner month-end close", "Audit-ready controls", "CapEx and spend governance"],
+      track: "business"
     }
   ]
 
@@ -179,14 +179,17 @@ export default function ServicesPage() {
                   Hands-on leadership from strategy through execution — not just advice from the sidelines
                 </p>
               </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-4">
-                {services.filter(s => s.track === 'technical').map((service, index) => (
-                  <ServiceCard key={service.title} service={service} priority={false} />
+              <h3 className="text-sm uppercase tracking-[0.2em] text-primary-700 font-semibold mb-6">Technical Track &mdash; Fractional CTO</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 mb-14">
+                {services.filter(s => s.track === 'technical').map((service) => (
+                  <ServiceCard key={service.title} service={service} />
                 ))}
               </div>
+
+              <h3 className="text-sm uppercase tracking-[0.2em] text-accent-700 font-semibold mb-6">Financial Track &mdash; Fractional CFO</h3>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-                {services.filter(s => s.track === 'business').map((service, index) => (
-                  <ServiceCard key={service.title} service={service} priority={false} />
+                {services.filter(s => s.track === 'business').map((service) => (
+                  <ServiceCard key={service.title} service={service} />
                 ))}
               </div>
             </div>

--- a/content/blog/building-your-first-data-room.md
+++ b/content/blog/building-your-first-data-room.md
@@ -2,7 +2,7 @@
 title: 'Building Your First Data Room: What Investors Expect to See'
 description: 'Complete guide to creating a data room for fundraising. What documents to include, how to organise them, and common mistakes to avoid.'
 date: '2024-12-28'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '9 min read'
 tags: ['Fundraising', 'Due Diligence', 'Data Room']
 ---

--- a/content/blog/extending-startup-runway-practical-guide.md
+++ b/content/blog/extending-startup-runway-practical-guide.md
@@ -2,7 +2,7 @@
 title: 'Extending Your Runway: A Practical Guide to Startup Cash Management'
 description: 'Practical strategies to extend your runway without sacrificing growth. Cash management tactics that work for seed and Series A startups.'
 date: '2025-08-10'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '9 min read'
 tags: ['Cash Management', 'Startup Finance']
 ---

--- a/content/blog/financial-modeling-seed-stage-startups.md
+++ b/content/blog/financial-modeling-seed-stage-startups.md
@@ -2,7 +2,7 @@
 title: 'Financial Modeling for Seed-Stage Startups: A Practical Guide'
 description: 'What investors actually want to see in your financial model—revenue projections, unit economics, and scenario planning that builds confidence.'
 date: '2025-10-15'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '8 min read'
 tags: ['Financial Modeling', 'Startup Finance']
 ---

--- a/content/blog/fractional-cfo-vs-accountant-vs-controller.md
+++ b/content/blog/fractional-cfo-vs-accountant-vs-controller.md
@@ -2,7 +2,7 @@
 title: 'Fractional CFO vs Accountant vs Financial Controller: What Your Startup Actually Needs'
 description: 'Accountant, financial controller, or fractional CFO? What each role does, what it costs in the UK, and which your startup needs from pre-seed to Series A.'
 date: '2026-08-04'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '8 min read'
 tags: ['Fractional CFO', 'Startup Finance', 'Hiring']
 ---

--- a/content/blog/how-much-does-fractional-cfo-cost-uk.md
+++ b/content/blog/how-much-does-fractional-cfo-cost-uk.md
@@ -2,7 +2,7 @@
 title: 'How Much Does a Fractional CFO Cost in the UK? 2026 Pricing Guide'
 description: 'Complete UK pricing guide for fractional CFO services in 2026. Retainer ranges, day rates, full-time cost comparisons, and how to budget at every stage.'
 date: '2026-08-04'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '7 min read'
 tags: ['Fractional CFO', 'Pricing', 'Startup Finance']
 ---

--- a/content/blog/investor-due-diligence-what-to-expect.md
+++ b/content/blog/investor-due-diligence-what-to-expect.md
@@ -2,7 +2,7 @@
 title: "What Investors Look for in Due Diligence: A Founder's Preparation Guide"
 description: 'What investors actually examine during due diligence, how to prepare your data room, and common pitfalls that cause deals to fall apart.'
 date: '2025-09-22'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '10 min read'
 tags: ['Due Diligence', 'Fundraising']
 ---

--- a/content/blog/seis-eis-tax-benefits-startup-investors.md
+++ b/content/blog/seis-eis-tax-benefits-startup-investors.md
@@ -2,7 +2,7 @@
 title: 'SEIS and EIS Explained: UK Tax Benefits for Startup Investors'
 description: 'Complete guide to SEIS and EIS tax relief schemes for UK startup investors. Understand the benefits, eligibility, and how startups can become SEIS/EIS qualifying.'
 date: '2025-01-04'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '9 min read'
 tags: ['Fundraising', 'Finance', 'UK Startups']
 ---

--- a/content/blog/startup-unit-economics-explained.md
+++ b/content/blog/startup-unit-economics-explained.md
@@ -2,7 +2,7 @@
 title: 'Startup Unit Economics Explained: CAC, LTV, and the Metrics That Matter'
 description: 'Complete guide to unit economics for startup founders. Learn how to calculate CAC, LTV, payback period, and why these metrics matter for fundraising.'
 date: '2024-12-22'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '10 min read'
 tags: ['Finance', 'Metrics', 'Unit Economics']
 ---

--- a/content/blog/when-to-hire-fractional-cfo.md
+++ b/content/blog/when-to-hire-fractional-cfo.md
@@ -2,7 +2,7 @@
 title: 'When Should You Hire a Fractional CFO? 7 Signs Your Startup Is Ready'
 description: 'Not sure if your startup needs a fractional CFO? Seven clear signs you are ready, from fundraising plans and runway anxiety to investor reporting burden.'
 date: '2026-08-04'
-author: 'Ankit Rana'
+author: 'Michelle Rana'
 readTime: '8 min read'
 tags: ['Fractional CFO', 'Hiring', 'Startup Finance']
 ---


### PR DESCRIPTION
Four changes, all aimed at the same problem: the site read as technical even though the CTO and CFO halves of the business are roughly equal.

## 1. Fundraising restored for Michelle

A previous pass narrowed her claims to "Board and Executive reporting" because her CV showed no fundraising experience. You've confirmed she has it, so the capability goes back into her `knowsAbout` schema, her bio and the expertise grid.

No specifics are attached — no round sizes, amounts raised, or named investors — until real figures are supplied. `BRANDING.md` rule 16 now records this, and a new rule 17 forbids publishing personal contact details from CVs.

## 2. Blog bylines follow the domain

| Michelle Rana (9) | Ankit Rana (10) |
|---|---|
| building-your-first-data-room | fractional-cto-vs-full-time-cto-uk-startups |
| extending-startup-runway-practical-guide | gitops-startup-deployment-github-actions |
| financial-modeling-seed-stage-startups | how-much-does-fractional-cto-cost-uk |
| fractional-cfo-vs-accountant-vs-controller | infrastructure-as-code-for-startups |
| how-much-does-fractional-cfo-cost-uk | kubernetes-startups-overkill-essential |
| investor-due-diligence-what-to-expect | mvp-vs-mlp-what-to-build-first |
| seis-eis-tax-benefits-startup-investors | non-technical-founder-hiring-developers |
| startup-unit-economics-explained | startup-technical-due-diligence-checklist |
| when-to-hire-fractional-cfo | terraform-aws-infrastructure-as-code |
| | when-to-hire-fractional-cto |

`startup-technical-due-diligence-checklist` stays with Ankit despite its Fundraising tag — it is about *technical* due diligence. All nine reassigned posts were read in full and checked for first-person authorial claims that would now be falsely attributed to Michelle; there were none.

The byline propagates automatically to the visible byline, `metadata.authors`, `openGraph.authors` and the `BlogPosting` JSON-LD, all of which read `post.author`.

## 3. The homepage hero image is gone

It was a stock photo of five people at laptops with code on the screens — the loudest "dev shop" signal on the site, and the first thing a founder looking for a CFO saw.

In its place: a two-half proof panel, equal heights (measured 260px / 260px), carrying real evidence instead of stock imagery.

- **Fractional CTO** — 5 → 1,000+ concurrent users scaled at Rungway
- **Fractional CFO** — £35m → £165m revenue, EBITDA margin up 4%

No image asset needed, crisp at any resolution, and `next/image` is dropped from the homepage since that was its only use. When founder photos arrive this can become a two-portrait layout.

## 4. The services page had the same problem underneath

Two specific causes, both fixed:

- The grid rendered **all four technical services in a full row**, then the three financial ones in a partial row below.
- Both finance cards were illustrated with **engineering photographs** — "Financial Modeling" showed server infrastructure, and "Fundraising Support" showed the very same people-writing-code photo being removed from the hero.

Service cards no longer use photographs at all, since every available image is an engineering scene; the track's colour carries it instead (navy technical, gold financial — matching the hero and the `/about` principal cards). A fourth financial service, **Financial Controls & Governance**, brings both tracks to four, and each row is now labelled with the track it belongs to.

Measured vocabulary balance on that page moved from **62/38** technical to **54/46**.

## 5. /services joins the header

Nav is now Services · Fractional CTO · Fractional CFO · Case Studies · About · Blog. With six links the desktop menu no longer fits at the `md` breakpoint — where it was **already overflowing with five** — so it switches to `lg` and tablets get the mobile menu.

## Verification

- `npm run build` passes, all 40 routes export
- Hero panel halves measured equal; the `£35m → £165m` line was wrapping below 360px with only ~19px of clearance inside a fixed-height container, so the panel is now `min-h` and the figure scales down a step at small widths
- Service grid confirmed 4 technical / 4 financial with zero images; both track headings render
- Desktop nav confirmed fitting at 1280px, mobile menu confirmed listing all six links
- Blog bylines verified in the built `BlogPosting` JSON-LD
- Reviewed by a `code-reviewer` agent: contrast ratios computed from the real palette (all pass AA — closest is `slate-500` on white at 4.76:1), byline/subject matching checked across all 19 posts, reassigned posts read for first-person leakage, dead assets and Tailwind JIT resolution checked
- Swept the repo to confirm no personal contact details from the CV appear anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)