### PR TITLE
Drop the London geo-targeting from service page metadata

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -39,7 +39,9 @@ editorial voice for headlines, and claims you could defend in a due-diligence ro
   hero badge, "Strategic Advisory" in any form.
 - **The audience (ICP):** UK startup founders on the 0→1 journey, **pre-seed to
   Series A** (one phrasing, everywhere), in fintech, healthtech, and B2B SaaS.
-  London-based, remote-friendly across the UK and Europe.
+  Many of them are London-based; Codenest works remotely across the UK and Europe
+  and claims no London base of its own. Describing a *client* as London-based is
+  fine and true; describing *Codenest* that way is not (§13.25).
 - **The operators:** Codenest is founder-led in each track, and the tracks do not
   overlap. **Ankit Rana, Fractional CTO** — ex-Deloitte Digital, Elavon (US Bancorp),
   Opayo — leads the technical seat. **Michelle Rana FCCA, Fractional CFO** — strategic
@@ -375,10 +377,16 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     office, and the `geo` block is gone rather than re-guessed — it held the generic
     51.5074/-0.1278 London centroid for an address the business does not occupy. The
     footer's "London-based" line was dropped. Put a locality claim back only alongside
-    an address that supports it. **Still open:** the `/services/fractional-cto/` and
-    `/services/fractional-cfo/` page titles both say "London", as do several metadata
-    keywords — decide whether London is a claim Codenest can make before the next
-    metadata pass.
+    an address that supports it. **Closed 5 Aug 2026:** "London" is out of both service
+    page titles and OG titles, and out of the `fractional CTO/CFO London` keywords in
+    `app/layout.js` and the referral page. The titles now say "for UK Startups", which
+    matches `areaServed`. This gave up a title-tag signal for "fractional CFO London",
+    a high-intent query — the owner accepted that cost rather than keep a geographic
+    claim the site cannot support. **What stays:** London in *client* and *market*
+    context is true and permitted — Rungway as a London-based startup, the anonymised
+    London testimonials (§2.3), and London salary benchmarks in the guides. Only claims
+    about where Codenest itself sits are barred. If a London presence is ever
+    established, reinstate the targeting and the address together, never separately.
 26. **The Services dropdown is the two seats, nothing else.** "All Services" was removed
     from it (4 Aug 2026): every route out of `/services` leads back to one of those two
     pages, so it was a third nav slot reaching nothing new — and a third page competing

