### PR TITLE
Remove the legacy cod3nest identifier from public surfaces

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -298,6 +298,14 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
 5. **Tagline is "Big 4 rigour meets founder empathy"** + flourish "Executive
    firepower. Startup agility." — all other slogans retired. (4 Aug 2026.)
 6. **"cod3nest" never appears in user-facing surfaces.** (4 Aug 2026.)
+   **Enforced 5 Aug 2026:** the GitHub org URL was removed from the
+   `ProfessionalService` `sameAs` in `app/layout.js` and from `public/humans.txt`.
+   The `sameAs` entry was a genuine entity-disambiguation signal for Google, and the
+   owner chose this rule over that signal — do not reinstate it as an SEO
+   improvement. **One unavoidable exception:** `GiscusComments.js` passes
+   `data-repo="cod3nest/cod3nest.github.io"`, which is functional configuration
+   rather than copy, and comments break without it. It stays until the repository
+   itself is renamed.
 7. **No emojis.** (Project CLAUDE.md, standing.)
 8. **No gold text on white below AA contrast.** (4 Aug 2026.)
 9. **One FAQPage schema per page, owned by the page.** (4 Aug 2026.)

--- a/app/layout.js
+++ b/app/layout.js
@@ -132,9 +132,12 @@ export default function RootLayout({ children }) {
         name: 'Europe'
       }
     ],
+    // LinkedIn only. The GitHub org URL was the one place the legacy `cod3nest`
+    // identifier still reached a public surface, and §1 bars it from schema by
+    // name. It was a real entity-disambiguation signal; the owner chose the rule
+    // over the signal (5 Aug 2026).
     sameAs: [
-      'https://www.linkedin.com/company/codenest-ltd',
-      'https://github.com/cod3nest'
+      'https://www.linkedin.com/company/codenest-ltd'
     ],
     contactPoint: {
       '@type': 'ContactPoint',

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -2,7 +2,6 @@
 Company: Codenest Ltd
 Site: https://codenest.uk
 LinkedIn: https://www.linkedin.com/company/codenest-ltd
-GitHub: https://github.com/cod3nest
 Location: United Kingdom
 
 /* THANKS */
@@ -10,7 +9,7 @@ Built with: Next.js 15, TailwindCSS
 Hosted on: GitHub Pages
 
 /* SITE */
-Last update: 2024/11/05
+Last update: 2026/08/05
 Standards: HTML5, CSS3, ES2024
 Components: React, EmailJS
 SEO: Optimized with structured data, sitemap, and semantic HTML


### PR DESCRIPTION
Closes item 5 from the [site review](https://github.com/cod3nest/cod3nest.github.io/pull/44). BRANDING §1 bars the legacy `cod3nest` org name from copy, schema and user-facing links by name. Two surfaces still carried it.

## Changes

**`app/layout.js`** — dropped the GitHub org URL from the `ProfessionalService` `sameAs`, leaving LinkedIn.

This was the trade-off flagged in the review: `sameAs` is a genuine entity-disambiguation signal for Google, so removing it has a real if small cost. You chose the rule over the signal. That reasoning is recorded in BRANDING §13.6 and in a comment at the call site, so it does not get quietly reinstated later as an SEO improvement.

**`public/humans.txt`** — dropped the `GitHub:` line. This one was a new find while auditing for other occurrences; it is the same violation with nothing on the other side of the scale, so I applied your decision to it rather than leaving a known breach in place. Say the word if you'd rather it stayed.

While in that file I also corrected its own `Last update`, which still read `2024/11/05`. Leaving a false date on a file I was editing seemed worse than the small scope creep.

## One occurrence stays

`app/components/GiscusComments.js` passes `data-repo="cod3nest/cod3nest.github.io"`. That is functional configuration rather than copy, and blog comments break without it — the repository really is named that. It is recorded in BRANDING as an explicit exception until the repo itself is renamed.

## Verification

- `npm run build` clean
- `"sameAs":["https://www.linkedin.com/company/codenest-ltd"]` in the built schema
- No HTML, sitemap, feed, manifest or text file in `out/` contains the string; the sole match across the whole build is the Giscus attribute in one JS chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
