### PR TITLE
Name the principal on each service page

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -193,6 +193,16 @@ Assemble pages from these; don't invent parallel patterns:
   passes one today. The two seats are **not** ServiceCards — they are the Two-Track
   cards, and listing "Fractional CTO" as an item inside the Fractional CTO track put
   the seat on one page three times. (4 Aug 2026.)
+- **PrincipalBand** — the named executive behind a seat, on that seat's service page.
+  Sits directly after the hero, where "who actually is this?" lands. Ankit on
+  `/services/fractional-cto/`, Michelle on `/services/fractional-cfo/`, never crossed
+  (§2.4). Every fact restates `/about`; the band introduces no claim of its own, and
+  Dishoom's numbers stay attached to Michelle's *role* (§13.15). Carries no avatar
+  on purpose — real headshots are outstanding and a letter-avatar placeholder is
+  barred (§5); the left column is sized to take a portrait when the files exist.
+  It adds no `Person` schema: those nodes live on `/about` and are referenced by
+  `@id`, never restated (§8). (5 Aug 2026 — both service pages sold a seat without
+  naming who fills it.)
 - **Outcome badges** — "Series A closed", "MVP in 10 weeks" — the approved proof
   device (never star ratings).
 - **Comparison grid** — categories only, factual rows, "Best for:" footers, Codenest