--- a/app/layout.js
+++ b/app/layout.js
@@ -26,8 +26,6 @@ export const metadata = {
   keywords: [
     'fractional CTO UK',
     'fractional CFO UK',
-    'fractional CTO London',
-    'fractional CFO London',
     'startup technical leadership UK',
     'startup financial modelling',
     'technical co-founder UK',

--- a/app/refer/page.js
+++ b/app/refer/page.js
@@ -7,7 +7,7 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 export const metadata = {
   title: 'Refer a UK Startup, Earn Up to £2,000',
   description: 'Refer a UK startup that needs fractional CTO or CFO support and earn up to £2,000 per engagement. For VCs, accelerators and founders.',
-  keywords: ['startup referral program UK', 'refer a startup', 'fractional CTO referral', 'VC referral fees', 'startup partner program London'],
+  keywords: ['startup referral program UK', 'refer a startup', 'fractional CTO referral', 'VC referral fees', 'startup partner program UK'],
   openGraph: {
     title: 'Codenest Referral Program – Earn Up to £2,000',
     description: 'Know a UK founder who needs a fractional CTO or CFO? Refer them to Codenest and earn up to £2,000 per engagement.',

--- a/app/services/fractional-cfo/page.js
+++ b/app/services/fractional-cfo/page.js
@@ -6,12 +6,16 @@ import Footer from '../../components/Footer'
 import JsonLd from '../../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../../lib/schema'
 
+// No "London" in the title or keywords. The registered office is in Surrey and
+// the site publishes no London address, so a city in the title was an implied
+// geographic claim nothing on the site supported. `areaServed` is the United
+// Kingdom, and the title now matches it. (BRANDING.md §13.25.)
 export const metadata = {
-  title: 'Fractional CFO Services London for UK Startups',
+  title: 'Fractional CFO Services for UK Startups',
   description: 'Fractional CFO for UK startups, pre-seed to Series A. Financial modelling, fundraising support and investor reporting. Free 30-minute strategy call.',
-  keywords: ['fractional CFO UK', 'fractional CFO London', 'startup CFO', 'FP&A UK', 'financial planning analysis', 'financial strategy', 'startup finance UK', 'part-time CFO'],
+  keywords: ['fractional CFO UK', 'startup CFO', 'FP&A UK', 'financial planning analysis', 'financial strategy', 'startup finance UK', 'part-time CFO'],
   openGraph: {
-    title: 'Fractional CFO Services London | Codenest',
+    title: 'Fractional CFO Services for UK Startups | Codenest',
     description: 'FP&A and financial strategy for UK startups — investor-ready financials without the overhead.',
     type: 'website',
     url: 'https://codenest.uk/services/fractional-cfo/',

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -6,12 +6,16 @@ import Footer from '../../components/Footer'
 import JsonLd from '../../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../../lib/schema'
 
+// No "London" in the title or keywords. The registered office is in Surrey and
+// the site publishes no London address, so a city in the title was an implied
+// geographic claim nothing on the site supported. `areaServed` is the United
+// Kingdom, and the title now matches it. (BRANDING.md §13.25.)
 export const metadata = {
-  title: 'Fractional CTO Services London for UK Startups',
+  title: 'Fractional CTO Services for UK Startups',
   description: 'Fractional CTO for UK startups, pre-seed to Series A. Architecture, engineering hiring and due diligence preparation. Free 30-minute strategy call.',
-  keywords: ['fractional CTO UK', 'fractional CTO London', 'part-time CTO', 'startup CTO', 'technical leadership', 'CTO as a service', 'interim CTO UK', 'fractional CTO cost', 'startup technical leadership'],
+  keywords: ['fractional CTO UK', 'part-time CTO', 'startup CTO', 'technical leadership', 'CTO as a service', 'interim CTO UK', 'fractional CTO cost', 'startup technical leadership'],
   openGraph: {
-    title: 'Fractional CTO Services London | Codenest',
+    title: 'Fractional CTO Services for UK Startups | Codenest',
     description: 'Engineering rigour and technical leadership for UK startups — without the overhead.',
     type: 'website',
     url: 'https://codenest.uk/services/fractional-cto/',


### PR DESCRIPTION
Closes item 6 from the [site review](https://github.com/cod3nest/cod3nest.github.io/pull/44) — the last piece of the §13.25 reconciliation, left open when the footer line and the schema address were fixed.

The registered office is in Surrey and the site publishes no London address. A city in the title was an implied geographic claim nothing on the site supported.

## Changes

| | Before | After |
|---|---|---|
| CTO title | Fractional CTO Services **London** for UK Startups | Fractional CTO Services for UK Startups |
| CFO title | Fractional CFO Services **London** for UK Startups | Fractional CFO Services for UK Startups |
| OG titles | …Services **London** \| Codenest | …Services for UK Startups \| Codenest |
| Sitewide keywords | included `fractional CTO/CFO London` | removed |
| Referral keywords | `startup partner program London` | `startup partner program UK` |

The new titles match the `areaServed: United Kingdom` the schema already declares, so metadata and structured data finally agree.

**BRANDING §1** also said the ICP was "London-based, remote-friendly across the UK and Europe" — ambiguous about whether "London-based" described the clients or Codenest, and the root of this whole inconsistency. It now separates the two explicitly.

## The trade-off, stated plainly

This gives up a title-tag signal for **"fractional CFO London"**, which is plausibly the highest-intent commercial query either service page could rank for. That is a real cost, not a free win.

The counter-argument, for the record: ranking for a city query generally wants a matching address and a Business Profile, neither of which exists here — and a geo claim that contradicts the only address you publish is a liability in its own right. My read is that the trade is worth it, but it is your call and it is reversible.

BRANDING records both the cost and the condition for reversing it: **if a London presence is ever established, reinstate the targeting and the address together, never separately.**

## What stays

London is true and permitted in client and market context, so these are untouched:

- Rungway described as "a London-based HR-tech startup"
- The anonymised "Founder & CEO, London fintech" testimonials (§2.3 prescribes exactly that phrasing)
- London salary benchmarks in the cost guides and blog posts — "London-based fractional CFOs typically charge 10-20% more", "a full-time CTO in London costs £150,000-£220,000". Market editorial about the category, explicitly permitted by §8.

I audited every `London` string in the built site to confirm none of the survivors asserts a Codenest London base.

## Verification

- `npm run build` clean
- Both titles render at 49 characters including the ` | Codenest` template
- Rendered keywords on the homepage and both service pages carry no city

## Note on merge order

This touches `app/layout.js` (the `keywords` array), and open [#45](https://github.com/cod3nest/cod3nest.github.io/pull/45) touches the same file (the `sameAs` array). Different regions ~100 lines apart, so they should auto-merge, but whichever lands second is worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
