### PR TITLE
Correct the Regeno client name and framing missed by PR #49

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -472,10 +472,17 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     PrincipalBand highlight and `/about` all do. The owner directed the naming twice;
     written permission from Regeno to be named is not on file here, and getting it is
     an owner action, not a blocker the site re-litigates.
-    **Still outstanding:** Regeno is not on the homepage logo strip. That needs a logo
-    asset and a caption that no longer says "Founder track record includes" — the
-    strip is currently true only because it holds no clients. Change the caption and
-    add the mark in one commit, never the mark alone.
+    **Homepage strip, done 5 Aug 2026 (owner).** It is now two labelled groups:
+    **"Codenest clients"** (Regeno) above **"Founder track record includes"** (Rungway,
+    Opayo, AstraZeneca, Dishoom). The founder caption and the four marks under it are
+    untouched — the fix was to stop that caption having to cover a client, not to
+    reword it. Never merge the two groups back into one strip, and never move a mark
+    between them without the engagement changing.
+    **Regeno renders as a wordmark, not a logo.** No asset has been supplied, and a
+    client's brand asset is not Codenest's to lift from their codebase. The slot takes
+    an `<img>` the moment Regeno provides one; until then the text treatment matches
+    Rungway's name-and-sector block. Sector is "Agritech" — land-management and
+    compliance software for UK farmers.
 
     **Spelling: Regeno.** It was first published as "Regono" and corrected the same
     day. The company is `regeno.farm`; check the spelling against the source repos,

--- a/BRANDING.md
+++ b/BRANDING.md
@@ -356,6 +356,13 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     ItemList schema all say "Fractional CTO" and name Ankit. It previously advertised
     "Fractional CTO & CFO Outcomes" against no CFO content. Restore the dual framing in
     the same change that adds a CFO study, and never ahead of one.
+    **Codenest now has a client, and the page distinguishes it** (owner, 5 Aug 2026):
+    Regeno is a Codenest client engagement; Rungway, Opayo and AstraZeneca predate the
+    firm and are Ankit's own track record. Every card carries a `kind` label above its
+    title saying which it is — "Codenest client engagement" or "Founder track record".
+    Do not drop those labels to make the page look like a client wall; the whole
+    reason the distinction is drawn in copy is that the page can no longer rely on
+    "none of these are clients" being true. Any study added later needs a `kind`.
 16. **Michelle covers both operational finance and fundraising.** Her CV documents the
     operational side in detail — multi-site P&L, budgeting and rolling forecasts,
     controls and governance, margin and procurement, Board reporting — and the owner
@@ -458,9 +465,17 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     `status` and `note` together with the real numbers. Regeno is **not** in the
     homepage logo strip — that strip is captioned "Founder track record includes"
     and is not a client wall (§13.15). The study attributes the work to Ankit by
-    name, as the other three do; whether Regeno may additionally be described as a
-    Codenest *client*, and whether it has given permission to be named at all, is
-    unconfirmed and needs the owner before any copy claims it.
+    name, as the other three do.
+    **Confirmed 5 Aug 2026: Regeno is a client of Codenest** — the firm's first named
+    client engagement, and the first proof on the site that is not founder track
+    record. Copy may say so directly; `/case-studies`, the CTO page FAQ, the
+    PrincipalBand highlight and `/about` all do. The owner directed the naming twice;
+    written permission from Regeno to be named is not on file here, and getting it is
+    an owner action, not a blocker the site re-litigates.
+    **Still outstanding:** Regeno is not on the homepage logo strip. That needs a logo
+    asset and a caption that no longer says "Founder track record includes" — the
+    strip is currently true only because it holds no clients. Change the caption and
+    add the mark in one commit, never the mark alone.
 
     **Spelling: Regeno.** It was first published as "Regono" and corrected the same
     day. The company is `regeno.farm`; check the spelling against the source repos,

--- a/BRANDING.md
+++ b/BRANDING.md
@@ -224,7 +224,7 @@ Assemble pages from these; don't invent parallel patterns:
   `accent-400`+`text-primary-900` (financial). No emoji (§2.6). No icon fonts.
 - Alt text: logos are always `Codenest - Fractional CTO & CFO for UK startups`;
   content images describe the content, no keyword stuffing.
