### PR TITLE
Fix two-seat messaging, reconcile the address, add the CFO guides

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -167,6 +167,14 @@ Two faces, two jobs. Loaded via `next/font` in `app/layout.js` — never CDN-lin
 - **Mobile:** verify at 375px. No horizontal scroll. The sticky mobile CTA must hide
   when the contact section is in view. In comparison grids, the Codenest card renders
   first on mobile (`order-first lg:order-none`).
+- **Hero sizing steps up, never down.** Desktop hero values do not ride down to mobile:
+  section top padding is `pt-28 md:pt-40|44` (`pt-24 md:pt-32` on interior pages), and
+  the homepage h1 is `text-4xl sm:text-5xl md:text-6xl`. Measured 5 Aug 2026: carrying
+  the desktop values down made the homepage hero 1798px tall at 375px, 2.2 screens, with
+  the primary CTA below the fold. After: 1411px, CTA at 746px. Re-measure hero height
+  and CTA offset at 375px after any hero change rather than eyeballing it.
+- **Wide content scrolls inside its own container.** Tables and code blocks get an
+  `overflow-x-auto` wrapper; the page body never scrolls horizontally.
 
 ## 6. Components (the section grammar)
 
@@ -215,6 +223,12 @@ Assemble pages from these; don't invent parallel patterns:
 - **Schema:** ProfessionalService lives in the root layout ONLY. FAQPage/Article
   schema belongs to the page that visibly renders the content — never sitewide, never
   two FAQPage blocks on one page. Finance posts are `BlogPosting` (not `TechArticle`).
