### PR TITLE
Name both principals in BRANDING §1; state that either seat sells alone

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -27,9 +27,11 @@ editorial voice for headlines, and claims you could defend in a due-diligence ro
   "Code Nest", or "cod3nest" (the GitHub org `cod3nest` is a legacy identifier only;
   never surface it in copy, schema, or user-facing links — see §13.6).
 - **The offer (say it plainly, always):** **Fractional CTO and Fractional CFO services**
-  for UK startups, pre-seed to Series A. Two named executive seats, one integrated
-  partner. If a page or component cannot name at least one of the two services, it is
-  off-brand.
+  for UK startups, pre-seed to Series A. Two named executive seats, **each engageable on
+  its own.** Taking both is an option, not a condition — a founder who needs only a CFO
+  buys only the CFO seat. The integrated pairing is an advantage to offer, never a
+  minimum to imply. If a page or component cannot name at least one of the two services,
+  it is off-brand.
 - **Positioning line (the tagline):** "Big 4 rigour meets founder empathy."
 - **Brand flourish (secondary, display use only):** "Executive firepower. Startup agility."
 - **Retired lines — do not reintroduce:** "Where Startups Scale", "Big 4 rigour meets
@@ -38,8 +40,12 @@ editorial voice for headlines, and claims you could defend in a due-diligence ro
 - **The audience (ICP):** UK startup founders on the 0→1 journey, **pre-seed to
   Series A** (one phrasing, everywhere), in fintech, healthtech, and B2B SaaS.
   London-based, remote-friendly across the UK and Europe.
-- **The operator:** Codenest is founder-led — Ankit Rana, ex-Deloitte Digital and
-  Elavon (US Bancorp). This is a strength, not a secret (see §2 voice rules).
+- **The operators:** Codenest is founder-led in each track, and the tracks do not
+  overlap. **Ankit Rana, Fractional CTO** — ex-Deloitte Digital, Elavon (US Bancorp),
+  Opayo — leads the technical seat. **Michelle Rana FCCA, Fractional CFO** — strategic
+  finance at Dishoom — leads the financial seat. Being founder-led is a strength, not a
+  secret (see §2 voice rules), but "founder-led" never means one person covering both:
+  each seat is named to its own principal in copy and in schema (§2 rule 4, §13 rule 14).
 
 ## 2. Voice & tone
 
@@ -358,3 +364,9 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     for the same queries as its own children. `/services` stays linked from the homepage
     and the footer as the side-by-side overview. Capabilities are never listed as
     navigation destinations — that applies to the footer too. (4 Aug 2026.)
+27. **Either seat can be bought alone.** A client can engage the Fractional CTO, the
+    Fractional CFO, or both. Copy may say the two work better together; it may never
+    say or imply that both are required, and no CTA, FAQ or schema may present the
+    pair as the only unit of sale. "Most startups need both" is an observation about
+    startups, not a condition of engagement — if a sentence could read as the latter,
+    rewrite it. (Owner, 4 Aug 2026.)

--- a/app/page.js
+++ b/app/page.js
@@ -34,8 +34,8 @@ export default function Home() {
       answer: "Fractional CTO/CFO engagements typically run 3-6 months at 2-3 days per week. MVP builds are fixed-scope at 8-12 weeks. We tailor every engagement to your stage and needs. No cookie-cutter packages."
     },
     {
-      question: "Do you handle both technical and financial leadership?",
-      answer: "Yes. Many startups need both CTO and CFO guidance but can't justify two executive hires. We offer integrated leadership covering technology architecture, financial planning, and investor relations."
+      question: "Can I engage just the CTO or just the CFO?",
+      answer: "Yes. Each seat is a separate engagement — take the Fractional CTO, the Fractional CFO, or both. Founders who take both get one roadmap and one financial model built in the same conversations, rather than two advisers reconciling afterwards, but there is no requirement to buy the pair."
     },
     {
       question: "What's your pricing model?",
@@ -201,10 +201,10 @@ export default function Home() {
       <section className="py-24 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Integrated Partnership</p>
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Two Executive Seats</p>
             <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Your Fractional CTO &amp; CFO</h2>
             <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-              Most startups need both CTO and CFO guidance. We cover both seats in one engagement, so the technical plan and the financial plan agree.
+              Take either seat on its own, or both. Founders who take both get a technical plan and a financial plan that agree, because the same two people build them together.
             </p>
           </div>
 

--- a/app/services/page.js
+++ b/app/services/page.js
@@ -7,7 +7,7 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 
 export const metadata = {
   title: 'Fractional CTO & CFO Services for UK Startups',
-  description: 'Two executive seats, one integrated partner. Fractional CTO and Fractional CFO services for UK startups, pre-seed to Series A, and what each engagement covers.',
+  description: 'Two executive seats, each engageable on its own. Fractional CTO and Fractional CFO services for UK startups, pre-seed to Series A, and what each engagement covers.',
   openGraph: {
     title: 'Codenest Services — Fractional CTO & Fractional CFO',
     description: 'Technical and financial leadership for UK startups, pre-seed to Series A.',
@@ -133,10 +133,10 @@ export default function ServicesPage() {
         <section className="pt-40 pb-24 bg-white">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-16">
-              <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Integrated Partnership</p>
+              <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Two Executive Seats</p>
               <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Fractional CTO &amp; CFO Services</h1>
               <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-                Most startups need both CTO and CFO guidance. We cover both seats in one engagement, so the technical plan and the financial plan agree.
+                Two seats, each engageable on its own. Take the one you need now, or both and get a roadmap and a financial plan that already agree.
               </p>
             </div>
 


### PR DESCRIPTION
Two owner corrections that landed after #41 was merged.

## `BRANDING.md` §1 named one founder

§1 said *"The operator: Codenest is founder-led — Ankit Rana, ex-Deloitte Digital and Elavon (US Bancorp)."* That contradicted rule 4 (*"not one generalist covering both"*) and rule 14 (*"Codenest is two people"*) a few hundred lines below in the same file. A brand guide that disagrees with itself gets read at whichever point the reader opens it.

Founder-led is accurate — it is founder-led **per track**. §1 now names both principals to their own seat and states that "founder-led" never means one person covering both, with pointers to the two rules it has to stay consistent with.

## The site sold the pair, not the seats

A founder who wants only a CFO had no sentence on the site telling them they could buy one:

- Homepage two-track section led with *"Most startups need both CTO and CFO guidance. We cover both seats in one engagement."*
- `/services` hero said the same thing, under the eyebrow "Integrated Partnership".
- The homepage FAQ asked *"Do you handle both technical and financial leadership?"* — answering a question about capability while the reader's actual question was about the unit of sale.

Each seat is engageable on its own. The integrated pairing is now framed as an advantage of taking both rather than a condition of either. The FAQ question is now **"Can I engage just the CTO or just the CFO?"**, which is also closer to what a single-seat buyer types into a search box — the answer feeds the FAQPage schema, so it is what gets surfaced.

Recorded as standing rule 27, so the bundle-only framing does not drift back the way the price anchors did.

## Verification

- `npm run build` clean, 42 static pages exported
- No remaining "both CTO and CFO" / "integrated partner" framing in `app/`, `lib/` or `content/` (only an `/about` code comment, which is a correctness note)
- Changed FAQ question and answer confirmed in the rendered FAQPage JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)