-- **A schematic beats a stock photo when no real photo exists.** The Regono case
+- **A schematic beats a stock photo when no real photo exists.** The Regeno case
   study renders a labelled charcoal stack of its platform layers rather than
   `service-ai.jpg`, which is an off-palette blue 3D "AI" render that says nothing.
   `PlatformDiagram` in `app/case-studies/page.js` takes the layers as data; a study
@@ -448,16 +448,41 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     observability. It stays a capability *inside* the Fractional CTO seat: it is not
     a nav destination, not a page of its own, and not a fifth entry in the layout's
     offer catalogue (§8, §13.26).
-29. **Regono is a live engagement, and the site says so.** (Owner, 5 Aug 2026.) It is
+29. **Regeno is a live engagement, and the site says so.** (Owner, 5 Aug 2026.) It is
     the first `/case-studies` entry that has not finished, so it breaks the card's
     usual shape on purpose: a status pill, headings relabelled to Brief / Build /
     What Is Being Built, and **no outcome figures at all**. The card prints a note
     stating that figures go up once measured and client-approved, which is §13.4
     made visible rather than an apology for a gap. Do not invent a metric, sector,
     funding stage, team size or timeline for it; get them from the owner, then drop
-    `status` and `note` together with the real numbers. Regono is **not** in the
+    `status` and `note` together with the real numbers. Regeno is **not** in the
     homepage logo strip — that strip is captioned "Founder track record includes"
     and is not a client wall (§13.15). The study attributes the work to Ankit by
-    name, as the other three do; whether Regono may additionally be described as a
+    name, as the other three do; whether Regeno may additionally be described as a
     Codenest *client*, and whether it has given permission to be named at all, is
     unconfirmed and needs the owner before any copy claims it.
