### PR TITLE
Lead the technical track with agentic AI, add the Regono engagement

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -224,6 +224,12 @@ Assemble pages from these; don't invent parallel patterns:
   `accent-400`+`text-primary-900` (financial). No emoji (§2.6). No icon fonts.
 - Alt text: logos are always `Codenest - Fractional CTO & CFO for UK startups`;
   content images describe the content, no keyword stuffing.
+- **A schematic beats a stock photo when no real photo exists.** The Regono case
+  study renders a labelled charcoal stack of its platform layers rather than
+  `service-ai.jpg`, which is an off-palette blue 3D "AI" render that says nothing.
+  `PlatformDiagram` in `app/case-studies/page.js` takes the layers as data; a study
+  with a `diagram` gets it instead of an `image`. Reach for this before buying
+  another abstract-technology photograph.
 
 ## 8. Metadata & SEO conventions
 
@@ -430,3 +436,28 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     pair as the only unit of sale. "Most startups need both" is an observation about
     startups, not a condition of engagement — if a sentence could read as the latter,
     rewrite it. (Owner, 4 Aug 2026.)
+28. **Agentic AI engineering is the named technical capability.** (Owner, 5 Aug 2026 —
+    it is what the market is asking for now.) The generic "AI & Data Engineering" tile
+    is retired: the technical track leads with agentic AI on the homepage, `/services`,
+    `/services/fractional-cto` (its own charcoal band, §13.22 still bans gold grounds),
+    `/about`, and both `knowsAbout` blocks. Two terms carry specific meaning and are
+    not interchangeable marketing words for "we do AI":
+    a **company brain** is a retrieval layer over the organisation's own documents,
+    systems and process; an **AI factory** is the platform that makes agent delivery
+    repeatable — shared scaffolding, evaluation harness, guardrails, deployment,
+    observability. It stays a capability *inside* the Fractional CTO seat: it is not
+    a nav destination, not a page of its own, and not a fifth entry in the layout's
+    offer catalogue (§8, §13.26).
+29. **Regono is a live engagement, and the site says so.** (Owner, 5 Aug 2026.) It is
+    the first `/case-studies` entry that has not finished, so it breaks the card's
+    usual shape on purpose: a status pill, headings relabelled to Brief / Build /
+    What Is Being Built, and **no outcome figures at all**. The card prints a note
+    stating that figures go up once measured and client-approved, which is §13.4
+    made visible rather than an apology for a gap. Do not invent a metric, sector,
+    funding stage, team size or timeline for it; get them from the owner, then drop
+    `status` and `note` together with the real numbers. Regono is **not** in the
+    homepage logo strip — that strip is captioned "Founder track record includes"
+    and is not a client wall (§13.15). The study attributes the work to Ankit by
+    name, as the other three do; whether Regono may additionally be described as a
+    Codenest *client*, and whether it has given permission to be named at all, is
+    unconfirmed and needs the owner before any copy claims it.

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -48,6 +48,8 @@ const peopleSchema = [
     knowsAbout: [
       'Fractional CTO services',
       'Startup engineering',
+      'Agentic AI engineering',
+      'LLM application development',
       'Cloud architecture',
       'Kubernetes',
       'DevOps',
@@ -116,13 +118,14 @@ export default function AboutPage() {
       initial: "A",
       accent: "primary",
       linkedin: "https://www.linkedin.com/in/arana198",
-      credentials: ["AWS Certified", "15+ Years Engineering", "Kubernetes & Cloud"],
-      bio: "Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. Has led engineering teams from 5 to 50+, run a near seven-year platform transformation at Opayo by Elavon, and sat on the receiving end of technical due diligence.",
+      credentials: ["AWS Certified", "15+ Years Engineering", "Kubernetes & Cloud", "Agentic AI"],
+      bio: "Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. Has led engineering teams from 5 to 50+, run a near seven-year platform transformation at Opayo by Elavon, and sat on the receiving end of technical due diligence. Currently building agentic AI platforms.",
       proof: "Scaled Rungway from 5 to 1,000+ concurrent users",
       tracks: [
         { year: "2011-2015", title: "Enterprise Foundations", description: "Payment processors and financial services platforms at Deloitte Digital and Elavon (US Bancorp) — learning what enterprise-grade actually costs, and what startups can borrow from it." },
         { year: "2015-2017", title: "Scaling Startups", description: "Led engineering teams from 5 to 50+ across fintech and healthtech. Hypergrowth firsthand: the technical debt, the hiring mistakes, the architecture decisions that come back to haunt you." },
         { year: "2019-2026", title: "Payments at Scale", description: "Platform transformation at Opayo by Elavon — AWS EKS migration, GitOps and Infrastructure as Code, moving a payments monolith to microservices without dropping a transaction." },
+        { year: "2026-present", title: "Agentic AI Platforms", description: "Building a company brain and an AI factory at Regono: a retrieval layer over the organisation's own knowledge, plus the scaffolding, evaluation and guardrails that put agents into production and keep them honest there." },
       ],
     },
     {
@@ -184,7 +187,7 @@ export default function AboutPage() {
   // Two technical categories, two financial — the grid itself has to read 50/50.
   const expertise = [
     { category: "Cloud & Infrastructure", items: ["AWS", "GCP", "Kubernetes", "Terraform", "GitOps"] },
-    { category: "Engineering & Data", items: ["Python", "Java", "Node.js", "Microservices", "ML & LLM Integration"] },
+    { category: "Engineering & AI", items: ["Python", "Java", "Node.js", "Microservices", "Agentic AI & LLM Systems"] },
     { category: "Planning & Reporting", items: ["Financial Modelling", "Rolling Forecasts", "Scenario Planning", "Board & Investor Reporting", "Fundraising Support"] },
     { category: "Controls & Commercial", items: ["Financial Controls", "Margin Optimisation", "Procurement & Cost", "CapEx Governance", "Cash Management"] }
   ]

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import Navigation from '../components/Navigation'
 import Footer from '../components/Footer'
 import JsonLd from '../components/JsonLd'
@@ -10,10 +11,10 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 // of its own, and not before.
 export const metadata = {
   title: 'Case Studies: Fractional CTO Engagements',
-  description: 'Technical engagements led by Ankit Rana, Fractional CTO: scaling Rungway to 1,000+ concurrent users, transforming payments at Opayo, and a compliant MVP for AstraZeneca.',
+  description: 'Technical engagements led by Ankit Rana, Fractional CTO: an agentic AI platform at Regono, scaling Rungway to 1,000+ concurrent users, transforming payments at Opayo, and a compliant MVP for AstraZeneca.',
   openGraph: {
     title: 'Codenest Case Studies — Track Record',
-    description: 'Technical leadership engagements led by Ankit Rana, Fractional CTO. Rungway, Opayo by Elavon, AstraZeneca.',
+    description: 'Agentic AI platform engineering, scaling, payments and regulated delivery. Regono, Rungway, Opayo by Elavon, AstraZeneca.',
     type: 'website',
     url: 'https://codenest.uk/case-studies/',
     images: [
@@ -30,7 +31,32 @@ export const metadata = {
   },
 }
 
+// Three of these are completed engagements with measured outcomes. Regono is
+// live, so it carries `status` and its third block is scope rather than results
+// — the card renderer relabels the headings from `labels` and prints `note`
+// instead of inventing figures nobody has measured yet (§4, §13.28). Fill in
+// real numbers and drop `status`/`note` when the engagement produces them.
 const caseStudies = [
+  {
+    title: "Regono: A Company Brain and an AI Factory",
+    status: "Engagement in progress",
+    labels: { challenge: "The Brief", solution: "The Build", results: "What Is Being Built" },
+    challenge: "Most companies meet AI twice over: institutional knowledge spread across documents, tools and people's heads with no way to query it, and AI pilots that arrive one at a time with nothing shared underneath them. This engagement treats both as a single platform problem rather than two initiatives.",
+    solution: "Ankit is building the company brain first: a retrieval layer over Regono's own documents, systems and process, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt. The AI factory sits on top of it: shared agent scaffolding, an evaluation harness, guardrails, and the deployment and observability that agents need once they are doing real work. It exists so the tenth agent does not cost what the first one did.",
+    results: [
+      "Retrieval layer over internal knowledge sources",
+      "Shared agent scaffolding and an evaluation harness",
+      "Guardrails, deployment and observability for production agents",
+      "One platform for agent delivery, rather than a build per project"
+    ],
+    note: "Outcome figures go up once they are measured and the client has approved them. This engagement is still running, so there are none here yet.",
+    tags: ["Agentic AI", "AI Platform Engineering", "Knowledge Retrieval", "Evaluation & Guardrails", "LLMOps"],
+    diagram: [
+      { label: "Agents in production", detail: "Doing real work, watched" },
+      { label: "AI factory", detail: "Scaffolding, evaluation, deployment" },
+      { label: "Company brain", detail: "Retrieval over internal knowledge" },
+    ]
+  },
   {
     title: "Rungway: Scaling a Social Mentoring Platform",
     challenge: "A London-based HR-tech startup needed fractional CTO support to scale their social mentoring platform. The system could only handle 5 concurrent users before experiencing severe performance degradation — completely inadequate for their UK enterprise client base.",
@@ -78,6 +104,36 @@ const pageSchema = [
   },
 ]
 
+// Stands in for the photograph on studies that have no usable one. The only AI
+// image in `public/img/photos` is a blue 3D "AI" render that is off-palette and
+// says nothing; a labelled stack of the actual layers carries more information
+// than a stock photo would, and stays in brand colours (§7).
+function PlatformDiagram({ layers }) {
+  return (
+    <div className="h-full bg-primary-800 px-8 pb-8 pt-16 lg:px-10 lg:pb-10 flex flex-col">
+      <p className="text-xs uppercase tracking-[0.2em] text-accent-300 mb-6 font-medium">How the platform stacks</p>
+      {layers.map((layer, i) => (
+        <Fragment key={layer.label}>
+          <div className="rounded-xl border border-primary-600 bg-primary-700 px-5 py-4">
+            <p className="text-white font-semibold">{layer.label}</p>
+            <p className="text-slate-300 text-sm">{layer.detail}</p>
+          </div>
+          {/* The connector grows, so the stack fills a column sized by the text
+              beside it instead of floating in the middle of a tall void. */}
+          {i < layers.length - 1 && (
+            <div className="flex-1 min-h-[2.5rem] flex flex-col items-center py-2" aria-hidden="true">
+              <svg className="w-4 h-4 text-accent-300 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+              </svg>
+              <span className="w-px flex-1 bg-primary-600" />
+            </div>
+          )}
+        </Fragment>
+      ))}
+    </div>
+  )
+}
+
 export default function CaseStudiesPage() {
   return (
     <div className="min-h-screen bg-white">
@@ -93,7 +149,7 @@ export default function CaseStudiesPage() {
                   under a title that named the service and matched neither. */}
               <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Fractional CTO Case Studies</h1>
               <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-                Technical engagements led by Ankit Rana, Fractional CTO. Deep, hands-on collaboration at every stage
+                Technical engagements led by Ankit Rana, Fractional CTO. Agentic AI platforms, scaling, payments and regulated delivery
               </p>
             </div>
 
@@ -101,33 +157,45 @@ export default function CaseStudiesPage() {
               {caseStudies.map((study, index) => (
                 <div key={index} className="group bg-white rounded-3xl shadow-lg overflow-hidden border border-slate-200 hover:shadow-2xl hover:border-accent-200 transition-all duration-300">
                   <div className="grid grid-cols-1 lg:grid-cols-2 gap-0">
-                    <div className={`relative h-80 lg:h-auto overflow-hidden ${index % 2 === 0 ? 'lg:order-1' : 'lg:order-2'}`}>
-                      <img
-                        src={study.image}
-                        alt={study.imageAlt || study.title}
-                        className="w-full h-full object-cover"
-                        loading="lazy"
-                        width={600}
-                        height={400}
-                      />
+                    {/* Photo cards get a fixed mobile height so the crop stays
+                        consistent; the diagram sizes to its own content instead,
+                        because a fixed 20rem box would clip the bottom layer. */}
+                    <div className={`relative overflow-hidden ${study.diagram ? '' : 'h-80'} lg:h-auto ${index % 2 === 0 ? 'lg:order-1' : 'lg:order-2'}`}>
+                      {study.diagram ? (
+                        <PlatformDiagram layers={study.diagram} />
+                      ) : (
+                        <img
+                          src={study.image}
+                          alt={study.imageAlt || study.title}
+                          className="w-full h-full object-cover"
+                          loading="lazy"
+                          width={600}
+                          height={400}
+                        />
+                      )}
                       {/* Index badge */}
                       <div className="absolute top-4 left-4 w-10 h-10 bg-white/90 backdrop-blur-sm rounded-full flex items-center justify-center shadow-md">
                         <span className="text-sm font-bold text-primary-600">{String(index + 1).padStart(2, '0')}</span>
                       </div>
                     </div>
                     <div className={`p-10 lg:p-12 ${index % 2 === 0 ? 'lg:order-2' : 'lg:order-1'}`}>
+                      {study.status && (
+                        <p className="inline-block mb-4 px-3 py-1 rounded-full border border-accent-300 bg-accent-50 text-accent-800 text-xs font-semibold uppercase tracking-wide">
+                          {study.status}
+                        </p>
+                      )}
                       <h2 className="text-3xl font-bold text-slate-900 mb-4 group-hover:text-primary-700 transition-colors">{study.title}</h2>
                       <div className="space-y-6">
                         <div>
-                          <h3 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">Challenge</h3>
+                          <h3 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">{study.labels?.challenge || 'Challenge'}</h3>
                           <p className="text-slate-600">{study.challenge}</p>
                         </div>
                         <div>
-                          <h3 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">Solution</h3>
+                          <h3 className="text-sm font-semibold text-primary-600 uppercase tracking-wide mb-2">{study.labels?.solution || 'Solution'}</h3>
                           <p className="text-slate-600">{study.solution}</p>
                         </div>
                         <div>
-                          <h3 className="text-sm font-semibold text-accent-700 uppercase tracking-wide mb-3">Results</h3>
+                          <h3 className="text-sm font-semibold text-accent-700 uppercase tracking-wide mb-3">{study.labels?.results || 'Results'}</h3>
                           <ul className="space-y-2">
                             {study.results.map((result, i) => (
                               <li key={i} className="flex items-start">
@@ -138,6 +206,9 @@ export default function CaseStudiesPage() {
                               </li>
                             ))}
                           </ul>
+                          {study.note && (
+                            <p className="mt-4 text-sm text-slate-500 border-l-2 border-slate-200 pl-4">{study.note}</p>
+                          )}
                         </div>
                         <div className="flex flex-wrap gap-2 pt-2">
                           {study.tags.map((tag, i) => (

--- a/app/layout.js
+++ b/app/layout.js
@@ -26,6 +26,7 @@ export const metadata = {
   keywords: [
     'fractional CTO UK',
     'fractional CFO UK',
+    'agentic AI engineering',
     'startup technical leadership UK',
     'startup financial modelling',
     'technical co-founder UK',
@@ -144,6 +145,10 @@ export default function RootLayout({ children }) {
       email: 'hello@codenest.uk'
     },
     knowsAbout: [
+      'Agentic AI Engineering',
+      'LLM Application Development',
+      'AI Platform Engineering',
+      'Retrieval-Augmented Generation',
       'GitOps',
       'Infrastructure as Code',
       'Kubernetes',

--- a/app/page.js
+++ b/app/page.js
@@ -242,7 +242,7 @@ export default function Home() {
                   <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  AI & Data Engineering
+                  Agentic AI & Data Engineering
                 </li>
                 <li className="flex items-center text-slate-700">
                   <svg className="w-5 h-5 text-primary-600 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -263,7 +263,7 @@ export default function Home() {
             <p className="text-slate-600">
               Also need delivery capacity? Explore{' '}
               <Link href="/services/" className="text-primary-600 hover:text-primary-700 font-medium">all services</Link>
-              {' '}including 0-to-1 product builds and AI engineering.
+              {' '}including 0-to-1 product builds and agentic AI engineering.
             </p>
             <p className="text-slate-600">
               Building something exceptional? For the right opportunity, we also consider{' '}

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -13,11 +13,11 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../../lib/schema'
 // Kingdom, and the title now matches it. (BRANDING.md §13.25.)
 export const metadata = {
   title: 'Fractional CTO Services for UK Startups',
-  description: 'Fractional CTO for UK startups, pre-seed to Series A. Architecture, engineering hiring and due diligence preparation. Free 30-minute strategy call.',
-  keywords: ['fractional CTO UK', 'part-time CTO', 'startup CTO', 'technical leadership', 'CTO as a service', 'interim CTO UK', 'fractional CTO cost', 'startup technical leadership'],
+  description: 'Fractional CTO for UK startups, pre-seed to Series A. Agentic AI engineering, architecture, hiring and due diligence prep. Free 30-minute strategy call.',
+  keywords: ['fractional CTO UK', 'part-time CTO', 'startup CTO', 'technical leadership', 'CTO as a service', 'interim CTO UK', 'agentic AI engineering', 'fractional CTO AI', 'startup technical leadership'],
   openGraph: {
     title: 'Fractional CTO Services for UK Startups | Codenest',
-    description: 'Engineering rigour and technical leadership for UK startups — without the overhead.',
+    description: 'Engineering rigour, agentic AI delivery and technical leadership for UK startups.',
     type: 'website',
     url: 'https://codenest.uk/services/fractional-cto/',
     images: [
@@ -82,6 +82,8 @@ export default function FractionalCTOPage() {
   const services = [
     "Technical strategy and roadmap development",
     "Architecture design and review",
+    "Agentic AI strategy and delivery",
+    "LLM evaluation, guardrails and cost control",
     "Technology selection and evaluation",
     "Engineering team structure and hiring",
     "Code review and quality standards",
@@ -92,7 +94,38 @@ export default function FractionalCTOPage() {
     "Mentoring junior technical leaders",
   ]
 
+  // The capability the market is asking for right now, given its own band rather
+  // than a bullet inside "What We Do". Each block describes work Codenest does,
+  // not a claim about results — the Regono engagement is live and its outcome
+  // figures are not published yet (§13.28).
+  const agenticLayers = [
+    {
+      title: "The company brain",
+      description: "One retrieval layer over your own documents, systems and process, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt.",
+    },
+    {
+      title: "The AI factory",
+      description: "The platform underneath agent delivery: shared scaffolding, an evaluation harness, guardrails, deployment and observability. It is what stops the tenth agent costing what the first one did.",
+    },
+    {
+      title: "Evaluation before scale",
+      description: "An agent with no evaluation harness is a demo. Measurement goes in before volume does, so you can tell a real regression from a bad afternoon.",
+    },
+    {
+      title: "Cost and latency discipline",
+      description: "Model choice, routing, caching and context hygiene. Inference bills scale with usage, and left alone they scale faster than the usage does.",
+    },
+  ]
+
   const faqs = [
+    {
+      question: "Do you build agentic AI, or only advise on it?",
+      answer: "Build. Ankit is currently building a company brain and an AI factory at Regono: a retrieval layer over internal knowledge, and the platform that puts agents into production against it. The person advising on the architecture is the person writing it."
+    },
+    {
+      question: "Everyone is telling us to build AI agents. How do you decide whether we should?",
+      answer: "By asking what breaks if you do nothing. Agents earn their place on work that is repetitive, judgement-light, and already written down somewhere. Where the process itself is undefined, an agent automates the confusion faster. We will tell you when that is what we see."
+    },
     {
       question: "What's the difference between a fractional CTO and a consultant?",
       answer: "A fractional CTO is embedded in your team and takes ownership of technical outcomes. Unlike consultants who provide advice and leave, we're accountable for execution and stay engaged as your technical leader."
@@ -115,7 +148,7 @@ export default function FractionalCTOPage() {
     },
     {
       question: "What's your tech stack expertise?",
-      answer: "We specialize in cloud-native architectures (AWS, GCP), Kubernetes, Terraform, Python, Java, Postgres/MySQL, GitOps, and modern data/ML stacks. But our real value is in architectural thinking — we choose the right tools for your specific needs."
+      answer: "We specialize in cloud-native architectures (AWS, GCP), Kubernetes, Terraform, Python, Java, Postgres/MySQL, GitOps, and agentic AI stacks: LLM orchestration, retrieval, evaluation and guardrails. But our real value is in architectural thinking — we choose the right tools for your specific needs."
     },
     {
       question: "What makes you different from a dev shop?",
@@ -146,7 +179,7 @@ export default function FractionalCTOPage() {
     '@context': 'https://schema.org',
     '@type': 'Service',
     name: 'Fractional CTO Services',
-    description: 'Part-time technical leadership for startups. Architecture, team building, and strategic guidance.',
+    description: 'Part-time technical leadership for startups. Architecture, agentic AI engineering, team building, and strategic guidance.',
     // Reference the root layout's ProfessionalService by @id rather than
     // restating it: a second, differently-shaped Organization node for the same
     // business invites Google to treat them as two companies.
@@ -187,7 +220,7 @@ export default function FractionalCTOPage() {
                 Fractional CTO Services
               </h1>
               <p className="text-xl text-slate-600 mb-4 leading-relaxed">
-                Engineering rigour and technical leadership for ambitious startups. Make confident architecture decisions, build the right team, and become investor-ready — without the overhead.
+                Engineering rigour and technical leadership for ambitious startups. Make confident architecture decisions, put agentic AI into production, build the right team, and become investor-ready.
               </p>
               <p className="text-sm font-medium text-slate-700 mb-8">
                 Retained monthly engagements, scoped to your stage &middot; typically 60-80% less than a full-time CTO
@@ -220,9 +253,10 @@ export default function FractionalCTOPage() {
         name="Ankit Rana"
         role="Fractional CTO"
         accent="primary"
-        credentials={['AWS Certified', '15+ years engineering', 'Kubernetes & Cloud']}
+        credentials={['AWS Certified', '15+ years engineering', 'Kubernetes & Cloud', 'Agentic AI']}
         bio="Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
         highlights={[
+          'Currently building a company brain and an AI factory at Regono: retrieval over internal knowledge, and the platform that ships agents against it',
           'Led engineering teams from 5 to 50+ across fintech and healthtech',
           'Ran a near seven-year platform transformation at Opayo by Elavon: AWS EKS migration, GitOps, a payments monolith moved to microservices',
           'Rebuilt Rungway as its interim CTO, taking the platform from 5 to 1,000+ concurrent users with a zero-downtime migration',
@@ -306,6 +340,38 @@ export default function FractionalCTOPage() {
                   </div>
                 </li>
               </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Agentic AI. Charcoal rather than another white card grid: this is the
+          capability buyers are actively searching for, and it should not read as
+          the fifth item in a list. Gold grounds stay banned (§13.22). */}
+      <section className="py-24 bg-primary-800">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 lg:gap-16">
+            <div className="lg:col-span-1">
+              <p className="text-sm uppercase tracking-[0.2em] text-accent-300 mb-4 font-medium">In demand right now</p>
+              <h2 className="font-serif text-4xl font-bold text-white mb-6">Agentic AI Engineering</h2>
+              <p className="text-slate-300 leading-relaxed mb-6">
+                Most companies have AI pilots. Far fewer have anything underneath them: no shared knowledge layer, no evaluation, no way to ship the second agent faster than the first. That gap is the work.
+              </p>
+              <Link href="/case-studies/" className="inline-flex items-center gap-2 font-semibold text-accent-300 hover:text-accent-200">
+                See the Regono engagement
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                </svg>
+              </Link>
+            </div>
+
+            <div className="lg:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-8">
+              {agenticLayers.map((layer) => (
+                <div key={layer.title} className="border-l-2 border-accent-500 pl-6">
+                  <h3 className="text-xl font-bold text-white mb-3">{layer.title}</h3>
+                  <p className="text-slate-300 leading-relaxed">{layer.description}</p>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/app/services/page.js
+++ b/app/services/page.js
@@ -136,10 +136,10 @@ const services =
       track: "business"
     },
     {
-      title: "AI & Data Engineering",
-      benefit: "Turn AI experiments into production revenue",
-      description: "Move beyond prototypes. We build production-grade LLM applications, ML pipelines, and data infrastructure that actually scale.",
-      outcomes: ["Production-ready AI", "Cost-optimized inference", "Scalable data pipelines"],
+      title: "Agentic AI Engineering",
+      benefit: "Get agents past the demo and into production",
+      description: "A knowledge layer over what your business already knows, and the platform that ships agents against it: shared scaffolding, evaluation, guardrails and observability.",
+      outcomes: ["Company brain over internal knowledge", "Evaluation and guardrails before scale", "Cost and latency under control"],
       track: "technical"
     },
     {


### PR DESCRIPTION
## Agentic AI as the named technical capability

The technical track sold **"AI & Data Engineering"** — a tile that could have described any consultancy since 2018 — while the thing buyers are actively searching for went unnamed. Agentic AI engineering now leads it:

- **`/services/fractional-cto`** gains its own charcoal band with four blocks: the company brain, the AI factory, evaluation before scale, cost and latency discipline. Plus two FAQs, two entries in "What We Do", and the term in the title description and keywords.
- **Homepage** CTO bullet and the "all services" line
- **`/services`** capability tile rewritten
- **`/about`** — Ankit gains a `2026-present` track, an "Agentic AI" chip, and two `knowsAbout` terms
- **`app/layout.js`** `knowsAbout` had **no AI terms at all**; it now has four

It stays a capability *inside* the Fractional CTO seat. Not a nav slot, not a page, not a fifth entry in the offer catalogue (§8, §13.26).

Two terms are used consistently rather than as synonyms for "we do AI": a **company brain** is a retrieval layer over the organisation's own documents, systems and process; an **AI factory** is the platform that makes agent delivery repeatable — shared scaffolding, evaluation harness, guardrails, deployment, observability.

## Regono

The first `/case-studies` entry that has not finished, so it breaks the card shape on purpose: a status pill, headings relabelled to **Brief / Build / What Is Being Built**, and **no outcome figures at all**. The card states that figures go up once measured and client-approved — §13.4 made visible rather than an apology for a gap.

Nothing is invented for it: no metric, sector, funding stage, team size or timeline. It is **not** added to the homepage logo strip, which is captioned "Founder track record includes" and is not a client wall (§13.15).

It renders a labelled charcoal stack of its platform layers instead of a photograph. The only AI image in `public/img/photos` is an off-palette blue 3D "AI" render that says nothing; `PlatformDiagram` takes the layers as data, and any study with a `diagram` gets it instead of an `image`.

## Two things that need you

1. **Permission.** Naming a *live* client is a different bar from the three finished studies. The copy attributes the work to Ankit by name, as the other three do, and never calls Regono a Codenest client — that framing holds whether the engagement is contractual or not. Confirm before any copy claims more.
2. **The blanks.** Everything beyond "company brain" and "AI factory" is deliberately absent. Send sector, stage, and outcomes when they exist, then drop `status` and `note` together with the real numbers.

## Verification

- `npm run build` clean, 44 static pages
- Zero WCAG AA failures on `/case-studies`, `/services`, `/services/fractional-cto`, `/about` at 1280px and 375px
- No horizontal scroll at either width; the diagram sizes to its own content on mobile rather than clipping in a fixed 20rem box
- One `FAQPage` on the CTO page, 10 questions
- The CTO page still names no one but Ankit (§2.4); Regono appears once on `/about`, in Ankit's track only

Recorded as BRANDING §13.28 and §13.29, plus an imagery rule in §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)