### PR TITLE
Feature the Regeno engagement on the homepage

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -371,6 +371,12 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     Do not drop those labels to make the page look like a client wall; the whole
     reason the distinction is drawn in copy is that the page can no longer rely on
     "none of these are clients" being true. Any study added later needs a `kind`.
+    **The homepage teaser carries the same split** (5 Aug 2026): the client engagement
+    is a featured charcoal card, the three track-record studies sit in the grid below
+    under their own "Founder track record" label. It is a hand-maintained summary, not
+    a render of `/case-studies` data — when a study is added, edited or reordered
+    there, update `featuredStudy`/`caseStudies` in `app/page.js` too. It was already
+    stale once.
 16. **Michelle covers both operational finance and fundraising.** Her CV documents the
     operational side in detail — multi-site P&L, budgeting and rolling forecasts,
     controls and governance, margin and procurement, Board reporting — and the owner

--- a/app/page.js
+++ b/app/page.js
@@ -8,6 +8,17 @@ import Testimonials from './components/Testimonials'
 export default function Home() {
 
   // Teaser data only — the full case studies live at /case-studies
+  // The one live client engagement, kept separate from the grid below. It is the
+  // only client work on this page, and dropping it in as a fourth equal tile
+  // would repeat the flattening /case-studies was fixed for (§13.15, §13.29).
+  const featuredStudy = {
+    kind: "Codenest client engagement",
+    status: "In progress",
+    title: "Regeno: A Company Brain and an AI Factory",
+    summary: "Agentic AI for a UK agritech platform: a queryable layer over the client's own records, and a delivery platform that takes a ticket from Linear, GitHub or Slack and drives it to a merged pull request unattended.",
+    layers: ["Agents in production", "AI factory", "Company brain"],
+  }
+
   const caseStudies = [
     {
       title: "Rungway: Scaling a Social Mentoring Platform",
@@ -384,9 +395,46 @@ export default function Home() {
             <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Proven Track Record</p>
             <h2 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">Case Studies</h2>
             <p className="text-xl text-slate-600 max-w-3xl mx-auto">
-              Startup outcomes, backed by enterprise-grade experience
+              A live client engagement, and the founder track record behind it
             </p>
           </div>
+
+          {/* Featured, on charcoal: this is the agentic AI work, and the only
+              client engagement on the page. The layer names match the diagram on
+              /case-studies so the two read as the same thing. */}
+          <Link href="/case-studies/" className="group block mb-12">
+            <article className="bg-primary-800 border border-primary-700 rounded-xl p-8 md:p-10 hover:shadow-xl transition-all">
+              <div className="flex flex-wrap items-center gap-3 mb-5">
+                <p className="text-xs uppercase tracking-[0.2em] text-accent-300 font-semibold">{featuredStudy.kind}</p>
+                <span className="px-3 py-1 rounded-full border border-accent-300 text-accent-300 text-xs font-semibold uppercase tracking-wide">
+                  {featuredStudy.status}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 lg:gap-12 items-start">
+                <div className="lg:col-span-3">
+                  <h3 className="font-serif text-3xl font-bold text-white mb-4 leading-snug">{featuredStudy.title}</h3>
+                  <p className="text-slate-300 leading-relaxed mb-6">{featuredStudy.summary}</p>
+                  <span className="inline-flex items-center text-sm font-semibold text-accent-300 group-hover:text-accent-200">
+                    Read the case study
+                    <svg className="w-4 h-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                    </svg>
+                  </span>
+                </div>
+
+                <div className="lg:col-span-2 space-y-3">
+                  {featuredStudy.layers.map((layer) => (
+                    <div key={layer} className="rounded-lg border border-primary-600 bg-primary-700 px-4 py-3">
+                      <p className="text-white text-sm font-semibold">{layer}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </article>
+          </Link>
+
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500 mb-8 font-medium">Founder track record</p>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {caseStudies.map((study, index) => (
               <Link key={index} href="/case-studies/" className="group">


### PR DESCRIPTION
## Why

The homepage case-studies teaser listed three studies and was **already stale** — it predated Regeno entirely, so the agentic AI work the technical track now leads with appeared nowhere on the homepage.

It also flattened client work into founder track record: the same problem `/case-studies` was fixed for in #50. Adding Regeno as a fourth equal tile would have repeated it, and left an orphan in a three-column grid.

## What changed

A **featured charcoal card** for the live client engagement, above the three track-record studies under their own label:

- Carries both labels — "Codenest client engagement" and "In progress"
- Names the three platform layers (Agents in production / AI factory / Company brain), matching the diagram on `/case-studies` so the two read as the same thing
- One-paragraph summary naming the sector and what the platform actually does

The section sub changed from "Startup outcomes, backed by enterprise-grade experience" to "A live client engagement, and the founder track record behind it" — the old line covered both categories by being vague about each.

## One thing worth knowing

This teaser is **hand-maintained**, not rendered from the `/case-studies` data. That drift is what put a three-item list under a four-item page. BRANDING now says to update `featuredStudy` / `caseStudies` in `app/page.js` whenever a study is added, edited or reordered on `/case-studies`.

Rendering both from one source would be the better fix, but it means moving the study data into a shared module and is a bigger change than this one — worth doing if the list grows again.

## Balance note

This section was already 3:0 CTO, and is now 4:0. The Fractional CFO seat still has no case study of its own, which remains the largest outstanding credibility gap on the site and needs a citable, permissioned client outcome from you rather than anything I can write.

## Verification

| Width | Contrast | Overflow | Notes |
|---|---|---|---|
| 1440px | 0 AA failures | none | featured card 311px, sits above the grid |
| 375px | 0 AA failures | none | layer chips stack under the heading, all inside the card |

One h1 on the page; heading order unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)