### PR TITLE
Remove Codenest's own price anchors sitewide

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -206,8 +206,12 @@ Assemble pages from these; don't invent parallel patterns:
 - **Blog:** meta description = frontmatter `description`; post CTA is tag-aware
   (finance tags → Fractional CFO CTA, technical tags → Fractional CTO CTA);
   evergreen titles carry no year unless the content is genuinely refreshed annually.
-- **Pricing:** whatever figure metadata promises, the page states visibly. Current
-  anchors: CTO from £3k/month, CFO from £2.5k/month, "60-80% less than full-time".
+- **Pricing: Codenest publishes no prices of its own** (owner, 4 Aug 2026). No
+  per-month anchors on pages, in metadata, in OG descriptions, in the guides or in
+  posts. Comparative claims stay ("60-80% less than full-time", full-time salary
+  ranges), as does market-rate editorial such as the £2,000-£12,000 range in the CFO
+  guide — those describe the market, not our invoice. Pages say scope and terms
+  instead: written scope, fixed monthly figure, agreed before work starts.
 
 ## 9. Logo
 

--- a/app/guides/fractional-cfo-guide/page.js
+++ b/app/guides/fractional-cfo-guide/page.js
@@ -48,7 +48,7 @@ export default function FractionalCFOGuidePage() {
   const faqs = [
     {
       question: 'How much does a fractional CFO cost in the UK?',
-      answer: 'Most UK fractional CFO engagements fall roughly between £2,000 and £12,000 per month depending on intensity, from light-touch advisory through to two or three days per week. Codenest Fractional CFO engagements start from £2,500 per month. A full-time CFO, by comparison, typically costs £150,000-£250,000+ in salary alone, plus equity, benefits and recruitment fees.'
+      answer: 'Most UK fractional CFO engagements fall roughly between £2,000 and £12,000 per month depending on intensity, from light-touch advisory through to two or three days per week. A full-time CFO, by comparison, typically costs £150,000-£250,000+ in salary alone, plus equity, benefits and recruitment fees.'
     },
     {
       question: 'What is the difference between a fractional CFO and an accountant?',
@@ -341,7 +341,7 @@ export default function FractionalCFOGuidePage() {
                 </div>
 
                 <p>
-                  Codenest Fractional CFO engagements start from £2,500 per month. See the <Link href="/services/fractional-cfo/" className="text-primary-600 hover:text-primary-700 font-medium">Fractional CFO services page</Link> for what each engagement includes.
+                  See the <Link href="/services/fractional-cfo/" className="text-primary-600 hover:text-primary-700 font-medium">Fractional CFO services page</Link> for what each engagement includes.
                 </p>
 
                 <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Cost Comparison: Fractional vs Full-Time</h3>
@@ -592,7 +592,7 @@ export default function FractionalCFOGuidePage() {
                   Need a Fractional CFO?
                 </h2>
                 <p className="text-primary-100 mb-6 max-w-xl mx-auto">
-                  Codenest provides Fractional CFO services for UK startups from pre-seed to Series A: financial modelling, runway management, fundraising support and board reporting, from £2,500 per month.
+                  Codenest provides Fractional CFO services for UK startups from pre-seed to Series A: financial modelling, runway management, fundraising support and board reporting.
                 </p>
                 <Link
                   href="/contact/"

--- a/app/page.js
+++ b/app/page.js
@@ -39,7 +39,7 @@ export default function Home() {
     },
     {
       question: "What's your pricing model?",
-      answer: "We work on retainer for fractional leadership (monthly commitment) and fixed-fee for defined projects like MVP builds or financial modeling. Fractional engagements start from £2,500 per month (CFO) and £3,000 per month (CTO), typically 60-80% less than equivalent full-time hires."
+      answer: "We work on retainer for fractional leadership (monthly commitment) and fixed-fee for defined projects like MVP builds or financial modeling. You get a written scope and a fixed monthly figure before anything starts. Fractional leadership typically costs 60-80% less than an equivalent full-time hire."
     }
   ]
 
@@ -450,11 +450,11 @@ export default function Home() {
                   </dd>
                 </div>
                 <div>
-                  <dt className="text-xl font-bold text-slate-900 mb-2">Our rates are published.</dt>
+                  <dt className="text-xl font-bold text-slate-900 mb-2">We scope before we quote.</dt>
                   <dd className="text-slate-600 leading-relaxed">
-                    £3,000 a month for the CTO seat, £2,500 for the CFO seat, fixed fee for defined
-                    projects. You can work out what we cost before you speak to us, which is how we
-                    would want to buy it.
+                    You get a written scope and a fixed monthly figure before any work starts. No
+                    day-rate creep, no change requests for things that were always going to be needed,
+                    and no invoice that surprises you.
                   </dd>
                 </div>
                 <div>

--- a/app/services/fractional-cfo/page.js
+++ b/app/services/fractional-cfo/page.js
@@ -8,7 +8,7 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../../lib/schema'
 
 export const metadata = {
   title: 'Fractional CFO Services London for UK Startups',
-  description: 'Fractional CFO for UK startups from £2.5k/month. Financial modelling, fundraising support and investor reporting. Free 30-minute strategy call.',
+  description: 'Fractional CFO for UK startups, pre-seed to Series A. Financial modelling, fundraising support and investor reporting. Free 30-minute strategy call.',
   keywords: ['fractional CFO UK', 'fractional CFO London', 'startup CFO', 'FP&A UK', 'financial planning analysis', 'financial strategy', 'startup finance UK', 'part-time CFO'],
   openGraph: {
     title: 'Fractional CFO Services London | Codenest',
@@ -175,7 +175,7 @@ export default function FractionalCFOPage() {
                 FP&A, financial modeling, and investor-ready reporting from a part-time CFO. The financial discipline of a high-growth company — without the overhead.
               </p>
               <p className="text-sm font-medium text-slate-700 mb-8">
-                Engagements from £2,500/month &middot; typically 60-80% less than a full-time CFO
+                Fixed monthly retainer &middot; typically 60-80% less than a full-time CFO
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Button href="/contact/">Request a Strategy Call</Button>

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -8,11 +8,11 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../../lib/schema'
 
 export const metadata = {
   title: 'Fractional CTO Services London for UK Startups',
-  description: 'Fractional CTO for UK startups from £3k/month. Architecture, engineering hiring and due diligence preparation. Free 30-minute strategy call.',
+  description: 'Fractional CTO for UK startups, pre-seed to Series A. Architecture, engineering hiring and due diligence preparation. Free 30-minute strategy call.',
   keywords: ['fractional CTO UK', 'fractional CTO London', 'part-time CTO', 'startup CTO', 'technical leadership', 'CTO as a service', 'interim CTO UK', 'fractional CTO cost', 'startup technical leadership'],
   openGraph: {
     title: 'Fractional CTO Services London | Codenest',
-    description: 'Engineering rigour and technical leadership for UK startups — without the overhead. From £3k/month.',
+    description: 'Engineering rigour and technical leadership for UK startups, without the overhead of a full-time hire.',
     type: 'website',
     url: 'https://codenest.uk/services/fractional-cto/',
     images: [
@@ -186,7 +186,7 @@ export default function FractionalCTOPage() {
                 Engineering rigour and technical leadership for ambitious startups. Make confident architecture decisions, build the right team, and become investor-ready — without the overhead.
               </p>
               <p className="text-sm font-medium text-slate-700 mb-8">
-                Engagements from £3,000/month &middot; typically 60-80% less than a full-time CTO
+                Fixed monthly retainer &middot; typically 60-80% less than a full-time CTO
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Button href="/contact/">Request a Strategy Call</Button>

--- a/content/blog/fractional-cfo-vs-accountant-vs-controller.md
+++ b/content/blog/fractional-cfo-vs-accountant-vs-controller.md
@@ -62,7 +62,7 @@ A CFO is the forward-looking layer: strategy, capital, and the decisions that de
 - **Board and investor work** — board packs, metrics, the narrative behind the numbers
 - **Cash and runway** — burn management, hiring plans, scenario planning
 
-**Typical UK cost:** £2,000-£12,000 per month depending on intensity — a couple of days a month at the low end, several days a week at the top. Codenest engagements start from £2,500 per month. We've broken down [what a fractional CFO costs in the UK](/blog/how-much-does-fractional-cfo-cost-uk/), including what pushes the price up or down, in a separate post.
+**Typical UK cost:** £2,000-£12,000 per month depending on intensity — a couple of days a month at the low end, several days a week at the top. We've broken down [what a fractional CFO costs in the UK](/blog/how-much-does-fractional-cfo-cost-uk/), including what pushes the price up or down, in a separate post.
 
 ## The Three Roles at a Glance
 
@@ -136,4 +136,4 @@ Sequence them in that order, and don't expect any of them to do the others' jobs
 
 ---
 
-*Not sure which role your startup actually needs first? Our [fractional CFO services](/services/fractional-cfo/) start from £2,500 per month and are designed to work alongside your existing accountant — [get in touch](/contact/) for a straight answer.*
+*Not sure which role your startup actually needs first? Our [fractional CFO services](/services/fractional-cfo/) are designed to work alongside your existing accountant — [get in touch](/contact/) for a straight answer.*

--- a/content/blog/how-much-does-fractional-cfo-cost-uk.md
+++ b/content/blog/how-much-does-fractional-cfo-cost-uk.md
@@ -196,7 +196,7 @@ Fractional CFO services in the UK typically cost:
 - **Standard (~1 day/week):** £3,500-£6,000/month
 - **Intensive (2-3 days/week):** £6,000-£12,000/month
 
-As a reference point, Codenest fractional CFO engagements start from £2,500 per month. For most pre-seed to Series A startups, the fractional model represents **60-80% savings** versus a full-time CFO hire, with:
+For most pre-seed to Series A startups, the fractional model represents **60-80% savings** versus a full-time CFO hire, with:
 
 - Zero equity dilution
 - Zero recruitment fees


### PR DESCRIPTION
Owner decision (4 Aug 2026): **Codenest publishes no prices of its own**, rather than settle whether the per-month figures were ex or inc VAT.

[PR #40](https://github.com/cod3nest/cod3nest.github.io/pull/40) pushed against that decision without knowing it existed. The principle it added is live right now:

> **Our rates are published.** £3,000 a month for the CTO seat, £2,500 for the CFO seat…

That's replaced here with **"We scope before we quote"** — a written scope and a fixed monthly figure agreed before work starts, which is the commitment the number was standing in for anyway.

## Scope

14 locations. The homepage principle was mine; the rest predate PR #40.

| Location | Count |
|---|---|
| Homepage principle + pricing FAQ | 2 |
| `/services/fractional-cto/` — visible copy, meta description, OG description | 3 |
| `/services/fractional-cfo/` — visible copy, meta description | 2 |
| CFO guide — FAQ answer, mid-page, closing paragraph | 3 |
| `fractional-cfo-vs-accountant-vs-controller` | 2 |
| `how-much-does-fractional-cfo-cost-uk` | 1 |
| `BRANDING.md` §8 | 1 |

## What stays, deliberately

The decision covers *our* prices, not the market. Kept:

- Comparative claims — "60-80% less than full-time" (13 pages)
- The **£2,000-£12,000** monthly market range in the CFO guide
- The **£48,000-£96,000** fractional tiers
- Full-time salary comparisons (**£150,000-£250,000+**)
- `"saved £3k/month"` in the runway post — that's a startup's infrastructure saving, nothing to do with our rates

`BRANDING.md` §8 flips from listing pricing anchors to stating the ban and drawing that line explicitly, so the distinction survives the next content pass.

## Note on the in-flight branch

A separate branch covers this same decision alongside the Companies House disclosures, and its notes refer to its own standing rules 21-22. Per your call I've **left rule numbering alone** and only edited the §8 bullet — so expect a small conflict there, and let that branch win the numbering. If it also strips these figures, the resolution is both sides deleting the same lines.

## Verification

- Clean build, 41 routes; SEO audit **zero at every severity**
- Grepped the whole of `out/`: no own-price figure survives
- The four market-editorial figures still render on the pages that should carry them
- Meta and OG descriptions stayed within length after the edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)