+  **One offer catalogue, in the root layout** — the two retained seats plus the two
+  fixed-fee project shapes named in "How We Work". A page that needs to name the
+  company writes `provider: { '@id': ORGANIZATION_ID }`; it never restates an
+  Organization inline. (5 Aug 2026: the homepage carried a second
+  ProfessionalService and a three-item catalogue that had drifted from the
+  layout's four; it was deleted rather than kept in sync.)
 - **Canonicals & sitemap URLs carry the trailing slash** (config sets
   `trailingSlash: true`).
 - **OG image:** 1200×630 real card (logo + offer line), declared dimensions matching
@@ -357,13 +371,28 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     Clearways Accountants, Clearways, Colley Way, Reigate RH2 9JH, and the VAT number.
     Never remove them. Note the registered office is **Surrey, not London** — reconcile
     any "London-based" claim and the `addressLocality` in `app/layout.js` against it.
-    (4 Aug 2026.)
+    (4 Aug 2026.) **Reconciled 5 Aug 2026:** the schema `address` is now the registered
+    office, and the `geo` block is gone rather than re-guessed — it held the generic
+    51.5074/-0.1278 London centroid for an address the business does not occupy. The
+    footer's "London-based" line was dropped. Put a locality claim back only alongside
+    an address that supports it. **Still open:** the `/services/fractional-cto/` and
+    `/services/fractional-cfo/` page titles both say "London", as do several metadata
+    keywords — decide whether London is a claim Codenest can make before the next
+    metadata pass.
 26. **The Services dropdown is the two seats, nothing else.** "All Services" was removed
     from it (4 Aug 2026): every route out of `/services` leads back to one of those two
     pages, so it was a third nav slot reaching nothing new — and a third page competing
     for the same queries as its own children. `/services` stays linked from the homepage
-    and the footer as the side-by-side overview. Capabilities are never listed as
+    and the footer. Capabilities are never listed as
     navigation destinations — that applies to the footer too. (4 Aug 2026.)
+    **Updated 5 Aug 2026:** `/services` is no longer a side-by-side overview. It restated
+    the homepage's two-track section almost verbatim and competed with it, so it was
+    rewritten as the decision page — *which seat do I need?* — carrying the signal lists,
+    the two approved declines, and the capability grid. The track cards there give what
+    each seat owns and who leads it; they never repeat the homepage's bullet lists.
+    The nav also gained a **Resources** dropdown (Guides, Blog, Runway Calculator),
+    replacing the standalone Blog slot: five guides and the calculator were reachable
+    only from the footer. Slot count is unchanged at four plus the CTA.
 27. **Either seat can be bought alone.** A client can engage the Fractional CTO, the
     Fractional CFO, or both. Copy may say the two work better together; it may never
     say or imply that both are required, and no CTA, FAQ or schema may present the

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -201,7 +201,7 @@ export default function AboutPage() {
       <main id="main-content">
 
       {/* Hero Section */}
-      <section className="pt-32 pb-20 bg-gradient-to-b from-slate-50 to-white">
+      <section className="pt-24 md:pt-32 pb-20 bg-gradient-to-b from-slate-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Our Story</p>

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -62,7 +62,7 @@ export default function BlogPage() {
       <main id="main-content">
 
       {/* Hero Section */}
-      <section className="pt-32 pb-12 bg-white">
+      <section className="pt-24 md:pt-32 pb-12 bg-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-4">
             Insights

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -7,7 +7,7 @@ export const metadata = {
   title: 'Case Studies: Fractional CTO & CFO Outcomes',
   description: 'How Codenest scaled Rungway from 5 to 1,000+ concurrent users, modernised payment infrastructure at Opayo, and delivered a compliant MVP for AstraZeneca.',
   openGraph: {
-    title: 'Codenest Case Studies — Client Outcomes',
+    title: 'Codenest Case Studies — Track Record',
     description: 'Startup outcomes, backed by enterprise-grade experience. Rungway, Opayo by Elavon, AstraZeneca.',
     type: 'website',
     url: 'https://codenest.uk/case-studies/',
@@ -29,7 +29,7 @@ const caseStudies = [
   {
     title: "Rungway: Scaling a Social Mentoring Platform",
     challenge: "A London-based HR-tech startup needed fractional CTO support to scale their social mentoring platform. The system could only handle 5 concurrent users before experiencing severe performance degradation — completely inadequate for their UK enterprise client base.",
-    solution: "As Rungway's interim CTO, our founder delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
+    solution: "As Rungway's interim CTO, Ankit delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
     results: ["Scaled from 5 to 1000+ concurrent users", "Zero-downtime database migration", "Modern DevOps foundations established", "Event-driven microservices architecture"],
     tags: ["Backend Architecture", "AWS", "DevOps", "Scalability", "Microservices"],
     image: "/img/photos/case-rungway.jpg",
@@ -38,7 +38,7 @@ const caseStudies = [
   {
     title: "Opayo by Elavon: Payment Platform Transformation",
     challenge: "Leading UK fintech payment provider needed Kubernetes consulting to modernize their infrastructure and integrate new payment channels (Apple Pay, Google Pay) while maintaining 100% uptime for critical transaction processing across Europe.",
-    solution: "Working inside the Opayo platform team from August 2019 to June 2026, our founder orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
+    solution: "Working inside the Opayo platform team from August 2019 to June 2026, Ankit orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
     results: ["Accelerated releases from every 2 weeks to multiple times per day", "Contributed to 10% revenue increase through faster feature delivery", "Reduced CI pipeline failures through automated testing", "Successfully integrated Apple Pay and Google Pay"],
     tags: ["Payment Systems", "AWS EKS", "Kubernetes", "Terraform", "GitOps", "Team Leadership"],
     image: "/img/photos/case-opayo.jpg",
@@ -47,7 +47,7 @@ const caseStudies = [
   {
     title: "AstraZeneca: Drug Delivery Tracking System MVP",
     challenge: "AstraZeneca needed to replace manual spreadsheet-based drug delivery tracking with a modern web-based tool to improve efficiency and accelerate time-to-market for pharmaceutical products. The system required integration with existing workflows while maintaining regulatory compliance.",
-    solution: "Our founder built a production-grade web application with REST APIs and automated CI/CD pipelines, collaborating closely with stakeholders and business analysts to define requirements and align delivery with business goals — architecting scalable deployments on Kubernetes using Docker and Jenkins (config-as-code), and establishing robust testing practices with JUnit and Spock.",
+    solution: "Ankit built a production-grade web application with REST APIs and automated CI/CD pipelines, collaborating closely with stakeholders and business analysts to define requirements and align delivery with business goals — architecting scalable deployments on Kubernetes using Docker and Jenkins (config-as-code), and establishing robust testing practices with JUnit and Spock.",
     results: ["Accelerated delivery by 40% compared to manual processes", "Cut deployment errors by 30% through automated pipelines", "Improved stakeholder confidence through transparent roadmap planning", "Delivered production-ready MVP on Kubernetes infrastructure"],
     tags: ["Healthcare", "Team Leadership", "Kubernetes", "CI/CD", "REST APIs", "Stakeholder Management"],
     image: "/img/photos/case-astrazeneca.jpg",
@@ -61,7 +61,10 @@ const pageSchema = [
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'Codenest Case Studies',
-    description: 'Client outcomes from technical and financial leadership engagements.',
+    // Every study on this page is a technical engagement led by Ankit. The
+    // description said "technical and financial" while no financial study
+    // existed — a claim the page could not back (BRANDING.md §2.2).
+    description: 'Technical leadership engagements led by Ankit Rana, Fractional CTO.',
     itemListElement: caseStudies.map((study, index) => ({
       '@type': 'ListItem',
       position: index + 1,
@@ -77,13 +80,13 @@ export default function CaseStudiesPage() {
       <Navigation />
 
       <main id="main-content">
-        <section className="pt-40 pb-24 bg-white">
+        <section className="pt-28 md:pt-40 pb-24 bg-white">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-20">
               <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Proven Track Record</p>
               <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Case Studies</h1>
               <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-                Startup outcomes, backed by enterprise-grade experience. Deep, hands-on collaboration at every stage
+                Technical engagements led by Ankit Rana, Fractional CTO. Deep, hands-on collaboration at every stage
               </p>
             </div>
 

--- a/app/cofounder/page.js
+++ b/app/cofounder/page.js
@@ -151,7 +151,7 @@ export default function CofounderPage() {
       <main id="main-content">
 
       {/* Hero Section */}
-      <section className="pt-32 pb-20 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white relative overflow-hidden">
+      <section className="pt-24 md:pt-32 pb-20 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white relative overflow-hidden">
         {/* Background decoration */}
         <div className="absolute inset-0 opacity-10">
           <div className="absolute top-20 left-10 w-72 h-72 bg-accent-400 rounded-full blur-3xl"></div>

--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -38,7 +38,9 @@ export default function Footer() {
               <li><Link href="/guides/fractional-cto-guide/" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CTO Guide</Link></li>
               <li><Link href="/guides/fractional-cfo-guide/" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CFO Guide</Link></li>
               <li><Link href="/guides/fractional-cto-vs-full-time/" className="text-slate-400 hover:text-accent-400 transition-colors">CTO vs Full-Time</Link></li>
+              <li><Link href="/guides/fractional-cfo-vs-full-time/" className="text-slate-400 hover:text-accent-400 transition-colors">CFO vs Full-Time</Link></li>
               <li><Link href="/guides/fractional-cto-vs-agency/" className="text-slate-400 hover:text-accent-400 transition-colors">CTO vs Agency</Link></li>
+              <li><Link href="/guides/fractional-cfo-vs-outsourced-finance/" className="text-slate-400 hover:text-accent-400 transition-colors">CFO vs Outsourced Finance</Link></li>
               <li><Link href="/guides/technical-cofounder-alternatives/" className="text-slate-400 hover:text-accent-400 transition-colors">Co-founder Alternatives</Link></li>
               <li><Link href="/tools/runway-calculator/" className="text-slate-400 hover:text-accent-400 transition-colors">Runway Calculator</Link></li>
             </ul>
@@ -46,7 +48,7 @@ export default function Footer() {
           <div>
             <h2 className="font-semibold mb-4">Company</h2>
             <ul className="space-y-2 text-sm">
-              <li><a href="/case-studies/" className="text-slate-400 hover:text-accent-400 transition-colors">Client Partnerships</a></li>
+              <li><a href="/case-studies/" className="text-slate-400 hover:text-accent-400 transition-colors">Case Studies</a></li>
               <li><a href="/#how-we-work" className="text-slate-400 hover:text-accent-400 transition-colors">Our Methodology</a></li>
               <li><a href="/about/" className="text-slate-400 hover:text-accent-400 transition-colors">Our Story</a></li>
               <li><Link href="/blog/" className="text-slate-400 hover:text-accent-400 transition-colors">Insights</Link></li>
@@ -61,8 +63,12 @@ export default function Footer() {
               <li><a href="https://www.linkedin.com/company/codenest-ltd" className="text-slate-400 hover:text-accent-400 transition-colors" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
             </ul>
             <div className="mt-6">
+              {/* "London-based" removed: the only address this site publishes is
+                  the registered office in Reigate, Surrey, and the schema in
+                  app/layout.js now states that one. Put a locality claim back
+                  only alongside an address that supports it (BRANDING.md §13.25). */}
               <p className="text-slate-400 text-xs">
-                London-based. Serving select founders across the UK and Europe.
+                Serving select founders across the UK and Europe.
               </p>
             </div>
           </div>

--- a/app/components/Navigation.js
+++ b/app/components/Navigation.js
@@ -15,15 +15,165 @@ const SERVICE_LINKS = [
   { href: '/services/fractional-cfo/', label: 'Fractional CFO', hint: 'Financial models, controls, fundraising' },
 ]
 
+// Five guides and the runway calculator used to be reachable only from the footer,
+// while Blog held a top-level slot on its own. Grouping the three surfaces the whole
+// library without spending another slot: the nav still shows four items plus the CTA.
+const RESOURCE_LINKS = [
+  { href: '/guides/', label: 'Guides', hint: 'In-depth comparisons and hiring guides' },
+  { href: '/blog/', label: 'Blog', hint: 'Technical and finance writing for founders' },
+  { href: '/tools/runway-calculator/', label: 'Runway Calculator', hint: 'Free: months of runway and when to raise' },
+]
+
+// One disclosure menu, used by both Services and Resources. All the focus
+// management lives here, so a second menu costs a line rather than a copy of it.
+function NavDropdown({ label, menuId, links }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef(null)
+  const buttonRef = useRef(null)
+  const itemRefs = useRef([])
+  const pendingFocusIndex = useRef(null)
+  const pathname = usePathname()
+
+  // A dropdown that survives a route change, a click elsewhere, or Escape.
+  useEffect(() => {
+    setIsOpen(false)
+  }, [pathname])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const closeOnOutsideClick = (event) => {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setIsOpen(false)
+      }
+    }
+    const closeOnEscape = (event) => {
+      if (event.key !== 'Escape') return
+      setIsOpen(false)
+      // Below the lg breakpoint the desktop nav is display:none, and focusing a
+      // button with no CSS box silently drops focus to the body.
+      const button = buttonRef.current
+      if (button && button.offsetParent !== null) button.focus()
+    }
+    document.addEventListener('pointerdown', closeOnOutsideClick)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsideClick)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    // Clearing on close matters: a pending index that outlives its menu would
+    // be consumed by the next open and steal focus unasked.
+    if (!isOpen) {
+      pendingFocusIndex.current = null
+      return
+    }
+    if (pendingFocusIndex.current === null) return
+    const index = pendingFocusIndex.current
+    pendingFocusIndex.current = null
+    itemRefs.current[index]?.focus()
+  }, [isOpen])
+
+  // Keyboard activation is handled explicitly rather than leaning on the
+  // button's native Enter/Space behaviour, so the disclosure also supports the
+  // arrow keys a keyboard user expects from a navigation menu.
+  // The item refs only exist once the open menu has committed, so the focus
+  // move is deferred to an effect rather than run alongside the state update.
+  const open = (focusIndex) => {
+    pendingFocusIndex.current = focusIndex ?? null
+    setIsOpen(true)
+  }
+
+  // When the menu is already open, focus moves directly. Calling setState with
+  // the value it already holds makes React bail out without re-rendering, so
+  // the focus effect would never run and the pending index would go stale.
+  const handleButtonKeyDown = (event) => {
+    const lastIndex = links.length - 1
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      isOpen ? itemRefs.current[0]?.focus() : open(0)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      isOpen ? itemRefs.current[lastIndex]?.focus() : open(lastIndex)
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      isOpen ? setIsOpen(false) : open()
+    }
+  }
+
+  const handleItemKeyDown = (event, index) => {
+    const lastIndex = links.length - 1
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      itemRefs.current[index === lastIndex ? 0 : index + 1]?.focus()
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      itemRefs.current[index === 0 ? lastIndex : index - 1]?.focus()
+    }
+  }
+
+  return (
+    <div
+      className="relative"
+      ref={containerRef}
+      onBlur={(event) => {
+        // Tabbing past the last item would otherwise leave the panel
+        // open and floating with no focus inside it.
+        if (!containerRef.current?.contains(event.relatedTarget)) {
+          setIsOpen(false)
+        }
+      }}
+    >
+      <button
+        type="button"
+        ref={buttonRef}
+        onClick={() => setIsOpen((wasOpen) => !wasOpen)}
+        onKeyDown={handleButtonKeyDown}
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        className="flex items-center text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+      >
+        {label}
+        <svg
+          className={`w-4 h-4 ml-1.5 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          id={menuId}
+          className="absolute left-0 mt-2 w-72 rounded-xl bg-white py-2 shadow-xl ring-1 ring-slate-200"
+        >
+          {links.map((link, index) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              ref={(node) => { itemRefs.current[index] = node }}
+              onClick={() => setIsOpen(false)}
+              onKeyDown={(event) => handleItemKeyDown(event, index)}
+              className="block px-4 py-3 hover:bg-slate-50 transition-colors focus:outline-none focus-visible:bg-slate-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500"
+            >
+              <span className="block text-sm font-semibold text-slate-800">{link.label}</span>
+              <span className="block text-xs text-slate-500 mt-0.5">{link.hint}</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function Navigation() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const [isServicesOpen, setIsServicesOpen] = useState(false)
   const [isPastHero, setIsPastHero] = useState(false)
   const [isContactInView, setIsContactInView] = useState(false)
-  const servicesRef = useRef(null)
-  const servicesButtonRef = useRef(null)
-  const serviceItemRefs = useRef([])
-  const pendingFocusIndex = useRef(null)
   // On the homepage, scroll to its inline contact section instead of
   // navigating away (and potentially discarding in-progress form input).
   const pathname = usePathname()
@@ -59,85 +209,11 @@ export default function Navigation() {
 
   const showStickyCTA = isPastHero && !isContactInView
 
-  // A dropdown that survives a route change, a click elsewhere, or Escape.
+  // Each NavDropdown closes itself on a route change; the burger menu is this
+  // component's own state, so it still needs closing here.
   useEffect(() => {
-    setIsServicesOpen(false)
     setIsMenuOpen(false)
   }, [pathname])
-
-  useEffect(() => {
-    if (!isServicesOpen) return
-    const closeOnOutsideClick = (event) => {
-      if (servicesRef.current && !servicesRef.current.contains(event.target)) {
-        setIsServicesOpen(false)
-      }
-    }
-    const closeOnEscape = (event) => {
-      if (event.key !== 'Escape') return
-      setIsServicesOpen(false)
-      // Below the lg breakpoint the desktop nav is display:none, and focusing a
-      // button with no CSS box silently drops focus to the body.
-      const button = servicesButtonRef.current
-      if (button && button.offsetParent !== null) button.focus()
-    }
-    document.addEventListener('pointerdown', closeOnOutsideClick)
-    document.addEventListener('keydown', closeOnEscape)
-    return () => {
-      document.removeEventListener('pointerdown', closeOnOutsideClick)
-      document.removeEventListener('keydown', closeOnEscape)
-    }
-  }, [isServicesOpen])
-
-  useEffect(() => {
-    // Clearing on close matters: a pending index that outlives its menu would
-    // be consumed by the next open and steal focus unasked.
-    if (!isServicesOpen) {
-      pendingFocusIndex.current = null
-      return
-    }
-    if (pendingFocusIndex.current === null) return
-    const index = pendingFocusIndex.current
-    pendingFocusIndex.current = null
-    serviceItemRefs.current[index]?.focus()
-  }, [isServicesOpen])
-
-  // Keyboard activation is handled explicitly rather than leaning on the
-  // button's native Enter/Space behaviour, so the disclosure also supports the
-  // arrow keys a keyboard user expects from a navigation menu.
-  // The item refs only exist once the open menu has committed, so the focus
-  // move is deferred to an effect rather than run alongside the state update.
-  const openServices = (focusIndex) => {
-    pendingFocusIndex.current = focusIndex ?? null
-    setIsServicesOpen(true)
-  }
-
-  // When the menu is already open, focus moves directly. Calling setState with
-  // the value it already holds makes React bail out without re-rendering, so
-  // the focus effect would never run and the pending index would go stale.
-  const handleServicesButtonKeyDown = (event) => {
-    const lastIndex = SERVICE_LINKS.length - 1
-    if (event.key === 'ArrowDown') {
-      event.preventDefault()
-      isServicesOpen ? serviceItemRefs.current[0]?.focus() : openServices(0)
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault()
-      isServicesOpen ? serviceItemRefs.current[lastIndex]?.focus() : openServices(lastIndex)
-    } else if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      isServicesOpen ? setIsServicesOpen(false) : openServices()
-    }
-  }
-
-  const handleServicesItemKeyDown = (event, index) => {
-    const lastIndex = SERVICE_LINKS.length - 1
-    if (event.key === 'ArrowDown') {
-      event.preventDefault()
-      serviceItemRefs.current[index === lastIndex ? 0 : index + 1]?.focus()
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault()
-      serviceItemRefs.current[index === 0 ? lastIndex : index - 1]?.focus()
-    }
-  }
 
   return (
     <>
@@ -202,62 +278,10 @@ export default function Navigation() {
           {/* Desktop Menu — six links plus the CTA need lg; at md they overflow. */}
           <div className="hidden lg:block">
             <div className="ml-10 flex items-baseline space-x-1">
-              <div
-                className="relative"
-                ref={servicesRef}
-                onBlur={(event) => {
-                  // Tabbing past the last item would otherwise leave the panel
-                  // open and floating with no focus inside it.
-                  if (!servicesRef.current?.contains(event.relatedTarget)) {
-                    setIsServicesOpen(false)
-                  }
-                }}
-              >
-                <button
-                  type="button"
-                  ref={servicesButtonRef}
-                  onClick={() => setIsServicesOpen((open) => !open)}
-                  onKeyDown={handleServicesButtonKeyDown}
-                  aria-expanded={isServicesOpen}
-                  aria-controls="services-menu"
-                  className="flex items-center text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
-                >
-                  Services
-                  <svg
-                    className={`w-4 h-4 ml-1.5 transition-transform ${isServicesOpen ? 'rotate-180' : ''}`}
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    aria-hidden="true"
-                  >
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
-                </button>
-
-                {isServicesOpen && (
-                  <div
-                    id="services-menu"
-                    className="absolute left-0 mt-2 w-72 rounded-xl bg-white py-2 shadow-xl ring-1 ring-slate-200"
-                  >
-                    {SERVICE_LINKS.map((link, index) => (
-                      <Link
-                        key={link.href}
-                        href={link.href}
-                        ref={(node) => { serviceItemRefs.current[index] = node }}
-                        onClick={() => setIsServicesOpen(false)}
-                        onKeyDown={(event) => handleServicesItemKeyDown(event, index)}
-                        className="block px-4 py-3 hover:bg-slate-50 transition-colors focus:outline-none focus-visible:bg-slate-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500"
-                      >
-                        <span className="block text-sm font-semibold text-slate-800">{link.label}</span>
-                        <span className="block text-xs text-slate-500 mt-0.5">{link.hint}</span>
-                      </Link>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <NavDropdown label="Services" menuId="services-menu" links={SERVICE_LINKS} />
               <a href="/case-studies/" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Case Studies</a>
               <a href="/about/" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">About</a>
-              <a href="/blog/" className="text-slate-700 hover:text-primary-700 px-3 py-2 text-sm font-medium transition-colors rounded-xl hover:bg-slate-50 link-gold">Blog</a>
+              <NavDropdown label="Resources" menuId="resources-menu" links={RESOURCE_LINKS} />
               <a href={contactHref} className="bg-accent-400 text-primary-900 px-6 py-2.5 ml-2 rounded-lg text-sm font-semibold hover:bg-accent-500 transition-all shadow-sm hover:shadow-gold">Request a Strategy Call</a>
             </div>
           </div>
@@ -302,7 +326,22 @@ export default function Navigation() {
               </ul>
               <a href="/case-studies/" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Case Studies</a>
               <a href="/about/" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">About</a>
-              <a href="/blog/" onClick={() => setIsMenuOpen(false)} className="text-slate-700 hover:text-primary-700 block px-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50">Blog</a>
+              <p id="mobile-resources-heading" className="px-3 pt-2 pb-1 text-xs uppercase tracking-[0.15em] text-slate-500 font-semibold">
+                Resources
+              </p>
+              <ul aria-labelledby="mobile-resources-heading" className="space-y-1">
+                {RESOURCE_LINKS.map((link) => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      onClick={() => setIsMenuOpen(false)}
+                      className="text-slate-700 hover:text-primary-700 block pl-6 pr-3 py-2 text-base font-medium rounded-lg hover:bg-slate-50"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
               <a href={contactHref} onClick={() => setIsMenuOpen(false)} className="bg-accent-400 text-primary-900 font-semibold block px-3 py-2 text-base rounded-lg hover:bg-accent-500 transition-all shadow-sm">Request a Strategy Call</a>
             </div>
           </div>

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -48,7 +48,7 @@ export default function ContactPage() {
       <main id="main-content">
         {/* Shares the homepage's #contact id so the sticky CTA suppresses itself
             here too — on this page the shortcut has nothing to offer. */}
-        <section id="contact" className="pt-40 pb-24 bg-gradient-to-b from-slate-50 to-white relative overflow-hidden">
+        <section id="contact" className="pt-28 md:pt-40 pb-24 bg-gradient-to-b from-slate-50 to-white relative overflow-hidden">
           {/* Background decorations */}
           <div className="absolute top-0 left-1/4 w-96 h-96 bg-accent-400 opacity-[0.02] rounded-full blur-3xl" />
           <div className="absolute bottom-0 right-1/4 w-64 h-64 bg-primary-600 opacity-[0.03] rounded-full blur-3xl" />

--- a/app/guides/fractional-cfo-guide/page.js
+++ b/app/guides/fractional-cfo-guide/page.js
@@ -122,7 +122,7 @@ export default function FractionalCFOGuidePage() {
       <main id="main-content">
 
         {/* Hero */}
-        <section className="pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
+        <section className="pt-24 md:pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
           <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center">
               <span className="inline-block px-4 py-2 bg-accent-50 text-accent-700 rounded-full text-sm font-medium mb-6">

--- a/app/guides/fractional-cfo-vs-full-time/page.js
+++ b/app/guides/fractional-cfo-vs-full-time/page.js
@@ -1,0 +1,363 @@
+import Link from 'next/link'
+import Navigation from '../../components/Navigation'
+import Footer from '../../components/Footer'
+import JsonLd from '../../components/JsonLd'
+import { breadcrumbs, ORGANIZATION_ID } from '../../../lib/schema'
+
+export const metadata = {
+  title: 'Fractional CFO vs Full-Time CFO: Cost Comparison',
+  description: 'Compare fractional CFO vs full-time CFO for UK startups. Year-one cost breakdown, equity dilution, time to start, and a decision framework for each stage.',
+  keywords: ['fractional CFO vs full-time CFO', 'part-time CFO vs permanent CFO', 'startup CFO hiring UK', 'when to hire a full-time CFO', 'fractional vs full-time finance leader'],
+  openGraph: {
+    title: 'Fractional CFO vs Full-Time CFO: Complete Comparison',
+    description: 'Which finance leadership model fits your stage? Costs, dilution, and the trade-offs compared for UK founders.',
+    type: 'article',
+    url: 'https://codenest.uk/guides/fractional-cfo-vs-full-time/',
+    images: [
+      {
+        url: '/img/og-default.png',
+        width: 1200,
+        height: 630,
+        alt: 'Codenest - Fractional CTO & CFO for UK startups',
+      },
+    ],
+  },
+  alternates: {
+    canonical: 'https://codenest.uk/guides/fractional-cfo-vs-full-time/',
+  },
+}
+
+const pageSchema = [
+  breadcrumbs([
+    { name: 'Guides', path: '/guides/' },
+    { name: 'CFO vs Full-Time', path: '/guides/fractional-cfo-vs-full-time/' },
+  ]),
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Fractional CFO vs Full-Time CFO: Cost Comparison',
+    description: 'Salary, employer costs, equity and time-to-start compared, plus a decision framework for each startup stage.',
+    author: { '@id': ORGANIZATION_ID },
+    publisher: { '@id': ORGANIZATION_ID },
+    datePublished: '2026-08-05',
+    dateModified: '2026-08-05',
+    mainEntityOfPage: 'https://codenest.uk/guides/fractional-cfo-vs-full-time/',
+    inLanguage: 'en-GB',
+  },
+]
+
+// UK market ranges, consistent with the figures published in our fractional CFO
+// cost guide. These describe the market; they are not a Codenest price list
+// (BRANDING.md §13.24 — Codenest publishes no prices of its own).
+const comparisonData = [
+  { factor: 'Year-one cost', fractional: '£24,000-£144,000', fullTime: '£210,000-£360,000', advantage: 'fractional' },
+  { factor: 'Equity dilution', fractional: 'None', fullTime: '0.5-2%', advantage: 'fractional' },
+  { factor: 'Time to start', fractional: '1-2 weeks', fullTime: '3-6 months', advantage: 'fractional' },
+  { factor: 'Weekly availability', fractional: '8-16 hours', fullTime: '40+ hours', advantage: 'fullTime' },
+  { factor: 'Commitment', fractional: 'Monthly, 30-day notice typical', fullTime: 'Permanent employment', advantage: 'fractional' },
+  { factor: 'Exit cost if it fails', fractional: 'Notice period', fullTime: 'Severance plus a repeat search', advantage: 'fractional' },
+  { factor: 'Day-to-day presence', fractional: 'Scheduled days and fundraise spikes', fullTime: 'In the room every day', advantage: 'fullTime' },
+  { factor: 'Typical fit', fractional: 'Pre-seed to Series A', fullTime: 'Series B and beyond', advantage: null },
+]
+
+const fractionalCosts = [
+  { label: 'Monthly retainer', value: '£2,000-£12,000' },
+  { label: 'Employer NI', value: '£0' },
+  { label: 'Pension contribution', value: '£0' },
+  { label: 'Benefits', value: '£0' },
+  { label: 'Recruitment fees', value: '£0' },
+  { label: 'Equity', value: '0%' },
+]
+
+const fullTimeCosts = [
+  { label: 'Base salary', value: '£150,000-£250,000' },
+  { label: 'Employer NI', value: '£18,000-£30,000' },
+  { label: 'Pension', value: '£5,000-£10,000' },
+  { label: 'Benefits', value: '£5,000-£15,000' },
+  { label: 'Recruitment fees', value: '£30,000-£60,000' },
+  { label: 'Equity', value: '0.5-2%' },
+]
+
+const chooseFractional = [
+  'You are pre-seed to Series A',
+  'You need investor-ready numbers before a raise',
+  'Runway is under 18 months and every fixed cost matters',
+  'Your finance work spikes around raises and board meetings',
+  'You want senior judgement without committing equity',
+  'You need someone in place in weeks',
+]
+
+const chooseFullTime = [
+  'You are post-Series B with a finance team to lead',
+  'Regulatory reporting demands a named, permanent officer',
+  'Your model runs on daily commercial decisions at volume',
+  'Investors or your board have made it a condition',
+  'You need 40+ hours a week of finance leadership',
+  'The role is as much people management as financial judgement',
+]
+
+export default function FractionalCFOvsFullTimePage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <JsonLd schema={pageSchema} />
+      <Navigation />
+
+      <main id="main-content">
+
+      {/* Hero */}
+      <section className="pt-24 md:pt-32 pb-16 bg-gradient-to-b from-accent-50 to-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <span className="inline-block px-4 py-2 bg-accent-100 text-accent-800 rounded-full text-sm font-medium mb-6">
+            Comparison Guide
+          </span>
+          <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">
+            Fractional CFO vs Full-Time CFO
+          </h1>
+          <p className="text-xl text-slate-600 max-w-2xl mx-auto">
+            A complete comparison to help UK founders decide which finance leadership model fits their stage and their runway.
+          </p>
+        </div>
+      </section>
+
+      {/* Quick Answer */}
+      <section className="py-12 bg-accent-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="bg-white rounded-2xl p-8 shadow-sm border border-accent-100">
+            <h2 className="text-xl font-bold text-slate-900 mb-4">Quick answer</h2>
+            <p className="text-slate-700 mb-4">
+              <strong>Choose a fractional CFO if:</strong> you are pre-seed to Series A, you need
+              investor-ready financials and a model you can defend, and you would rather spend
+              runway on the product than on a six-figure salary.
+            </p>
+            <p className="text-slate-700">
+              <strong>Choose a full-time CFO if:</strong> you have a finance team to lead, your
+              board has made it a condition of the round, or the job genuinely fills a week.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Comparison Table */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="font-serif text-3xl font-bold text-slate-900 mb-4 text-center">
+            Side-by-side comparison
+          </h2>
+          <p className="text-slate-600 text-center mb-8 max-w-2xl mx-auto">
+            Figures are UK market ranges for 2026, not a price list. What an engagement costs
+            depends on your stage and the intensity you need.
+          </p>
+          {/* Wide content scrolls inside its own container rather than the page. */}
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse bg-white rounded-xl overflow-hidden shadow-sm">
+              <caption className="sr-only">
+                Fractional CFO compared with a full-time CFO hire across cost, dilution, availability and commitment
+              </caption>
+              <thead>
+                <tr className="bg-slate-800 text-white">
+                  <th scope="col" className="px-6 py-4 text-left font-semibold">Factor</th>
+                  <th scope="col" className="px-6 py-4 text-left font-semibold">Fractional CFO</th>
+                  <th scope="col" className="px-6 py-4 text-left font-semibold">Full-Time CFO</th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparisonData.map((row) => (
+                  <tr key={row.factor} className="odd:bg-white even:bg-slate-50">
+                    <th scope="row" className="px-6 py-4 text-left font-medium text-slate-900 border-b border-slate-200">
+                      {row.factor}
+                    </th>
+                    <td className={`px-6 py-4 border-b border-slate-200 ${row.advantage === 'fractional' ? 'text-accent-800 font-semibold' : 'text-slate-600'}`}>
+                      {row.fractional}
+                    </td>
+                    <td className={`px-6 py-4 border-b border-slate-200 ${row.advantage === 'fullTime' ? 'text-primary-700 font-semibold' : 'text-slate-600'}`}>
+                      {row.fullTime}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* Cost Breakdown */}
+      <section className="py-16 bg-slate-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="font-serif text-3xl font-bold text-slate-900 mb-4">
+            The real cost breakdown
+          </h2>
+          <p className="text-slate-600 mb-8 max-w-2xl">
+            A salary is the visible part of a full-time hire. Employer National Insurance, pension,
+            benefits and the recruiter&apos;s fee land in the same year, and the seat usually sits
+            empty for three to six months while you search.
+          </p>
+
+          <div className="grid md:grid-cols-2 gap-8">
+            <div className="bg-white rounded-2xl p-8 border border-slate-200">
+              <h3 className="text-xl font-bold text-accent-800 mb-4">Fractional CFO</h3>
+              <ul className="space-y-3 text-slate-700">
+                {fractionalCosts.map((line) => (
+                  <li key={line.label} className="flex justify-between gap-4">
+                    <span>{line.label}</span>
+                    <span className="font-semibold text-right">{line.value}</span>
+                  </li>
+                ))}
+                <li className="flex justify-between gap-4 pt-3 border-t border-slate-200">
+                  <span className="font-bold">Year-one total</span>
+                  <span className="font-bold text-accent-800 text-right">£24,000-£144,000</span>
+                </li>
+              </ul>
+            </div>
+
+            <div className="bg-white rounded-2xl p-8 border border-slate-200">
+              <h3 className="text-xl font-bold text-slate-700 mb-4">Full-Time CFO</h3>
+              <ul className="space-y-3 text-slate-700">
+                {fullTimeCosts.map((line) => (
+                  <li key={line.label} className="flex justify-between gap-4">
+                    <span>{line.label}</span>
+                    <span className="font-semibold text-right">{line.value}</span>
+                  </li>
+                ))}
+                <li className="flex justify-between gap-4 pt-3 border-t border-slate-200">
+                  <span className="font-bold">Year-one total</span>
+                  <span className="font-bold text-slate-700 text-right">£210,000-£360,000</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <p className="text-slate-600 mt-8">
+            At a typical seed-stage engagement of £3,500 a month, the year-one difference runs to
+            well over £150,000, before counting the equity and the months the seat stands empty.
+            For the full picture, read{' '}
+            <Link href="/blog/how-much-does-fractional-cfo-cost-uk/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+              how much a fractional CFO costs in the UK
+            </Link>.
+          </p>
+        </div>
+      </section>
+
+      {/* When to choose each */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="font-serif text-3xl font-bold text-slate-900 mb-8 text-center">
+            When to choose each option
+          </h2>
+
+          <div className="grid md:grid-cols-2 gap-8">
+            <div className="bg-accent-50 rounded-2xl p-8 border border-accent-200">
+              <h3 className="text-xl font-bold text-slate-900 mb-4">Choose a fractional CFO when:</h3>
+              <ul className="space-y-3">
+                {chooseFractional.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <svg className="w-5 h-5 text-accent-700 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-slate-700">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="bg-slate-100 rounded-2xl p-8 border border-slate-200">
+              <h3 className="text-xl font-bold text-slate-900 mb-4">Choose a full-time CFO when:</h3>
+              <ul className="space-y-3">
+                {chooseFullTime.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <svg className="w-5 h-5 text-primary-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-slate-700">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* What the fractional model gives up */}
+      <section className="py-16 bg-slate-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+            What the fractional model gives up
+          </h2>
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-bold text-slate-900 mb-2">Availability between scheduled days</h3>
+              <p className="text-slate-600 leading-relaxed">
+                A fractional CFO is contactable, but they are not sitting in your standup. If your
+                week turns on finance decisions taken hourly, that gap will show.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-slate-900 mb-2">Line management depth</h3>
+              <p className="text-slate-600 leading-relaxed">
+                Two or three days a week can lead a small finance function. Building and managing a
+                team of eight is a full-time job, and pricing it fractionally is the expensive way
+                to get one.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-slate-900 mb-2">Permanence in the eyes of a regulator</h3>
+              <p className="text-slate-600 leading-relaxed">
+                Some regulated activities expect a named officer with a permanent contract. Check
+                your obligations before assuming a fractional appointment satisfies them.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="p-6 bg-accent-50 rounded-2xl border border-accent-100 text-center">
+            <p className="text-slate-700">
+              Weighing an outsourced provider instead? Read{' '}
+              <Link href="/guides/fractional-cfo-vs-outsourced-finance/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+                Fractional CFO vs Outsourced Finance Function
+              </Link>.
+              {' '}Working out when you need the role at all? Try the free{' '}
+              <Link href="/tools/runway-calculator/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+                Startup Runway Calculator
+              </Link>.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 bg-gradient-to-r from-primary-600 to-primary-700">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent-300 mb-4 font-medium">Financial Leadership</p>
+          <h2 className="font-serif text-3xl font-bold text-white mb-4">
+            Still not sure which is right for you?
+          </h2>
+          <p className="text-xl text-primary-100 mb-8">
+            Request a free 30-minute call. We will help you assess your stage and say so if a
+            fractional CFO is the wrong answer.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/contact/"
+              className="inline-block bg-accent-400 text-primary-900 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg"
+            >
+              Request a Strategy Call
+            </Link>
+            <Link
+              href="/services/fractional-cfo/"
+              className="inline-block border-2 border-primary-300 text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-primary-500/30 transition-all"
+            >
+              Explore Fractional CFO Services
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/app/guides/fractional-cfo-vs-outsourced-finance/page.js
+++ b/app/guides/fractional-cfo-vs-outsourced-finance/page.js
@@ -1,0 +1,289 @@
+import Link from 'next/link'
+import Navigation from '../../components/Navigation'
+import Footer from '../../components/Footer'
+import JsonLd from '../../components/JsonLd'
+import { breadcrumbs, ORGANIZATION_ID } from '../../../lib/schema'
+
+export const metadata = {
+  title: 'Fractional CFO vs Outsourced Finance Function',
+  description: 'Outsourced finance providers run your books; a fractional CFO owns the decisions behind them. What each delivers, where they overlap, and why most UK startups end up with both.',
+  keywords: ['fractional CFO vs outsourced finance', 'outsourced finance function UK', 'finance as a service startup', 'outsourced FD vs fractional CFO', 'startup bookkeeping vs CFO'],
+  openGraph: {
+    title: 'Fractional CFO vs Outsourced Finance Function',
+    description: 'Processing versus judgement: which model your startup needs, and when the answer is both.',
+    type: 'article',
+    url: 'https://codenest.uk/guides/fractional-cfo-vs-outsourced-finance/',
+    images: [
+      {
+        url: '/img/og-default.png',
+        width: 1200,
+        height: 630,
+        alt: 'Codenest - Fractional CTO & CFO for UK startups',
+      },
+    ],
+  },
+  alternates: {
+    canonical: 'https://codenest.uk/guides/fractional-cfo-vs-outsourced-finance/',
+  },
+}
+
+const pageSchema = [
+  breadcrumbs([
+    { name: 'Guides', path: '/guides/' },
+    { name: 'CFO vs Outsourced Finance', path: '/guides/fractional-cfo-vs-outsourced-finance/' },
+  ]),
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: 'Fractional CFO vs Outsourced Finance Function',
+    description: 'What an outsourced finance provider delivers, what a fractional CFO adds on top, and how the two work together.',
+    author: { '@id': ORGANIZATION_ID },
+    publisher: { '@id': ORGANIZATION_ID },
+    datePublished: '2026-08-05',
+    dateModified: '2026-08-05',
+    mainEntityOfPage: 'https://codenest.uk/guides/fractional-cfo-vs-outsourced-finance/',
+    inLanguage: 'en-GB',
+  },
+]
+
+const outsourcedDelivers = [
+  'Bookkeeping and transaction processing',
+  'Payroll and pension administration',
+  'VAT returns and statutory filings',
+  'Monthly management accounts to a standard template',
+  'Accounts payable and receivable runs',
+  'Year-end pack prepared for your accountant',
+]
+
+const cfoAdds = [
+  'A financial model that answers questions the accounts cannot',
+  'Pricing and unit economics analysis with a decision attached',
+  'Scenario planning and rolling forecasts against your runway',
+  'A data room and the diligence answers behind it',
+  'Board packs written for the people who read them',
+  'Ownership of the number when an investor pushes back',
+]
+
+const comparisonData = [
+  { factor: 'Primary output', outsourced: 'Accurate historical records', cfo: 'Forward-looking decisions' },
+  { factor: 'Time horizon', outsourced: 'Last month', cfo: 'Next 18 months' },
+  { factor: 'Typical engagement', outsourced: 'Fixed monthly fee per volume', cfo: 'Retainer scoped to your stage' },
+  { factor: 'Who it reports to', outsourced: 'Your finance lead or founder', cfo: 'Founder and board' },
+  { factor: 'In a fundraise', outsourced: 'Supplies the underlying numbers', cfo: 'Builds and defends the case' },
+  { factor: 'Accountable for', outsourced: 'Accuracy and deadlines', cfo: 'Financial judgement and outcomes' },
+  { factor: 'Replaces the other', outsourced: 'No', cfo: 'No' },
+]
+
+export default function FractionalCFOvsOutsourcedFinancePage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <JsonLd schema={pageSchema} />
+      <Navigation />
+
+      <main id="main-content">
+
+      {/* Hero */}
+      <section className="pt-24 md:pt-32 pb-16 bg-gradient-to-b from-accent-50 to-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <span className="inline-block px-4 py-2 bg-accent-100 text-accent-800 rounded-full text-sm font-medium mb-6">
+            Comparison Guide
+          </span>
+          <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">
+            Fractional CFO vs Outsourced Finance Function
+          </h1>
+          <p className="text-xl text-slate-600 max-w-2xl mx-auto">
+            One keeps your books right. The other decides what to do about what they say. Most UK
+            startups need both, and buying the wrong one first is an expensive way to find out.
+          </p>
+        </div>
+      </section>
+
+      {/* Quick Answer */}
+      <section className="py-12 bg-accent-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="bg-white rounded-2xl p-8 shadow-sm border border-accent-100">
+            <h2 className="text-xl font-bold text-slate-900 mb-4">Quick answer</h2>
+            <p className="text-slate-700 mb-4">
+              <strong>An outsourced finance function</strong> is a processing capability. It closes
+              your month, files your VAT, runs payroll and hands you management accounts. Buy it as
+              soon as the admin outgrows a spreadsheet.
+            </p>
+            <p className="text-slate-700">
+              <strong>A fractional CFO</strong> is a decision capability. They build the model,
+              price the product, plan the runway and answer to your board. Buy it when the
+              decisions get expensive, which for most startups is the raise before Series A.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* What each delivers */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="font-serif text-3xl font-bold text-slate-900 mb-8 text-center">
+            What each one actually delivers
+          </h2>
+
+          <div className="grid md:grid-cols-2 gap-8">
+            <div className="bg-slate-50 rounded-2xl p-8 border border-slate-200">
+              <h3 className="text-xl font-bold text-slate-900 mb-2">Outsourced finance function</h3>
+              <p className="text-sm text-slate-600 mb-5">Bookkeeping firms, finance-as-a-service providers, outsourced FD packages</p>
+              <ul className="space-y-3">
+                {outsourcedDelivers.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <svg className="w-5 h-5 text-primary-600 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-slate-700">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="bg-accent-50 rounded-2xl p-8 border border-accent-200">
+              <h3 className="text-xl font-bold text-slate-900 mb-2">Fractional CFO</h3>
+              <p className="text-sm text-slate-600 mb-5">Senior finance judgement, retained for part of a week</p>
+              <ul className="space-y-3">
+                {cfoAdds.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <svg className="w-5 h-5 text-accent-700 mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-slate-700">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Comparison Table */}
+      <section className="py-16 bg-slate-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="font-serif text-3xl font-bold text-slate-900 mb-8 text-center">
+            Side-by-side comparison
+          </h2>
+          {/* Wide content scrolls inside its own container rather than the page. */}
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse bg-white rounded-xl overflow-hidden shadow-sm">
+              <caption className="sr-only">
+                Outsourced finance function compared with a fractional CFO across output, horizon, accountability and role in a fundraise
+              </caption>
+              <thead>
+                <tr className="bg-slate-800 text-white">
+                  <th scope="col" className="px-6 py-4 text-left font-semibold">Factor</th>
+                  <th scope="col" className="px-6 py-4 text-left font-semibold">Outsourced finance</th>
+                  <th scope="col" className="px-6 py-4 text-left font-semibold">Fractional CFO</th>
+                </tr>
+              </thead>
+              <tbody>
+                {comparisonData.map((row) => (
+                  <tr key={row.factor} className="odd:bg-white even:bg-slate-50">
+                    <th scope="row" className="px-6 py-4 text-left font-medium text-slate-900 border-b border-slate-200">
+                      {row.factor}
+                    </th>
+                    <td className="px-6 py-4 border-b border-slate-200 text-slate-600">{row.outsourced}</td>
+                    <td className="px-6 py-4 border-b border-slate-200 text-slate-600">{row.cfo}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* The usual answer is both */}
+      <section className="py-16">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="font-serif text-3xl font-bold text-slate-900 mb-6">
+            For most startups the answer is both
+          </h2>
+          <p className="text-slate-600 leading-relaxed mb-6">
+            These two roles are complements. The outsourced provider produces clean, timely,
+            reconciled numbers. The fractional CFO takes those numbers and decides what they mean
+            for pricing, hiring, runway and the next raise. Paying a CFO rate for bookkeeping wastes
+            money; asking a bookkeeping provider to own a fundraise asks for judgement you did not
+            buy.
+          </p>
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-lg font-bold text-slate-900 mb-2">The sequence that usually works</h3>
+              <p className="text-slate-600 leading-relaxed">
+                Bookkeeping first, from the moment invoices and payroll stop fitting in a
+                spreadsheet. Fractional CFO second, six to nine months before you intend to raise,
+                so the model and the data room are built before an investor asks for them.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-slate-900 mb-2">The mistake we see most</h3>
+              <p className="text-slate-600 leading-relaxed">
+                Founders assume that a provider producing management accounts is also watching the
+                runway. Management accounts describe what already happened. Nobody is forecasting
+                unless you have asked someone to, and named them.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-slate-900 mb-2">How they should work together</h3>
+              <p className="text-slate-600 leading-relaxed">
+                A fractional CFO should reduce your outsourced bill over time by tightening the
+                chart of accounts, cutting rework at month-end and settling what gets reported. If
+                the two are duplicating each other after a quarter, the scope was drawn wrong.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="p-6 bg-accent-50 rounded-2xl border border-accent-100 text-center">
+            <p className="text-slate-700">
+              Comparing the individual roles instead of the providers? Read{' '}
+              <Link href="/blog/fractional-cfo-vs-accountant-vs-controller/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+                Fractional CFO vs Accountant vs Financial Controller
+              </Link>.
+              {' '}Weighing a permanent hire? Read{' '}
+              <Link href="/guides/fractional-cfo-vs-full-time/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+                Fractional CFO vs Full-Time CFO
+              </Link>.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 bg-gradient-to-r from-primary-600 to-primary-700">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-sm uppercase tracking-[0.2em] text-accent-300 mb-4 font-medium">Financial Leadership</p>
+          <h2 className="font-serif text-3xl font-bold text-white mb-4">
+            Not sure which gap you are filling?
+          </h2>
+          <p className="text-xl text-primary-100 mb-8">
+            Request a free 30-minute call. We will look at what you already have in place and tell
+            you where the actual hole is.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/contact/"
+              className="inline-block bg-accent-400 text-primary-900 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg"
+            >
+              Request a Strategy Call
+            </Link>
+            <Link
+              href="/services/fractional-cfo/"
+              className="inline-block border-2 border-primary-300 text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-primary-500/30 transition-all"
+            >
+              Explore Fractional CFO Services
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      </main>
+
+      <Footer />
+    </div>
+  )
+}

--- a/app/guides/fractional-cto-guide/page.js
+++ b/app/guides/fractional-cto-guide/page.js
@@ -127,7 +127,7 @@ export default function FractionalCTOGuidePage() {
       <main id="main-content">
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
+      <section className="pt-24 md:pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <span className="inline-block px-4 py-2 bg-primary-100 text-primary-700 rounded-full text-sm font-medium mb-6">

--- a/app/guides/fractional-cto-vs-agency/page.js
+++ b/app/guides/fractional-cto-vs-agency/page.js
@@ -66,7 +66,7 @@ export default function FractionalVsAgencyPage() {
       <main id="main-content">
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-to-b from-accent-50 to-white">
+      <section className="pt-24 md:pt-32 pb-16 bg-gradient-to-b from-accent-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <span className="inline-block px-4 py-2 bg-accent-100 text-accent-800 rounded-full text-sm font-medium mb-6">
             Comparison Guide

--- a/app/guides/fractional-cto-vs-full-time/page.js
+++ b/app/guides/fractional-cto-vs-full-time/page.js
@@ -66,7 +66,7 @@ export default function FractionalVsFullTimePage() {
       <main id="main-content">
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-to-b from-slate-50 to-white">
+      <section className="pt-24 md:pt-32 pb-16 bg-gradient-to-b from-slate-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <span className="inline-block px-4 py-2 bg-primary-100 text-primary-700 rounded-full text-sm font-medium mb-6">
             Comparison Guide

--- a/app/guides/page.js
+++ b/app/guides/page.js
@@ -6,7 +6,7 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 
 export const metadata = {
   title: 'Fractional CTO & CFO Guides for UK Founders',
-  description: 'Free in-depth guides for UK startup founders: fractional CTO costs and comparisons, technical co-founder alternatives, and the startup runway calculator.',
+  description: 'Free in-depth guides for UK startup founders: fractional CTO and CFO costs and comparisons, technical co-founder alternatives, and the startup runway calculator.',
   openGraph: {
     title: 'Codenest Guides — Startup Leadership Resources',
     description: 'Free in-depth guides and tools for UK startup founders evaluating fractional CTO and CFO support.',
@@ -40,9 +40,21 @@ const guides = [
     tag: 'Guide',
   },
   {
+    title: 'Fractional CFO vs Full-Time CFO',
+    href: '/guides/fractional-cfo-vs-full-time/',
+    description: 'Year-one costs, equity dilution and time to start, with a decision framework for each stage.',
+    tag: 'Comparison',
+  },
+  {
     title: 'Fractional CTO vs Full-Time CTO',
     href: '/guides/fractional-cto-vs-full-time/',
     description: 'The real cost analysis: salary, equity, hidden costs, and the strategic trade-offs at each stage.',
+    tag: 'Comparison',
+  },
+  {
+    title: 'Fractional CFO vs Outsourced Finance Function',
+    href: '/guides/fractional-cfo-vs-outsourced-finance/',
+    description: 'Processing versus judgement: what each delivers, and why most startups end up with both.',
     tag: 'Comparison',
   },
   {
@@ -82,7 +94,7 @@ export default function GuidesPage() {
       <Navigation />
 
       <main id="main-content">
-        <section className="pt-40 pb-24 bg-white">
+        <section className="pt-28 md:pt-40 pb-24 bg-white">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-16">
               <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Resources</p>

--- a/app/guides/technical-cofounder-alternatives/page.js
+++ b/app/guides/technical-cofounder-alternatives/page.js
@@ -124,7 +124,7 @@ export default function TechnicalCofounderAlternativesPage() {
       <main id="main-content">
 
       {/* Hero */}
-      <section className="pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
+      <section className="pt-24 md:pt-32 pb-16 bg-gradient-to-b from-primary-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <span className="inline-block px-4 py-2 bg-primary-100 text-primary-700 rounded-full text-sm font-medium mb-6">
             Founder Guide

--- a/app/layout.js
+++ b/app/layout.js
@@ -109,16 +109,18 @@ export default function RootLayout({ children }) {
     image: 'https://codenest.uk/img/companylogo.png',
     description: 'Boutique technical and financial advisory for ambitious UK founders. Big 4 rigour meets founder empathy. Fractional CTO and CFO services with executive firepower.',
     priceRange: '£££',
+    // The registered office — the only address the site publishes, and the one in
+    // the statutory footer disclosure. It previously claimed London with the
+    // generic 51.5074/-0.1278 city centroid, an address the business does not
+    // occupy paired with coordinates nobody measured. The `geo` block is gone
+    // rather than re-guessed. (BRANDING.md §13.25.)
     address: {
       '@type': 'PostalAddress',
-      addressLocality: 'London',
-      addressRegion: 'Greater London',
+      streetAddress: 'Clearways Accountants, Clearways, Colley Way',
+      addressLocality: 'Reigate',
+      addressRegion: 'Surrey',
+      postalCode: 'RH2 9JH',
       addressCountry: 'GB'
-    },
-    geo: {
-      '@type': 'GeoCoordinates',
-      latitude: 51.5074,
-      longitude: -0.1278
     },
     areaServed: [
       {
@@ -158,6 +160,11 @@ export default function RootLayout({ children }) {
       'Technical Co-founder Partnerships',
       'Startup Equity Partnerships'
     ],
+    // The single offer catalogue for the site. The homepage carried a second,
+    // shorter one (three offers, its own ProfessionalService provider) that had
+    // drifted from this list; it was removed rather than kept in sync. Two
+    // retained seats plus the two fixed-fee project shapes named in "How We Work"
+    // — nothing else the site sells is a separate purchase.
     hasOfferCatalog: {
       '@type': 'OfferCatalog',
       name: 'Startup Leadership Services',
@@ -190,7 +197,7 @@ export default function RootLayout({ children }) {
           '@type': 'Offer',
           itemOffered: {
             '@type': 'Service',
-            name: 'Financial Modeling & Strategy',
+            name: 'Financial Modelling & Strategy',
             description: 'Financial models, unit economics, and fundraising preparation'
           }
         }

--- a/app/not-found.js
+++ b/app/not-found.js
@@ -17,7 +17,7 @@ export default function NotFound() {
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
       <Navigation />
 
-      <section className="pt-40 pb-32">
+      <section className="pt-28 md:pt-40 pb-32">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h1 className="text-8xl font-bold text-primary-600 mb-4">404</h1>
           <h2 className="text-3xl md:text-4xl font-bold text-slate-900 mb-6">

--- a/app/page.js
+++ b/app/page.js
@@ -57,52 +57,11 @@ export default function Home() {
     }))
   }
 
-  // Service Schema for SEO
-  const serviceSchema = {
-    '@context': 'https://schema.org',
-    '@type': 'Service',
-    serviceType: 'Business Consulting',
-    provider: {
-      '@type': 'ProfessionalService',
-      name: 'Codenest',
-      url: 'https://codenest.uk'
-    },
-    areaServed: {
-      '@type': 'Country',
-      name: 'United Kingdom'
-    },
-    hasOfferCatalog: {
-      '@type': 'OfferCatalog',
-      name: 'Startup Advisory Services',
-      itemListElement: [
-        {
-          '@type': 'Offer',
-          itemOffered: {
-            '@type': 'Service',
-            name: 'Fractional CTO',
-            description: 'Part-time technical leadership for startups. Architecture decisions, team building, and investor readiness.'
-          }
-        },
-        {
-          '@type': 'Offer',
-          itemOffered: {
-            '@type': 'Service',
-            name: 'Fractional CFO',
-            description: 'Part-time financial leadership for startups. Financial modeling, fundraising support, and strategic planning.'
-          }
-        },
-        {
-          '@type': 'Offer',
-          itemOffered: {
-            '@type': 'Service',
-            name: '0-to-1 Product Development',
-            description: 'End-to-end MVP development from strategy to launch.'
-          }
-        }
-      ]
-    }
-  }
-
+  // No Service/OfferCatalog block here. The root layout already declares the
+  // company and everything it sells; this page used to restate both, and its
+  // `provider` was a second ProfessionalService node for the same business
+  // (BRANDING.md §8: ProfessionalService lives in the root layout ONLY). The two
+  // catalogues had also drifted apart — four offers in the layout, three here.
   return (
     <div className="min-h-screen bg-white">
       {/* Structured Data for SEO */}
@@ -110,28 +69,27 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceSchema) }}
-      />
       <Navigation />
 
       <main id="main-content">
 
       {/* Hero Section */}
-      <section id="home" className="pt-44 pb-32 bg-white">
+      {/* At 375px this hero measured 1798px tall — 2.2 screens, with the primary
+          CTA below the fold. Every size below steps up at a breakpoint rather
+          than carrying its desktop value down to mobile. */}
+      <section id="home" className="pt-28 md:pt-44 pb-20 md:pb-32 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-20 items-center">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 items-center">
             <div>
-              <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-8 font-medium animate-hero-1">
+              <p className="text-xs sm:text-sm uppercase tracking-[0.2em] text-accent-700 mb-6 md:mb-8 font-medium animate-hero-1">
                 Fractional CTO &amp; CFO for UK Startups
               </p>
-              <h1 className="font-serif text-5xl md:text-6xl font-normal text-slate-900 leading-[1.1] mb-6 animate-hero-2">
+              <h1 className="font-serif text-4xl sm:text-5xl md:text-6xl font-normal text-slate-900 leading-[1.1] mb-6 animate-hero-2">
                 Executive Firepower.<br />
                 <span className="italic">Startup Agility.</span>
               </h1>
               <p className="text-xl text-slate-600 mb-6 leading-relaxed max-w-lg animate-hero-3">
-                Big 4 rigour meets founder empathy. Your part-time CTO and CFO in one engagement: architecture, engineering leadership, financial models, and fundraising for founders from pre-seed to Series A.
+                Big 4 rigour meets founder empathy. A part-time CTO, a part-time CFO, or both: architecture, engineering leadership, financial models, and fundraising for founders from pre-seed to Series A.
               </p>
               <ul className="space-y-4 mb-8 max-w-lg animate-hero-3">
                 <li className="flex items-start text-slate-700 group">
@@ -172,20 +130,20 @@ export default function Home() {
               <div className="absolute -inset-1 bg-gradient-to-br from-accent-400/30 via-accent-500/20 to-transparent rounded-2xl blur-sm" />
               {/* Two halves, equal height: the offer is 50/50 and the hero has to
                   show it. Real proof beats a stock photo of people at laptops. */}
-              <div className="relative rounded-xl overflow-hidden min-h-[520px] ring-1 ring-accent-400/20 shadow-xl flex flex-col">
-                <div className="flex-1 bg-primary-800 p-8 flex flex-col justify-center">
+              <div className="relative rounded-xl overflow-hidden min-h-[400px] sm:min-h-[520px] ring-1 ring-accent-400/20 shadow-xl flex flex-col">
+                <div className="flex-1 bg-primary-800 p-6 sm:p-8 flex flex-col justify-center">
                   <p className="text-xs uppercase tracking-[0.2em] text-accent-300 mb-4 font-semibold">Fractional CTO</p>
                   <p className="font-serif text-4xl md:text-5xl font-bold text-white mb-3">5 &rarr; 1,000+</p>
-                  <p className="text-slate-300 text-sm mb-4">Concurrent users scaled at Rungway</p>
+                  <p className="text-slate-300 text-sm mb-4">Concurrent users at Rungway, where Ankit was interim CTO</p>
                   <p className="text-slate-300 text-xs">Architecture, engineering leadership, delivery</p>
                 </div>
 
                 <div className="h-px bg-gradient-to-r from-transparent via-accent-400 to-transparent" />
 
-                <div className="flex-1 bg-white p-8 flex flex-col justify-center">
+                <div className="flex-1 bg-white p-6 sm:p-8 flex flex-col justify-center">
                   <p className="text-xs uppercase tracking-[0.2em] text-accent-700 mb-4 font-semibold">Fractional CFO</p>
                   <p className="font-serif text-3xl sm:text-4xl md:text-5xl font-bold text-slate-900 mb-3">&pound;35m &rarr; &pound;165m</p>
-                  <p className="text-slate-600 text-sm mb-4">Revenue scaled, EBITDA margin up 4%</p>
+                  <p className="text-slate-600 text-sm mb-4">Revenue at Dishoom, where Michelle led strategic finance</p>
                   <p className="text-slate-500 text-xs">Financial models, controls, fundraising</p>
                 </div>
               </div>
@@ -595,7 +553,7 @@ export default function Home() {
               <svg className="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
               </svg>
-              Free initial consultation
+              Free 30-minute consultation
             </div>
           </div>
 

--- a/app/privacy/page.js
+++ b/app/privacy/page.js
@@ -76,7 +76,7 @@ export default function PrivacyPolicyPage() {
       <Navigation />
 
       <main id="main-content">
-        <section className="pt-40 pb-24 bg-white">
+        <section className="pt-28 md:pt-40 pb-24 bg-white">
           <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="mb-14">
               <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Legal</p>

--- a/app/refer/page.js
+++ b/app/refer/page.js
@@ -118,7 +118,7 @@ export default function ReferralPage() {
       <main id="main-content">
 
       {/* Hero Section */}
-      <section className="pt-32 pb-20 bg-gradient-to-br from-slate-900 to-slate-800 text-white">
+      <section className="pt-24 md:pt-32 pb-20 bg-gradient-to-br from-slate-900 to-slate-800 text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <p className="text-sm uppercase tracking-[0.2em] text-accent-400 mb-6 font-medium">
             Referral Program

--- a/app/services/fractional-cfo/page.js
+++ b/app/services/fractional-cfo/page.js
@@ -131,11 +131,10 @@ export default function FractionalCFOPage() {
     '@type': 'Service',
     name: 'Fractional CFO Services',
     description: 'Part-time financial leadership for startups. FP&A, financial modeling, and fundraising support.',
-    provider: {
-      '@type': 'Organization',
-      name: 'Codenest',
-      url: 'https://codenest.uk'
-    },
+    // Reference the root layout's ProfessionalService by @id rather than
+    // restating it: a second, differently-shaped Organization node for the same
+    // business invites Google to treat them as two companies.
+    provider: { '@id': ORGANIZATION_ID },
     areaServed: {
       '@type': 'Country',
       name: 'United Kingdom'
@@ -161,7 +160,7 @@ export default function FractionalCFOPage() {
       <main id="main-content">
 
       {/* Hero Section */}
-      <section className="pt-40 pb-24 bg-gradient-to-b from-accent-50 to-white">
+      <section className="pt-28 md:pt-40 pb-24 bg-gradient-to-b from-accent-50 to-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div>
@@ -179,7 +178,11 @@ export default function FractionalCFOPage() {
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Button href="/contact/">Request a Strategy Call</Button>
-                <Button href="/case-studies/" variant="secondary">See Our Results</Button>
+                {/* Not /case-studies: every study there is a technical engagement,
+                    so a CFO buyer clicking through for proof landed on three
+                    Kubernetes write-ups. /about carries Michelle's actual record
+                    until this seat has case studies of its own. */}
+                <Button href="/about/" variant="secondary">Meet Your Fractional CFO</Button>
               </div>
             </div>
             <div className="relative">
@@ -306,6 +309,13 @@ export default function FractionalCFOPage() {
               New to strategic finance? Read{' '}
               <Link href="/guides/fractional-cfo-guide/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
                 The Complete Guide to Fractional CFO Services
+              </Link>.
+              {' '}Weighing this against a permanent hire or an outsourced provider? Compare{' '}
+              <Link href="/guides/fractional-cfo-vs-full-time/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+                fractional vs full-time CFO
+              </Link>{' '}and{' '}
+              <Link href="/guides/fractional-cfo-vs-outsourced-finance/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
+                fractional CFO vs outsourced finance
               </Link>.
               {' '}Not sure when you&apos;ll need to raise? Try our free{' '}
               <Link href="/tools/runway-calculator/" className="font-semibold text-accent-700 hover:text-accent-800 underline">

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -142,11 +142,10 @@ export default function FractionalCTOPage() {
     '@type': 'Service',
     name: 'Fractional CTO Services',
     description: 'Part-time technical leadership for startups. Architecture, team building, and strategic guidance.',
-    provider: {
-      '@type': 'Organization',
-      name: 'Codenest',
-      url: 'https://codenest.uk'
-    },
+    // Reference the root layout's ProfessionalService by @id rather than
+    // restating it: a second, differently-shaped Organization node for the same
+    // business invites Google to treat them as two companies.
+    provider: { '@id': ORGANIZATION_ID },
     areaServed: {
       '@type': 'Country',
       name: 'United Kingdom'
@@ -172,7 +171,7 @@ export default function FractionalCTOPage() {
       <main id="main-content">
 
       {/* Hero Section */}
-      <section className="pt-40 pb-24 bg-gradient-to-b from-primary-50 to-white">
+      <section className="pt-28 md:pt-40 pb-24 bg-gradient-to-b from-primary-50 to-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div>
@@ -190,7 +189,7 @@ export default function FractionalCTOPage() {
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Button href="/contact/">Request a Strategy Call</Button>
-                <Button href="/case-studies/" variant="secondary">View Client Outcomes</Button>
+                <Button href="/case-studies/" variant="secondary">View Case Studies</Button>
               </div>
             </div>
             <div className="relative">

--- a/app/services/page.js
+++ b/app/services/page.js
@@ -5,12 +5,16 @@ import Footer from '../components/Footer'
 import JsonLd from '../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 
+// This page used to restate the homepage's two-track section almost verbatim —
+// same descriptions, same eight bullets — and competed with it for the same
+// queries. It now answers the question the homepage does not: which seat do I
+// need? The capability grid below stays, because that is genuinely only here.
 export const metadata = {
-  title: 'Fractional CTO & CFO Services for UK Startups',
-  description: 'Two executive seats, each engageable on its own. Fractional CTO and Fractional CFO services for UK startups, pre-seed to Series A, and what each engagement covers.',
+  title: 'Fractional CTO or CFO: Which Does Your Startup Need?',
+  description: 'Which executive seat your startup needs now. The signals that point to a Fractional CTO, the signals that point to a Fractional CFO, and what each engagement covers. Either is engageable on its own.',
   openGraph: {
-    title: 'Codenest Services — Fractional CTO & Fractional CFO',
-    description: 'Technical and financial leadership for UK startups, pre-seed to Series A.',
+    title: 'Fractional CTO or Fractional CFO: Which Does Your Startup Need?',
+    description: 'The signals that point to each seat, and what each engagement covers. UK startups, pre-seed to Series A.',
     type: 'website',
     url: 'https://codenest.uk/services/',
     images: [
@@ -27,32 +31,87 @@ export const metadata = {
   },
 }
 
+// Deliberately not the homepage's bullet lists. Those four-item lists are
+// repeated verbatim in the capability grid further down this page; here the
+// cards carry what the seat owns and who leads it, and route onward.
 const tracks = [
   {
     name: 'Fractional CTO',
     href: '/services/fractional-cto/',
     accent: 'primary',
-    description: 'Architecture decisions, engineering team building, and infrastructure that scales from day one.',
-    items: [
-      'Technical Strategy & Architecture',
-      '0-to-1 Product Builds',
-      'AI & Data Engineering',
-      'DevOps & Platform Engineering',
-    ],
+    principal: 'Led by Ankit Rana',
+    owns: 'The technical plan, and the team that has to deliver it.',
+    bestFor: 'Founders carrying technical risk they cannot evaluate on their own.',
   },
   {
     name: 'Fractional CFO',
     href: '/services/fractional-cfo/',
     accent: 'accent',
-    description: 'Strategic finance, FP&A, and the financial discipline that makes your startup investable.',
+    principal: 'Led by Michelle Rana FCCA',
+    owns: 'The financial plan, and the numbers an investor will test.',
+    bestFor: 'Founders whose next decision has a cash consequence they cannot model.',
+  },
+]
+
+// The decision aid. Symptoms a founder would recognise in their own week, rather
+// than a list of capabilities they would have to translate first.
+const signals = [
+  {
+    heading: 'Signs you need the Fractional CTO',
+    accent: 'primary',
     items: [
-      'Financial Modeling & FP&A',
-      'Business Strategy & Planning',
-      'Fundraising & Investor Relations',
-      'Due Diligence Preparation',
+      'You are making architecture decisions you have no way to evaluate',
+      'The roadmap slips and you cannot tell whether the estimate or the execution was wrong',
+      'You are about to hire engineers and have nobody to interview them',
+      'Technical due diligence is coming and nobody owns the answers',
+      'Your build is outsourced and you have no independent read on its quality',
+      'Infrastructure cost is climbing faster than usage',
+    ],
+  },
+  {
+    heading: 'Signs you need the Fractional CFO',
+    accent: 'accent',
+    items: [
+      'You cannot state your runway without rebuilding a spreadsheet first',
+      'An investor asked for a model and you are starting from a blank page',
+      'You price on instinct and margin is drifting',
+      'Month-end takes two weeks and the numbers still get argued about',
+      'A raise is six to nine months out and there is no data room',
+      'The board pack gets assembled the night before',
+    ],
+  },
+  {
+    heading: 'Signs you need both',
+    accent: 'dark',
+    items: [
+      'Your hiring plan and your engineering roadmap are two documents that disagree',
+      'You are raising on a technical story the financial model does not support',
+      'Build-versus-buy and runway keep arriving as the same question',
+      'You are at 0-to-1, where every technical decision has an immediate cash consequence',
     ],
   },
 ]
+
+const SIGNAL_STYLES = {
+  primary: {
+    card: 'bg-primary-50 border-primary-200',
+    heading: 'text-slate-900',
+    icon: 'text-primary-600',
+    text: 'text-slate-700',
+  },
+  accent: {
+    card: 'bg-accent-50 border-accent-200',
+    heading: 'text-slate-900',
+    icon: 'text-accent-700',
+    text: 'text-slate-700',
+  },
+  dark: {
+    card: 'bg-primary-800 border-primary-800',
+    heading: 'text-white',
+    icon: 'text-accent-300',
+    text: 'text-slate-300',
+  },
+}
 
 // Capabilities delivered inside a seat — not services you buy separately, and not
 // pages. They render as static tiles (see ServiceCard). The two seats themselves are
@@ -112,7 +171,7 @@ const pageSchema = [
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'Codenest Services',
-    description: 'Fractional CTO and Fractional CFO services for UK startups.',
+    description: 'The two executive seats Codenest offers UK startups, each engageable on its own.',
     itemListElement: tracks.map((track, index) => ({
       '@type': 'ListItem',
       position: index + 1,
@@ -130,13 +189,58 @@ export default function ServicesPage() {
       <Navigation />
 
       <main id="main-content">
-        <section className="pt-40 pb-24 bg-white">
+        <section className="pt-28 md:pt-40 pb-24 bg-white">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-16">
-              <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Two Executive Seats</p>
-              <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Fractional CTO &amp; CFO Services</h1>
+              <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Choosing a seat</p>
+              <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">
+                Fractional CTO or Fractional CFO?
+              </h1>
               <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-                Two seats, each engageable on its own. Take the one you need now, or both and get a roadmap and a financial plan that already agree.
+                Which seat your startup needs now, what each one owns, and what an engagement
+                covers. Either is engageable on its own; taking both is an option rather than a
+                condition.
+              </p>
+            </div>
+
+            {/* The decision aid this page exists for. Three panels rather than the
+                two-card grid the homepage already runs (BRANDING.md §5). */}
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-20">
+              {signals.map((group) => {
+                const style = SIGNAL_STYLES[group.accent]
+                return (
+                  <div key={group.heading} className={`rounded-xl border p-8 ${style.card}`}>
+                    <h2 className={`text-lg font-bold mb-5 ${style.heading}`}>{group.heading}</h2>
+                    <ul className="space-y-3">
+                      {group.items.map((item) => (
+                        <li key={item} className="flex items-start gap-3">
+                          <svg
+                            className={`w-5 h-5 mt-0.5 flex-shrink-0 ${style.icon}`}
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            aria-hidden="true"
+                          >
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                          </svg>
+                          <span className={`text-sm leading-relaxed ${style.text}`}>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )
+              })}
+            </div>
+
+            {/* The two approved declines, worded as on the homepage. Nothing else
+                goes in here without owner sign-off (BRANDING.md §13.17). */}
+            <div className="max-w-3xl mx-auto mb-20 border-l-4 border-slate-300 pl-6">
+              <h2 className="text-lg font-bold text-slate-900 mb-3">When neither seat is the answer</h2>
+              <p className="text-slate-600 leading-relaxed">
+                If technology is your moat, a novel algorithm or custom hardware needs someone in
+                the building full time with their name on it. And if you need someone 40+ hours a
+                week, you are describing a permanent hire, where paying fractional rates is the
+                expensive route. We would rather say that on the first call than in the third month.
               </p>
             </div>
 
@@ -150,23 +254,20 @@ export default function ServicesPage() {
                       : 'bg-gradient-to-br from-primary-50 to-white border-primary-200 hover:border-primary-400 hover:shadow-lg'
                   }`}
                 >
-                  <h2 className="text-2xl font-bold text-slate-900 mb-4">{track.name}</h2>
-                  <p className="text-slate-600 mb-6 leading-relaxed">{track.description}</p>
-                  <ul className="space-y-3 mb-8">
-                    {track.items.map((item) => (
-                      <li key={item} className="flex items-center text-slate-700">
-                        <svg
-                          className={`w-5 h-5 mr-3 ${track.accent === 'accent' ? 'text-accent-500' : 'text-primary-600'}`}
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                        </svg>
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
+                  <h2 className="text-2xl font-bold text-slate-900 mb-1">{track.name}</h2>
+                  <p className={`text-sm font-semibold mb-5 ${track.accent === 'accent' ? 'text-accent-700' : 'text-primary-700'}`}>
+                    {track.principal}
+                  </p>
+                  <dl className="space-y-4 mb-8">
+                    <div>
+                      <dt className="text-xs uppercase tracking-[0.15em] text-slate-600 font-semibold mb-1">Owns</dt>
+                      <dd className="text-slate-700 leading-relaxed">{track.owns}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs uppercase tracking-[0.15em] text-slate-600 font-semibold mb-1">Best for</dt>
+                      <dd className="text-slate-700 leading-relaxed">{track.bestFor}</dd>
+                    </div>
+                  </dl>
                   <Link
                     href={track.href}
                     className={`inline-flex items-center font-semibold ${
@@ -174,7 +275,7 @@ export default function ServicesPage() {
                     }`}
                   >
                     Explore {track.name} Services
-                    <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <svg className="w-5 h-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
                     </svg>
                   </Link>

--- a/app/tools/runway-calculator/page.js
+++ b/app/tools/runway-calculator/page.js
@@ -53,7 +53,7 @@ export default function RunwayCalculatorPage() {
       <main id="main-content">
 
       {/* Hero */}
-      <section className="pt-32 pb-12 bg-gradient-to-b from-accent-50 to-white">
+      <section className="pt-24 md:pt-32 pb-12 bg-gradient-to-b from-accent-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <span className="inline-block px-4 py-2 bg-accent-100 text-accent-800 rounded-full text-sm font-medium mb-6">
             Free Tool


### PR DESCRIPTION
Follow-up to the site review. The site's structure said "two executive seats" while every proof and attribution surface said one. This closes that gap where the fix was mechanical, and records in `BRANDING.md` what still needs owner input.

## Messaging and attribution

- **The hero sold a bundle.** "Your part-time CTO and CFO **in one engagement**" sat ~200px above "Take either seat on its own, or both". The hero is the most-read sentence on the site and it contradicted BRANDING §27. Now: "A part-time CTO, a part-time CFO, or both".
- **"Our founder" x3** in the case studies, against §13.14 and against `/about`'s own "two executives, not one generalist". Now "Ankit", with the page sub naming him so the first name resolves.
- **Pre-Codenest work was labelled client work** in three places: the case-studies OG title, the footer nav item, and the CTO page CTA. Rungway and Opayo are founder track record (§13.15).
- **The ItemList schema claimed "technical and financial leadership engagements"** on a page with no financial ones.
- **The hero's CFO stat was unattributed.** The CTO half named Rungway; the CFO half said only "Revenue scaled, EBITDA margin up 4%", reading as a Codenest outcome. Both halves now name their engagement and principal, role-framed per §13.15.
- **The CFO page's "See Our Results"** delivered three Kubernetes case studies. It now routes to `/about`, the only page carrying Michelle's record, until the CFO seat has studies of its own.

## Address (§13.25, previously flagged unresolved)

The `ProfessionalService` schema claimed London with the generic `51.5074/-0.1278` city centroid, for an address the business does not occupy. It now carries the registered office — the only address the site publishes — and the `geo` block is removed rather than re-guessed. The footer's "London-based" line is dropped.

## Schema (§8)

Deleted the homepage `Service` block. Its `provider` was a second `ProfessionalService` node for the same company, and its three-offer catalogue had drifted from the layout's four. One catalogue now, in the layout; both service pages reference the org by `@id` (the import was already there, unused).

## Mobile

Every hero carried its desktop top padding straight down to mobile.

| At 375px | Before | After |
|---|---|---|
| Homepage hero height | 1798px (2.2 screens) | **1411px** |
| Primary CTA offset | 825px (below the 812px fold) | **746px** |
| H1 size | 48px | 36px |

## `/services` is now the decision page

It restated the homepage's two-track section almost verbatim — same descriptions, same eight bullets — and competed with it for the same queries. Rewritten around the question neither page answered: *which seat do I need?* Signal lists written as symptoms a founder recognises, the two owner-approved declines (§13.17, nothing added), and the capability grid that is genuinely only here. Track cards now give what each seat owns and who leads it.

## Content and navigation

- **Two CFO guides**, bringing guides to 3 CTO / 3 CFO (§12). Figures match the published CFO cost post and are labelled as UK market ranges, not our prices (§13.24).
  - The second guide compares outsourced **providers** rather than individual **roles**, so it does not cannibalise the existing accountant-vs-controller post — the same duplication problem `/services` had. The two cross-link.
- **Resources dropdown** (Guides, Blog, Runway Calculator) replaces the standalone Blog slot. Five guides and the calculator were reachable only from the footer. Slot count unchanged at four plus the CTA. Extracted `NavDropdown` rather than duplicating ~80 lines of focus management.

## Verification

- `npm run build` clean, 44 pages (was 42)
- All JSON-LD parses; homepage is now `ProfessionalService | WebSite | FAQPage`, one of each
- Zero WCAG AA failures across the changed pages, checked by walking every text node against its effective background (gradient stops included)
- No console errors; no horizontal scroll at 375px; wide tables scroll inside their own container
- Dropdown keyboard behaviour verified unchanged after the refactor: ArrowDown opens and focuses the first item, Escape closes and returns focus to the button, the two menus operate independently

## Still needs owner input

Not in this PR:

1. **Citable, permissioned CFO case studies** — the largest remaining credibility gap
2. **Naming the principals on the service pages** with a proof line
3. **Real headshots** — `/about` still renders letter-avatar placeholders, against §5
4. **`/case-studies` still titled "Fractional CTO & CFO Outcomes"** with no CFO content. Changing it now and again after (1) means two title changes, so it is left for you to call
5. **`github.com/cod3nest` in `sameAs`** — §1 bars the legacy name from schema, but `sameAs` is legitimate entity disambiguation. Which rule wins is your call
6. **Service page titles still target "London"** — noted in BRANDING as open, pending (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