--- a/app/components/PrincipalBand.js
+++ b/app/components/PrincipalBand.js
@@ -1,0 +1,125 @@
+import Link from 'next/link'
+
+// The named executive behind a seat, shown on that seat's service page.
+//
+// Both service pages used to sell a seat without ever naming who fills it: a
+// visitor deciding whether to hire a Fractional CFO met a stock photo and no
+// human. The whole positioning is two named principals rather than one
+// generalist (BRANDING.md §2.4), and it was invisible at the point of decision.
+//
+// Every fact here already appears on /about — this restates, it never claims
+// anything new. Dishoom's numbers stay attached to Michelle's *role* rather than
+// to her personally (§13.15).
+//
+// Deliberately no avatar. Real headshots are still outstanding, and a
+// letter-avatar placeholder is barred in production (§5) — an initial in a
+// coloured box is worse than nothing here. The left column is sized to take a
+// portrait when the files exist; drop it above the name.
+
+const ACCENT_STYLES = {
+  primary: {
+    role: 'text-primary-700',
+    chip: 'bg-primary-50 text-primary-800 border-primary-200',
+    rule: 'bg-primary-600',
+    marker: 'text-primary-600',
+    proof: 'bg-primary-50 text-primary-800 border-primary-200',
+    link: 'text-primary-700 hover:text-primary-800',
+  },
+  accent: {
+    role: 'text-accent-700',
+    chip: 'bg-accent-50 text-accent-800 border-accent-200',
+    rule: 'bg-accent-500',
+    marker: 'text-accent-700',
+    proof: 'bg-accent-50 text-accent-800 border-accent-200',
+    link: 'text-accent-700 hover:text-accent-800',
+  },
+}
+
+const LinkedInIcon = () => (
+  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+  </svg>
+)
+
+export default function PrincipalBand({
+  eyebrow = 'Who you would be working with',
+  name,
+  role,
+  accent,
+  credentials,
+  bio,
+  highlights,
+  proof,
+  linkedin,
+}) {
+  const style = ACCENT_STYLES[accent]
+
+  return (
+    <section className="py-20 bg-slate-50 border-y border-slate-200">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-10 font-medium">{eyebrow}</p>
+
+        {/* Asymmetric, not another centred card grid (§5). Identity on the left,
+            evidence on the right. */}
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-10 lg:gap-16">
+          <div className="lg:col-span-2">
+            <h2 className="font-serif text-3xl font-bold text-slate-900 mb-1">{name}</h2>
+            <p className={`${style.role} font-semibold mb-5`}>{role}</p>
+            <div className={`w-16 h-1 rounded-full mb-6 ${style.rule}`} />
+
+            <div className="flex flex-wrap gap-2 mb-6">
+              {credentials.map((credential) => (
+                <span key={credential} className={`px-3 py-1 border rounded-full text-xs font-medium ${style.chip}`}>
+                  {credential}
+                </span>
+              ))}
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Link href="/about/" className={`inline-flex items-center gap-2 font-semibold ${style.link}`}>
+                Full background
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                </svg>
+              </Link>
+              <a
+                href={linkedin}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`inline-flex items-center gap-2 font-medium ${style.link}`}
+              >
+                <LinkedInIcon />
+                {name.split(' ')[0]} on LinkedIn
+              </a>
+            </div>
+          </div>
+
+          <div className="lg:col-span-3">
+            <p className="text-lg text-slate-700 leading-relaxed mb-8">{bio}</p>
+
+            <ul className="space-y-4 mb-8">
+              {highlights.map((item) => (
+                <li key={item} className="flex items-start gap-3">
+                  <svg
+                    className={`w-5 h-5 mt-0.5 flex-shrink-0 ${style.marker}`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span className="text-slate-700 leading-relaxed">{item}</span>
+                </li>
+              ))}
+            </ul>
+
+            <p className={`text-sm font-semibold border rounded-lg px-4 py-3 inline-block ${style.proof}`}>
+              {proof}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/services/fractional-cfo/page.js
+++ b/app/services/fractional-cfo/page.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Navigation from '../../components/Navigation'
 import Button from '../../components/Button'
 import Footer from '../../components/Footer'
+import PrincipalBand from '../../components/PrincipalBand'
 import JsonLd from '../../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../../lib/schema'
 
@@ -201,6 +202,24 @@ export default function FractionalCFOPage() {
           </div>
         </div>
       </section>
+
+      {/* This page carried no named human at all: a CFO buyer met a stock photo
+          and a list of capabilities. Dishoom's numbers stay attached to the role
+          Michelle held, never to her personally growing the business (§13.15). */}
+      <PrincipalBand
+        name="Michelle Rana FCCA"
+        role="Fractional CFO"
+        accent="accent"
+        credentials={['FCCA', 'BSc Mathematics', '£165m P&L']}
+        bio="Chartered accountant and strategic finance leader. As Head of Strategic Finance at Dishoom she owned the five-year model, rolling forecasts and CapEx governance through a 6-to-27-site expansion, and held the company's cash together through COVID-19. She has supported founders through fundraising and investor due diligence."
+        highlights={[
+          'Led strategic finance at Dishoom through £35m to £165m revenue and a four-point EBITDA margin improvement',
+          'Built and led a 20+ person finance function, owning Board and investor reporting',
+          'Rolling forecasts accurate to ±3%, month-end close cut from 14 days to 8, and £6m in procurement and contract improvements',
+        ]}
+        proof="Led strategic finance at Dishoom through £35m → £165m"
+        linkedin="https://www.linkedin.com/in/michellerana1"
+      />
 
       {/* Benefits Section */}
       <section className="py-24 bg-white">

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Navigation from '../../components/Navigation'
 import Button from '../../components/Button'
 import Footer from '../../components/Footer'
+import PrincipalBand from '../../components/PrincipalBand'
 import JsonLd from '../../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../../lib/schema'
 
@@ -208,6 +209,23 @@ export default function FractionalCTOPage() {
           </div>
         </div>
       </section>
+
+      {/* Directly after the pitch, because that is where the question "who
+          actually is this?" lands. Facts restated from /about; nothing new. */}
+      <PrincipalBand
+        name="Ankit Rana"
+        role="Fractional CTO"
+        accent="primary"
+        credentials={['AWS Certified', '15+ years engineering', 'Kubernetes & Cloud']}
+        bio="Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
+        highlights={[
+          'Led engineering teams from 5 to 50+ across fintech and healthtech',
+          'Ran a near seven-year platform transformation at Opayo by Elavon: AWS EKS migration, GitOps, a payments monolith moved to microservices',
+          'Rebuilt Rungway as its interim CTO, taking the platform from 5 to 1,000+ concurrent users with a zero-downtime migration',
+        ]}
+        proof="Rungway: 5 → 1,000+ concurrent users"
+        linkedin="https://www.linkedin.com/in/arana198"
+      />
 
       {/* Benefits Section */}
       <section className="py-24 bg-white">


### PR DESCRIPTION
Closes item 2 from the [site review](https://github.com/cod3nest/cod3nest.github.io/pull/44) — one of the two highest-leverage items on the list.

Both service pages sold a seat without ever naming who fills it. A founder deciding whether to hire a Fractional CFO met a stock photo and a list of capabilities. The entire positioning is *two named executives rather than one generalist* (§2.4), and it was invisible at exactly the point where the decision gets made.

## What this adds

A `PrincipalBand` component, used once per service page, placed directly after the hero — where "who actually is this?" lands:

- **Ankit Rana** on `/services/fractional-cto/` — 15 years, Deloitte Digital and Elavon, teams from 5 to 50+, the Opayo platform transformation, and Rungway 5 → 1,000+ as interim CTO
- **Michelle Rana FCCA** on `/services/fractional-cfo/` — chartered accountant, the Dishoom strategic finance role through £35m → £165m, a 20+ person finance function, ±3% rolling forecasts, month-end close 14 days → 8

Each carries credentials, a short bio, three concrete highlights, a proof line, and links to `/about` and LinkedIn.

**Every fact restates what `/about` already publishes.** This PR introduces no new claim about either principal, so nothing here needs fresh verification. Dishoom's numbers stay attached to the role Michelle held rather than to her personally growing the business (§13.15) — I checked every rendered mention.

## Two deliberate omissions

**No avatar.** Headshots are still outstanding (item 3), and a letter-avatar placeholder is barred in production (§5). An initial in a coloured box would be actively worse on a band whose whole job is making a stranger real. The left column is sized to take a portrait — drop it above the name when the files exist.

**No `Person` schema.** Those nodes live on `/about` with stable `@id`s that the organisation already references via `member`. Restating them here would be the same duplicate-entity mistake §8 exists to prevent — verified that neither service page emits a `Person` node.

## Verification

- `npm run build` clean
- Each page names its own principal and **zero** mentions of the other — §2.4 holds
- Every Dishoom mention is role-framed
- Zero WCAG AA failures on both pages, checked against effective backgrounds including gradient stops
- No horizontal scroll at 375px or 1280px; the band stacks to one column on mobile
- One `h1` per page; the band heading is an `h2`

## Note

Once headshots land, `PrincipalBand` is the single place to add them — that was the point of extracting it rather than inlining the markup twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