+
+    **Spelling: Regeno.** It was first published as "Regono" and corrected the same
+    day. The company is `regeno.farm`; check the spelling against the source repos,
+    never against earlier site copy.
+
+    **Grounded 5 Aug 2026** against the owner's own repositories
+    (`~/workspace/regeno`), which replaced the first draft's generic description:
+    - **AI factory = Reggie** (`regeno/harlan`). It takes a unit of work from a
+      Linear ticket, GitHub issue or Slack message and drives it to a merged pull
+      request, unattended, with a ledger of every decision. Typed workflow graphs
+      (agent / action / wait nodes over guarded edges), an isolated sandbox per
+      run, bounded test and review re-entry, operator-set merge policy, MCP tool
+      bridging, and a learning loop that ranks each run's lessons back into later
+      runs on the same repository.
+    - **Regeno's own product** (`regeno/monorepo`) is land-management and
+      compliance software for UK farmers — SFI, Countryside Stewardship, Red
+      Tractor, environmental schemes — where evidence arrives as documents,
+      photographs, audio and video. That sector detail is now in the study.
+    - **"Company brain" is the owner's term, not the repos'.** It appears nowhere
+      in either codebase. The published description (queryable records exposed to
+      agents over MCP) is inferred from `monorepo/apps/mcp` and the platform's
+      document/audio/video handling. Confirm it before treating it as settled.
+    **Never publish:** any other client or tenant name found in those repos, and
+    the internal improvement plans or audit findings. Naming the stack at the level
+    the Opayo study does is fine; publishing another party's name is not ours to do.

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -125,7 +125,7 @@ export default function AboutPage() {
         { year: "2011-2015", title: "Enterprise Foundations", description: "Payment processors and financial services platforms at Deloitte Digital and Elavon (US Bancorp) — learning what enterprise-grade actually costs, and what startups can borrow from it." },
         { year: "2015-2017", title: "Scaling Startups", description: "Led engineering teams from 5 to 50+ across fintech and healthtech. Hypergrowth firsthand: the technical debt, the hiring mistakes, the architecture decisions that come back to haunt you." },
         { year: "2019-2026", title: "Payments at Scale", description: "Platform transformation at Opayo by Elavon — AWS EKS migration, GitOps and Infrastructure as Code, moving a payments monolith to microservices without dropping a transaction." },
-        { year: "2026-present", title: "Agentic AI Platforms", description: "Building a company brain and an AI factory at Regono: a retrieval layer over the organisation's own knowledge, plus the scaffolding, evaluation and guardrails that put agents into production and keep them honest there." },
+        { year: "2026-present", title: "Agentic AI Platforms", description: "Building a company brain and an AI factory at Regeno — a queryable layer over the organisation's own records, and a delivery platform that drives a ticket to a merged pull request unattended, with bounded review loops and a ledger of every decision." },
       ],
     },
     {

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -125,7 +125,7 @@ export default function AboutPage() {
         { year: "2011-2015", title: "Enterprise Foundations", description: "Payment processors and financial services platforms at Deloitte Digital and Elavon (US Bancorp) — learning what enterprise-grade actually costs, and what startups can borrow from it." },
         { year: "2015-2017", title: "Scaling Startups", description: "Led engineering teams from 5 to 50+ across fintech and healthtech. Hypergrowth firsthand: the technical debt, the hiring mistakes, the architecture decisions that come back to haunt you." },
         { year: "2019-2026", title: "Payments at Scale", description: "Platform transformation at Opayo by Elavon — AWS EKS migration, GitOps and Infrastructure as Code, moving a payments monolith to microservices without dropping a transaction." },
-        { year: "2026-present", title: "Agentic AI Platforms", description: "Building a company brain and an AI factory at Regeno — a queryable layer over the organisation's own records, and a delivery platform that drives a ticket to a merged pull request unattended, with bounded review loops and a ledger of every decision." },
+        { year: "2026-present", title: "Agentic AI Platforms", description: "Leading the Regeno engagement for Codenest: a company brain over the client's own records, and an AI factory that drives a ticket to a merged pull request unattended, with bounded review loops and a ledger of every decision." },
       ],
     },
     {

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -11,7 +11,7 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 // of its own, and not before.
 export const metadata = {
   title: 'Case Studies: Fractional CTO Engagements',
-  description: 'Technical engagements led by Ankit Rana, Fractional CTO: an agentic AI platform at Regeno, scaling Rungway to 1,000+ concurrent users, transforming payments at Opayo, and a compliant MVP for AstraZeneca.',
+  description: 'Fractional CTO work led by Ankit Rana: an agentic AI platform for Codenest client Regeno, plus the founder track record behind it at Rungway, Opayo by Elavon and AstraZeneca.',
   openGraph: {
     title: 'Codenest Case Studies — Track Record',
     description: 'Agentic AI platform engineering, scaling, payments and regulated delivery. Regeno, Rungway, Opayo by Elavon, AstraZeneca.',
@@ -31,6 +31,11 @@ export const metadata = {
   },
 }
 
+// `kind` is the load-bearing field. Regeno is a Codenest client; the other three
+// predate the firm and are Ankit's own track record (§13.15). Flattening the two
+// into one undifferentiated wall would read as four clients, which is the exact
+// claim §13.4 bars. Every study states which it is, above its own title.
+//
 // Three of these are completed engagements with measured outcomes. Regeno is
 // live, so it carries `status` and its third block is scope rather than results
 // — the card renderer relabels the headings from `labels` and prints `note`
@@ -39,10 +44,11 @@ export const metadata = {
 const caseStudies = [
   {
     title: "Regeno: A Company Brain and an AI Factory",
-    status: "Engagement in progress",
+    kind: "Codenest client engagement",
+    status: "In progress",
     labels: { challenge: "The Brief", solution: "The Build", results: "What Is Being Built" },
-    challenge: "Regeno builds land-management and compliance software for UK farmers, where the evidence that proves an agreement was met arrives as documents, photographs, audio and video rather than as tidy data. Two problems sat behind the AI work: knowledge the business already held that nothing could query, and a delivery backlog that no realistic amount of hiring was going to clear. The engagement treats both as one platform problem rather than two initiatives.",
-    solution: "The company brain makes the organisation's own records queryable and exposes them to agents over MCP, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt. The AI factory is the delivery half. It takes a unit of work from where it already lives — a Linear ticket, a GitHub issue, a Slack message — and drives it to a merged pull request: typed workflow graphs, an isolated sandbox per run, bounded test and review loops, and a merge policy the operator sets. Every run leaves a ledger of its decisions, and writes back what it learned for the next one to recall.",
+    challenge: "Regeno builds land-management and compliance software for UK farmers, where the evidence that proves an agreement was met arrives as documents, photographs, audio and video rather than as tidy data. Two problems sat behind the AI work: knowledge the business already held that nothing could query, and a delivery backlog that no realistic amount of hiring was going to clear. Codenest was brought in to treat both as one platform problem rather than two initiatives.",
+    solution: "The company brain makes Regeno's own records queryable and exposes them to agents over MCP, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt. The AI factory is the delivery half. It takes a unit of work from where it already lives — a Linear ticket, a GitHub issue, a Slack message — and drives it to a merged pull request: typed workflow graphs, an isolated sandbox per run, bounded test and review loops, and a merge policy the operator sets. Every run leaves a ledger of its decisions, and writes back what it learned for the next one to recall.",
     results: [
       "Queryable layer over the organisation's own records, exposed to agents over MCP",
       "Ticket in, reviewed and tested pull request out, running unattended",
@@ -59,6 +65,7 @@ const caseStudies = [
   },
   {
     title: "Rungway: Scaling a Social Mentoring Platform",
+    kind: "Founder track record",
     challenge: "A London-based HR-tech startup needed fractional CTO support to scale their social mentoring platform. The system could only handle 5 concurrent users before experiencing severe performance degradation — completely inadequate for their UK enterprise client base.",
     solution: "As Rungway's interim CTO, Ankit delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
     results: ["Scaled from 5 to 1000+ concurrent users", "Zero-downtime database migration", "Modern DevOps foundations established", "Event-driven microservices architecture"],
@@ -68,6 +75,7 @@ const caseStudies = [
   },
   {
     title: "Opayo by Elavon: Payment Platform Transformation",
+    kind: "Founder track record",
     challenge: "Leading UK fintech payment provider needed Kubernetes consulting to modernize their infrastructure and integrate new payment channels (Apple Pay, Google Pay) while maintaining 100% uptime for critical transaction processing across Europe.",
     solution: "Working inside the Opayo platform team from August 2019 to June 2026, Ankit orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
     results: ["Accelerated releases from every 2 weeks to multiple times per day", "Contributed to 10% revenue increase through faster feature delivery", "Reduced CI pipeline failures through automated testing", "Successfully integrated Apple Pay and Google Pay"],
@@ -77,6 +85,7 @@ const caseStudies = [
   },
   {
     title: "AstraZeneca: Drug Delivery Tracking System MVP",
+    kind: "Founder track record",
     challenge: "AstraZeneca needed to replace manual spreadsheet-based drug delivery tracking with a modern web-based tool to improve efficiency and accelerate time-to-market for pharmaceutical products. The system required integration with existing workflows while maintaining regulatory compliance.",
     solution: "Ankit built a production-grade web application with REST APIs and automated CI/CD pipelines, collaborating closely with stakeholders and business analysts to define requirements and align delivery with business goals — architecting scalable deployments on Kubernetes using Docker and Jenkins (config-as-code), and establishing robust testing practices with JUnit and Spock.",
     results: ["Accelerated delivery by 40% compared to manual processes", "Cut deployment errors by 30% through automated pipelines", "Improved stakeholder confidence through transparent roadmap planning", "Delivered production-ready MVP on Kubernetes infrastructure"],
@@ -92,10 +101,11 @@ const pageSchema = [
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'Codenest Case Studies',
-    // Every study on this page is a technical engagement led by Ankit. The
-    // description said "technical and financial" while no financial study
-    // existed — a claim the page could not back (BRANDING.md §2.2).
-    description: 'Technical leadership engagements led by Ankit Rana, Fractional CTO.',
+    // Every study on this page is technical and led by Ankit. The description
+    // said "technical and financial" while no financial study existed — a claim
+    // the page could not back (BRANDING.md §2.2). It names both categories the
+    // page holds rather than implying all four are client work (§13.15).
+    description: 'Fractional CTO work led by Ankit Rana: Codenest client engagements and the founder track record behind them.',
     itemListElement: caseStudies.map((study, index) => ({
       '@type': 'ListItem',
       position: index + 1,
@@ -149,7 +159,7 @@ export default function CaseStudiesPage() {
                   under a title that named the service and matched neither. */}
               <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Fractional CTO Case Studies</h1>
               <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-                Technical engagements led by Ankit Rana, Fractional CTO. Agentic AI platforms, scaling, payments and regulated delivery
+                Client engagements and the founder track record behind them, led by Ankit Rana, Fractional CTO. Each is labelled for which it is
               </p>
             </div>
 
@@ -179,11 +189,14 @@ export default function CaseStudiesPage() {
                       </div>
                     </div>
                     <div className={`p-10 lg:p-12 ${index % 2 === 0 ? 'lg:order-2' : 'lg:order-1'}`}>
-                      {study.status && (
-                        <p className="inline-block mb-4 px-3 py-1 rounded-full border border-accent-300 bg-accent-50 text-accent-800 text-xs font-semibold uppercase tracking-wide">
-                          {study.status}
-                        </p>
-                      )}
+                      <div className="flex flex-wrap items-center gap-3 mb-4">
+                        <p className="text-xs uppercase tracking-[0.2em] text-accent-700 font-semibold">{study.kind}</p>
+                        {study.status && (
+                          <span className="px-3 py-1 rounded-full border border-accent-300 bg-accent-50 text-accent-800 text-xs font-semibold uppercase tracking-wide">
+                            {study.status}
+                          </span>
+                        )}
+                      </div>
                       <h2 className="text-3xl font-bold text-slate-900 mb-4 group-hover:text-primary-700 transition-colors">{study.title}</h2>
                       <div className="space-y-6">
                         <div>

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -11,10 +11,10 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 // of its own, and not before.
 export const metadata = {
   title: 'Case Studies: Fractional CTO Engagements',
-  description: 'Technical engagements led by Ankit Rana, Fractional CTO: an agentic AI platform at Regono, scaling Rungway to 1,000+ concurrent users, transforming payments at Opayo, and a compliant MVP for AstraZeneca.',
+  description: 'Technical engagements led by Ankit Rana, Fractional CTO: an agentic AI platform at Regeno, scaling Rungway to 1,000+ concurrent users, transforming payments at Opayo, and a compliant MVP for AstraZeneca.',
   openGraph: {
     title: 'Codenest Case Studies — Track Record',
-    description: 'Agentic AI platform engineering, scaling, payments and regulated delivery. Regono, Rungway, Opayo by Elavon, AstraZeneca.',
+    description: 'Agentic AI platform engineering, scaling, payments and regulated delivery. Regeno, Rungway, Opayo by Elavon, AstraZeneca.',
     type: 'website',
     url: 'https://codenest.uk/case-studies/',
     images: [
@@ -31,30 +31,30 @@ export const metadata = {
   },
 }
 
-// Three of these are completed engagements with measured outcomes. Regono is
+// Three of these are completed engagements with measured outcomes. Regeno is
 // live, so it carries `status` and its third block is scope rather than results
 // — the card renderer relabels the headings from `labels` and prints `note`
 // instead of inventing figures nobody has measured yet (§4, §13.28). Fill in
 // real numbers and drop `status`/`note` when the engagement produces them.
 const caseStudies = [
   {
-    title: "Regono: A Company Brain and an AI Factory",
+    title: "Regeno: A Company Brain and an AI Factory",
     status: "Engagement in progress",
     labels: { challenge: "The Brief", solution: "The Build", results: "What Is Being Built" },
-    challenge: "Most companies meet AI twice over: institutional knowledge spread across documents, tools and people's heads with no way to query it, and AI pilots that arrive one at a time with nothing shared underneath them. This engagement treats both as a single platform problem rather than two initiatives.",
-    solution: "Ankit is building the company brain first: a retrieval layer over Regono's own documents, systems and process, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt. The AI factory sits on top of it: shared agent scaffolding, an evaluation harness, guardrails, and the deployment and observability that agents need once they are doing real work. It exists so the tenth agent does not cost what the first one did.",
+    challenge: "Regeno builds land-management and compliance software for UK farmers, where the evidence that proves an agreement was met arrives as documents, photographs, audio and video rather than as tidy data. Two problems sat behind the AI work: knowledge the business already held that nothing could query, and a delivery backlog that no realistic amount of hiring was going to clear. The engagement treats both as one platform problem rather than two initiatives.",
+    solution: "The company brain makes the organisation's own records queryable and exposes them to agents over MCP, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt. The AI factory is the delivery half. It takes a unit of work from where it already lives — a Linear ticket, a GitHub issue, a Slack message — and drives it to a merged pull request: typed workflow graphs, an isolated sandbox per run, bounded test and review loops, and a merge policy the operator sets. Every run leaves a ledger of its decisions, and writes back what it learned for the next one to recall.",
     results: [
-      "Retrieval layer over internal knowledge sources",
-      "Shared agent scaffolding and an evaluation harness",
-      "Guardrails, deployment and observability for production agents",
-      "One platform for agent delivery, rather than a build per project"
+      "Queryable layer over the organisation's own records, exposed to agents over MCP",
+      "Ticket in, reviewed and tested pull request out, running unattended",
+      "Typed workflow graphs: bounded retry, review and merge gates rather than one long prompt",
+      "A learning loop that ranks each run's lessons back into the next"
     ],
     note: "Outcome figures go up once they are measured and the client has approved them. This engagement is still running, so there are none here yet.",
-    tags: ["Agentic AI", "AI Platform Engineering", "Knowledge Retrieval", "Evaluation & Guardrails", "LLMOps"],
+    tags: ["Agentic AI", "AI Platform Engineering", "MCP", "Cloudflare Workers", "Knowledge Retrieval", "LLMOps"],
     diagram: [
-      { label: "Agents in production", detail: "Doing real work, watched" },
-      { label: "AI factory", detail: "Scaffolding, evaluation, deployment" },
-      { label: "Company brain", detail: "Retrieval over internal knowledge" },
+      { label: "Agents in production", detail: "Ticket in, merged PR out" },
+      { label: "AI factory", detail: "Workflow graphs, sandboxes, merge gates" },
+      { label: "Company brain", detail: "Queryable records, exposed over MCP" },
     ]
   },
   {

--- a/app/page.js
+++ b/app/page.js
@@ -273,9 +273,27 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Social Proof - Client Logos */}
+      {/* Social proof, in two labelled groups.
+          The strip used to carry one caption — "Founder track record includes" —
+          which was accurate only while Codenest had no clients to put in it.
+          Regeno is one (§13.15), so a client group exists rather than the client
+          being quietly filed under someone else's heading. The founder caption is
+          unchanged and still governs exactly the four marks it always did.
+          Regeno renders as a wordmark: no logo file has been supplied, and a
+          client's brand asset is not ours to lift. Drop an image into this slot
+          when they provide one. */}
       <section className="py-12 bg-slate-50/50 border-y border-slate-100">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <p className="text-center text-xs text-slate-500 mb-8 uppercase tracking-[0.2em] font-medium">Codenest clients</p>
+          <div className="flex flex-wrap justify-center items-center gap-8 md:gap-12 mb-12">
+            <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
+              <div>
+                <span className="text-lg font-semibold text-slate-700 group-hover:text-slate-900 transition-colors">Regeno</span>
+                <p className="text-xs text-slate-500">Agritech</p>
+              </div>
+            </div>
+          </div>
+
           <p className="text-center text-xs text-slate-500 mb-8 uppercase tracking-[0.2em] font-medium">Founder track record includes</p>
           <div className="flex flex-wrap justify-center items-center gap-8 md:gap-12">
             {/* Rungway - HR Tech */}

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -120,7 +120,7 @@ export default function FractionalCTOPage() {
   const faqs = [
     {
       question: "Do you build agentic AI, or only advise on it?",
-      answer: "Build. Ankit is currently building a company brain and an AI factory at Regeno: a queryable layer over the organisation's own records, and a delivery platform that takes a ticket from Linear, GitHub or Slack and drives it to a merged pull request unattended. The person advising on the architecture is the person writing it."
+      answer: "Build. Regeno is a current Codenest client, and the engagement is a company brain and an AI factory: a queryable layer over their own records, and a delivery platform that takes a ticket from Linear, GitHub or Slack and drives it to a merged pull request unattended. The person advising on the architecture is the person writing it."
     },
     {
       question: "Everyone is telling us to build AI agents. How do you decide whether we should?",
@@ -256,7 +256,7 @@ export default function FractionalCTOPage() {
         credentials={['AWS Certified', '15+ years engineering', 'Kubernetes & Cloud', 'Agentic AI']}
         bio="Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
         highlights={[
-          'Currently building a company brain and an AI factory at Regeno: queryable knowledge exposed to agents, and a platform that drives a ticket to a merged pull request unattended',
+          'Leads the Regeno engagement, a current Codenest client: a company brain over their own records, and an AI factory that drives a ticket to a merged pull request unattended',
           'Led engineering teams from 5 to 50+ across fintech and healthtech',
           'Ran a near seven-year platform transformation at Opayo by Elavon: AWS EKS migration, GitOps, a payments monolith moved to microservices',
           'Rebuilt Rungway as its interim CTO, taking the platform from 5 to 1,000+ concurrent users with a zero-downtime migration',

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -96,20 +96,20 @@ export default function FractionalCTOPage() {
 
   // The capability the market is asking for right now, given its own band rather
   // than a bullet inside "What We Do". Each block describes work Codenest does,
-  // not a claim about results — the Regono engagement is live and its outcome
+  // not a claim about results — the Regeno engagement is live and its outcome
   // figures are not published yet (§13.28).
   const agenticLayers = [
     {
       title: "The company brain",
-      description: "One retrieval layer over your own documents, systems and process, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt.",
+      description: "One queryable layer over your own documents, records and process, exposed to agents over MCP, so that people and agents answer from what the business already knows rather than from whatever fits in a prompt.",
     },
     {
       title: "The AI factory",
-      description: "The platform underneath agent delivery: shared scaffolding, an evaluation harness, guardrails, deployment and observability. It is what stops the tenth agent costing what the first one did.",
+      description: "The platform underneath agent delivery: typed workflow graphs, an isolated sandbox per run, bounded test and review loops, merge gates you control, and a ledger of every decision. It is what stops the tenth agent costing what the first one did.",
     },
     {
-      title: "Evaluation before scale",
-      description: "An agent with no evaluation harness is a demo. Measurement goes in before volume does, so you can tell a real regression from a bad afternoon.",
+      title: "Evaluation and learning",
+      description: "An agent with no evaluation harness is a demo. Measurement goes in before volume does, and what each run learns is captured and recalled into the next, so the system gets cheaper as it runs rather than dearer.",
     },
     {
       title: "Cost and latency discipline",
@@ -120,7 +120,7 @@ export default function FractionalCTOPage() {
   const faqs = [
     {
       question: "Do you build agentic AI, or only advise on it?",
-      answer: "Build. Ankit is currently building a company brain and an AI factory at Regono: a retrieval layer over internal knowledge, and the platform that puts agents into production against it. The person advising on the architecture is the person writing it."
+      answer: "Build. Ankit is currently building a company brain and an AI factory at Regeno: a queryable layer over the organisation's own records, and a delivery platform that takes a ticket from Linear, GitHub or Slack and drives it to a merged pull request unattended. The person advising on the architecture is the person writing it."
     },
     {
       question: "Everyone is telling us to build AI agents. How do you decide whether we should?",
@@ -256,7 +256,7 @@ export default function FractionalCTOPage() {
         credentials={['AWS Certified', '15+ years engineering', 'Kubernetes & Cloud', 'Agentic AI']}
         bio="Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
         highlights={[
-          'Currently building a company brain and an AI factory at Regono: retrieval over internal knowledge, and the platform that ships agents against it',
+          'Currently building a company brain and an AI factory at Regeno: queryable knowledge exposed to agents, and a platform that drives a ticket to a merged pull request unattended',
           'Led engineering teams from 5 to 50+ across fintech and healthtech',
           'Ran a near seven-year platform transformation at Opayo by Elavon: AWS EKS migration, GitOps, a payments monolith moved to microservices',
           'Rebuilt Rungway as its interim CTO, taking the platform from 5 to 1,000+ concurrent users with a zero-downtime migration',
@@ -358,7 +358,7 @@ export default function FractionalCTOPage() {
                 Most companies have AI pilots. Far fewer have anything underneath them: no shared knowledge layer, no evaluation, no way to ship the second agent faster than the first. That gap is the work.
               </p>
               <Link href="/case-studies/" className="inline-flex items-center gap-2 font-semibold text-accent-300 hover:text-accent-200">
-                See the Regono engagement
+                See the Regeno engagement
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
                 </svg>


### PR DESCRIPTION
## Why this exists

[PR #49](https://github.com/cod3nest/cod3nest.github.io/pull/49) merged at its **first commit only** — three follow-up commits never reached the remote before it was merged and the branch deleted. This restores them on top of current `master`.

The live site currently spells the client's name **"Regono"**. It is **Regeno** (`regeno.farm`). That is the one item here worth moving on; the rest is understated rather than incorrect.

## What changed

### 1. `f0a0f47` — the name, and copy grounded in the client's repos

- **Regono → Regeno** across `/case-studies`, `/about`, the CTO service page, the PrincipalBand highlight and BRANDING. The original spelling was taken from a chat message and never checked.
- The AI factory description was generic because the first draft had only two nouns to work from. It is now what the source actually shows: a platform that takes a unit of work from a Linear ticket, GitHub issue or Slack message and drives it to a merged pull request unattended — typed workflow graphs, an isolated sandbox per run, bounded test and review loops, an operator-set merge policy, a ledger of every decision, and a learning loop that ranks each run's lessons into the next.
- The brief gained its sector: land-management and compliance software for UK farmers, where evidence arrives as documents, photographs, audio and video.

**Deliberately excluded:** another company named in a cutover runbook in the client's monorepo, the internal improvement plans and audit findings, and the secrets/identity vendors. Stack naming stays where the Opayo study already sets it.

### 2. `8c81b29` — Regeno named as a client, and `kind` labels

Regeno is a Codenest client — the firm's first named client engagement and the first proof on the site that is not founder track record.

That confirmation creates an accuracy problem the page did not previously have. `/case-studies` used to hold four items that were all pre-Codenest, so nothing needed distinguishing. It now mixes one client engagement with three pieces of Ankit's own history, and presenting them identically would read as four clients — the claim §13.4 bars. Every card now carries a `kind` label above its title: **"Codenest client engagement"** or **"Founder track record"**.

### 3. `5a1705f` — homepage strip split into two groups

The strip carried one caption, "Founder track record includes", accurate only while Codenest had no client to put in it. Rewording it to cover both would have filed the client under someone else's heading *or* relabelled Rungway, Opayo, AstraZeneca and Dishoom as something they are not. It is now two labelled groups: **"Codenest clients"** above **"Founder track record includes"**, with the founder caption and its four marks untouched.

Regeno renders as a **wordmark, not a logo** — no asset was supplied, and a client's brand asset is not ours to lift from their codebase. The slot takes an `<img>` when they provide one.

## Reviewer notes

- **"Company brain" is the owner's term, not the repos'** — it appears in neither codebase. The published description (queryable records exposed to agents over MCP) is inferred from `apps/mcp` and the platform's document/audio/video handling, and BRANDING flags it as unconfirmed.
- Written permission from Regeno to be named is not on file here. The owner directed the naming; that is an owner action, not something the site re-litigates.
- BRANDING §13.15, §13.28 and §13.29 all updated to record these decisions.

## Verification

- `npm run build` clean; **zero `Regono` in source or build output**
- Zero WCAG AA failures on `/`, `/case-studies` and `/services/fractional-cto` at 1280px and 375px
- No horizontal overflow at either width; both strip captions hold one line at 375px; the case-study label row wraps rather than overflowing on mobile
- The CTO page still names no one but Ankit

🤖 Generated with [Claude Code](https://claude.com/claude-code)