### PR TITLE
Retitle /case-studies to the engagements it actually holds

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -325,6 +325,11 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     it is not a client wall, and nothing may relabel it as one. Attribute Dishoom's
     numbers to Michelle's *role* ("led strategic finance at Dishoom through
     £35m → £165m"), never to her personally growing the company. (Owner, 4 Aug 2026.)
+    **`/case-studies` is CTO-only until it is not** (5 Aug 2026): all three studies are
+    technical, so the page title, meta description, OG description, h1, sub and
+    ItemList schema all say "Fractional CTO" and name Ankit. It previously advertised
+    "Fractional CTO & CFO Outcomes" against no CFO content. Restore the dual framing in
+    the same change that adds a CFO study, and never ahead of one.
 16. **Michelle covers both operational finance and fundraising.** Her CV documents the
     operational side in detail — multi-site P&L, budgeting and rolling forecasts,
     controls and governance, margin and procurement, Board reporting — and the owner

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -3,12 +3,17 @@ import Footer from '../components/Footer'
 import JsonLd from '../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 
+// Every study on this page is technical. The title claimed "CTO & CFO Outcomes"
+// against no CFO content at all, and the description opened "How Codenest scaled
+// Rungway", which attributes founder track record to the firm (§13.15). Both now
+// say what the page holds. Restore the dual framing when the CFO seat has studies
+// of its own, and not before.
 export const metadata = {
-  title: 'Case Studies: Fractional CTO & CFO Outcomes',
-  description: 'How Codenest scaled Rungway from 5 to 1,000+ concurrent users, modernised payment infrastructure at Opayo, and delivered a compliant MVP for AstraZeneca.',
+  title: 'Case Studies: Fractional CTO Engagements',
+  description: 'Technical engagements led by Ankit Rana, Fractional CTO: scaling Rungway to 1,000+ concurrent users, transforming payments at Opayo, and a compliant MVP for AstraZeneca.',
   openGraph: {
     title: 'Codenest Case Studies — Track Record',
-    description: 'Startup outcomes, backed by enterprise-grade experience. Rungway, Opayo by Elavon, AstraZeneca.',
+    description: 'Technical leadership engagements led by Ankit Rana, Fractional CTO. Rungway, Opayo by Elavon, AstraZeneca.',
     type: 'website',
     url: 'https://codenest.uk/case-studies/',
     images: [
@@ -84,7 +89,9 @@ export default function CaseStudiesPage() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-20">
               <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Proven Track Record</p>
-              <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Case Studies</h1>
+              {/* Carries the target term, per §8. A bare "Case Studies" h1 sat
+                  under a title that named the service and matched neither. */}
+              <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Fractional CTO Case Studies</h1>
               <p className="text-xl text-slate-600 max-w-3xl mx-auto">
                 Technical engagements led by Ankit Rana, Fractional CTO. Deep, hands-on collaboration at every stage
               </p>


### PR DESCRIPTION
Closes item 4 from the [site review](https://github.com/cod3nest/cod3nest.github.io/pull/44).

All three case studies are technical engagements. The page advertised **"Case Studies: Fractional CTO & CFO Outcomes"** against no CFO content — a claim it cannot back (§2.2) — and opened its meta description with "How Codenest scaled Rungway", crediting founder track record to the firm (§13.15).

## Changes

| | Before | After |
|---|---|---|
| `title` | Case Studies: Fractional CTO & CFO Outcomes | **Case Studies: Fractional CTO Engagements** |
| `description` | "How Codenest scaled Rungway from 5 to 1,000+…" | Names Ankit; describes the three engagements without crediting them to Codenest |
| OG description | "Startup outcomes, backed by enterprise-grade experience." | "Technical leadership engagements led by Ankit Rana, Fractional CTO." |
| `h1` | Case Studies | **Fractional CTO Case Studies** |

The `h1` was slightly beyond your literal ask, so flag it if you'd rather it stayed. A bare "Case Studies" carried none of the page's target term while sitting under a title that named the service, which §8 rules against — and after the title change the two no longer matched each other. Easy to revert on its own.

## This is reversible by design

BRANDING §13.15 now records that `/case-studies` is CTO-only *until it is not*: the dual framing goes back in the same change that adds a CFO case study, and never ahead of one. That is deliberately written as a condition rather than a to-do, so nobody restores the wider claim before the content exists.

## Verification

- `npm run build` clean
- Rendered title is 51 characters including the ` | Codenest` template, inside budget
- No CFO claim survives inside `<main>` or the `ItemList` schema
- The `CFO` strings still present in the HTML are nav links, footer links and logo alt text — sitewide chrome, not claims about this page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
