### PR TITLE
Add blog post: How CFOs can use Claude in startup finance

### DIFF
--- a/content/blog/how-cfos-use-claude-ai-finance.md
+++ b/content/blog/how-cfos-use-claude-ai-finance.md
@@ -1,0 +1,152 @@
+---
+title: 'How CFOs Can Use Claude: A Practical Guide to AI in Startup Finance'
+seoTitle: 'How CFOs Can Use Claude for Startup Finance'
+description: 'A plain-English guide for finance leaders: what Claude does well, where it cannot be trusted, how to handle confidential data, and how to trial it in two weeks.'
+date: '2026-08-05'
+author: 'Michelle Rana'
+readTime: '11 min read'
+tags: ['Fractional CFO', 'AI', 'Startup Finance']
+---
+
+# How CFOs Can Use Claude: A Practical Guide to AI in Startup Finance
+
+Most finance leaders have now had the same week. Someone forwards an article about AI, the board asks what the company is doing about it, and the honest answer is a shrug. The material available tends to fall into two piles: breathless claims about replacing the finance function, or technical documentation written for engineers.
+
+This guide is neither. It is written for a founder or finance lead who wants to know what an AI assistant like Claude actually does inside a finance function, what it does badly, and what a sensible first month looks like. No coding knowledge is assumed.
+
+## What Claude Actually Is, in Plain Terms
+
+Claude is an AI assistant built by Anthropic. You use it much as you would a chat window or a document editor: you type a request, attach any files it needs, and it responds in writing. It can read what you give it, including PDFs, spreadsheets and exports from your accounting system, and it can produce written analysis, tables, drafts and summaries in return.
+
+Three things about it matter to a finance leader.
+
+**It works from documents you give it.** It becomes useful when you hand it your management accounts, your model and your last three board packs, then ask it to draft this month's variance commentary in the same format. Asking it general questions from a blank page wastes most of what it can do.
+
+**It reads a lot at once.** You can put a full data room index, a 40-page shareholders' agreement or a year of monthly reports in front of it and ask questions across the whole set. This is the capability that changes how a small finance team spends its week.
+
+**It writes and checks calculations properly.** For anything numerical, Claude can write and run analysis code rather than estimating in prose. That distinction matters. A language model asked to add a column in its head is guessing. The same model writing a short script to add the column is doing arithmetic. When you use it for numbers, ask it to show the working.
+
+There is one honest caveat before any of the use cases below. Claude is a drafting and analysis tool that sits under your review. It is not a filing system of record, it is not an auditor, and it does not carry professional liability. Your name still goes on the board pack.
+
+## Seven Places It Earns Its Keep
+
+### 1. Turning Management Accounts Into a Board Narrative
+
+The monthly close produces numbers. The board wants a story: what moved, why, what it means for the plan, and what you intend to do about it. Writing that narrative is a two-to-four-hour job for most finance leads, and it happens under time pressure at the worst point in the month.
+
+Give Claude the current month's P&L, the budget, the prior three months and last quarter's board pack. Ask for a first-draft commentary in the same structure and tone as the previous pack. What comes back is roughly seventy per cent of a document: the variances identified, the movements described, the format matched.
+
+The remaining thirty per cent is the part only you can write. Claude can see that marketing overspent by £18,000. It cannot know that you authorised it for a conference that produced the pipeline the board will ask about. Judgement stays with you; the typing does not have to.
+
+### 2. Interrogating a Financial Model You Did Not Build
+
+Every finance leader inherits a spreadsheet. Someone built it, they left, and it is now load-bearing.
+
+Claude is unusually good at this task. Upload the model and ask what drives revenue, which assumptions the output is most sensitive to, where hardcoded numbers sit inside formulas, and where the logic contradicts itself. It reads the structure rather than the story you were told about it.
+
+This works as a review layer on models you did build, too. Before a model goes to an investor, asking a fresh reader to hunt for circular references, broken links and assumptions that are stated in one tab and ignored in another is cheap insurance. Our guide to [financial modelling for seed-stage startups](/blog/financial-modeling-seed-stage-startups/) covers what that model needs to contain in the first place.
+
+### 3. Preparing for Investor Due Diligence
+
+Diligence is a document-handling problem wearing a finance costume. A typical process involves hundreds of files and a request list that arrives in whatever format the investor's analyst prefers.
+
+Three jobs suit an AI assistant well here:
+
+- **Gap analysis.** Give it your data room index and a standard request list, and ask what is missing. It is faster and more literal-minded than a human doing the same sweep at 11pm.
+- **Consistency checking.** Ask it to compare the headline numbers in your deck, your model and your statutory accounts, and to flag every place they disagree. Investors will run this check. Running it first is strictly better.
+- **Question rehearsal.** Ask it to read your materials as a sceptical investor and produce the twenty hardest questions. The list is uncomfortable and useful. Pair it with our walkthrough of [what to expect in investor due diligence](/blog/investor-due-diligence-what-to-expect/) and our guide to [building your first data room](/blog/building-your-first-data-room/).
+
+### 4. Scenario Planning and Runway Conversations
+
+Runway questions rarely arrive as one question. They arrive as a chain: what happens if the raise slips a quarter, and we hold hiring, and one large customer churns.
+
+Working through that chain by hand means rebuilding a spreadsheet three times. Describing it in writing and asking for the cash impact of each branch, with the arithmetic shown, gets you to the shape of the answer in minutes. You then rebuild the branch that matters in your actual model, because the model is the artefact your board reviews.
+
+Use it to explore, then commit the answer to a tool you control. For a quick first pass on the base case, our free [Startup Runway Calculator](/tools/runway-calculator/) does the simple version, and our [practical guide to extending runway](/blog/extending-startup-runway-practical-guide/) covers the levers worth pulling.
+
+### 5. Reading Contracts for Their Financial Consequences
+
+Customer agreements, supplier terms and your own facility documents all carry finance implications that legal review does not always surface in a form you can model: payment terms, indexation, auto-renewal, termination penalties, revenue-recognition triggers, currency exposure.
+
+Ask Claude to read a contract and produce a table of every clause with a cash or accounting consequence, with the clause reference beside each row. You get a working list in minutes, and the references let you verify each line against the document.
+
+This supplements legal advice and does not replace it. For anything that binds the company, a solicitor still reads it.
+
+### 6. Spreadsheet and Data Work Without an Analyst
+
+Small finance teams lose hours to data janitorial work: reconciling exports that do not agree, reshaping a payroll file, categorising eighteen months of transactions, pivoting a customer list into cohorts.
+
+This is the least glamorous use and often the highest-value one. Upload the file, describe what you want, and ask for the output as a spreadsheet with the method explained. Cohort analysis that would take an afternoon of pivot tables becomes a short conversation, which in turn makes it realistic to actually track the metrics in our primer on [startup unit economics](/blog/startup-unit-economics-explained/).
+
+Always ask for the workings, and always spot-check totals against a source you trust.
+
+### 7. Policy, Process and the Documents Nobody Wants to Write
+
+Expenses policy. Approval matrix. Month-end close checklist. Revenue recognition memo. Board reporting calendar. These documents matter for governance and diligence, and they sit undone for months because writing them from a blank page is miserable.
+
+Describe your company, your stage and your controls, and ask for a first draft. Editing a competent draft into something that fits your business is a different order of task from starting cold.
+
+## Where It Should Not Be Trusted
+
+An honest guide has to be specific about the failure modes.
+
+**It can state wrong things confidently.** This is the defining risk. A model can produce a plausible figure, a misremembered accounting rule or a citation that does not exist, in the same assured tone it uses when correct. The mitigation is procedural: for any number that leaves the building, the source document is the authority and the AI output is a draft. Ask for workings, then check them.
+
+**It is not current on regulation.** Tax rates, thresholds, reporting requirements and accounting standards change. Any model has a knowledge cut-off, and finance rules move afterwards. Treat regulatory answers as a starting point for a conversation with your accountant, never as the answer. For UK-specific matters such as R&D relief, [SEIS and EIS](/blog/seis-eis-tax-benefits-startup-investors/) or statutory filing, confirm with a qualified adviser.
+
+**It does not know your business.** It has no access to the conversation with your largest customer, the reason the founders set that price, or the commitment made verbally in a board meeting. Context you do not supply does not exist.
+
+**It cannot sign anything.** Statutory accounts, tax filings and audit opinions require a person with a qualification and professional liability. No AI output changes that.
+
+**Reproducibility is imperfect.** Ask the same question twice and the wording will differ. For anything reported repeatedly, fix the format in a template and require the same structure each time, rather than trusting the assistant to remember what you liked last month.
+
+## Confidentiality and Compliance
+
+This is the part finance leaders are right to ask about first, and it is largely a procurement question rather than a technology one.
+
+**Read the terms that apply to your plan.** Anthropic's commercial terms state that business inputs and outputs are not used to train its models by default, and business plans offer administrative controls and data retention settings. Consumer and business plans differ. Have whoever owns IT read the current terms for the specific plan you are buying, and record the answer.
+
+**Decide what may be uploaded before anyone uploads anything.** A one-page rule is enough. In most startups it lands somewhere near: management accounts, models and internal policies are fine; personal data, payroll at individual level, customer personal data, credentials and anything under a confidentiality obligation to a third party are not, unless legal has cleared it.
+
+**UK GDPR follows the data wherever it goes.** Putting personal data into any third-party service makes that service a processor. That needs a lawful basis, a processing agreement, and an entry in your record of processing activities. Most finance use cases do not require personal data at all, and the simplest control is to strip it before upload.
+
+**Keep the audit trail human.** Whatever the assistant contributes, the reviewable trail should show a named person who checked the output against source documents. If a figure cannot be traced to a source, it does not ship.
+
+**Tell your auditor.** Auditors are increasingly asking how AI tools are used in preparing financial information. A short written policy answers the question in one exchange instead of five.
+
+## A Sensible First Fortnight
+
+Skip the strategy document. Run a trial.
+
+**Week one: one task, measured.** Pick the recurring job you dislike most. For most finance leads that is board commentary or the month-end reconciliation pack. Do it your usual way and note the time. Then do the next one with Claude and note the time and the quality honestly. One task, one comparison.
+
+**Week two: build the prompt into a template.** The difference between a disappointing result and a useful one is almost always the input. A weak prompt says "analyse these accounts". A strong one says: here are the management accounts, the budget and the last three board packs; draft this month's commentary in the same structure; flag every variance over £5,000 or ten per cent; state where the data does not support a conclusion; show your workings on every calculation.
+
+Save the strong version. Reuse it monthly. That saved prompt is the actual asset, and it is worth more than any amount of general enthusiasm about AI.
+
+**Then decide with evidence.** After two weeks you will have real hours saved on real work, a view on output quality, and a list of tasks where it did not help. That is a board answer. A pilot on one workflow is also a far better first step than a company-wide rollout that nobody has tested.
+
+## How to Tell It Is Working
+
+The useful measures are boring:
+
+- Hours from close to a board-ready pack
+- Number of times a variance needs a follow-up because the commentary did not explain it
+- Time to answer an investor diligence request
+- Whether the analysis you always meant to do, on cohorts, on margin by segment, on cost-to-serve, now actually gets done
+
+The last one matters most. In a small finance function the realistic gain shows up as analysis that was previously unaffordable becoming routine, which is the gap between reporting what happened and influencing what happens next. Headcount reduction is rarely the point at this stage, because there is rarely any headcount to reduce.
+
+## The Bottom Line
+
+Claude does not replace a finance leader. It removes a large share of the mechanical work around one: the first drafts, the document sweeps, the reshaping of data, the reconciliation of what three files claim about the same number.
+
+For a startup finance function of one or two people, that shift is material. The judgement, the relationships, the accountability and the decisions all stay exactly where they were. The typing and the tedium do not have to.
+
+Start with one task. Measure it. Write down what may be uploaded before anyone uploads it. Keep a human between every AI output and every decision.
+
+If you want a deeper view of what the finance seat covers at this stage, read our [complete fractional CFO guide](/guides/fractional-cfo-guide/). If you are thinking beyond personal productivity, towards AI systems built into how your company operates, that sits on the technical side of the house and is covered by our [Fractional CTO service](/services/fractional-cto/).
+
+---
+
+*Want a finance function that uses these tools well and still stands up to diligence? Explore our [Fractional CFO services](/services/fractional-cfo/), check your numbers with the free [Startup Runway Calculator](/tools/runway-calculator/), or [get in touch](/contact/) to discuss your situation.*


### PR DESCRIPTION
## What

New blog post at `/blog/how-cfos-use-claude-ai-finance/` — a plain-English guide to using Claude in a startup finance function, written for a non-technical CFO/founder audience.

~2,300 words. Structure:

- What Claude actually is, in plain terms
- Seven concrete use cases: board narrative from management accounts, interrogating an inherited model, diligence prep, scenario/runway planning, contract review for financial consequences, spreadsheet and data work, policy drafting
- Where it should not be trusted (confident errors, stale regulation, no business context, cannot sign anything, imperfect reproducibility)
- Confidentiality and UK GDPR handling
- A two-week trial plan and how to measure it

## Brand compliance (`BRANDING.md`)

- Authored to the CFO seat, Michelle Rana (§2.4)
- Finance tags route the end-of-post CTA to Fractional CFO — verified in built HTML
- Title 54 chars with the `%s | Codenest` template, description exactly 160 (§8)
- `BlogPosting` schema emitted; present in sitemap and RSS feed
- No em-dashes, no emojis, British English, no "X meets Y" / "X, not Y" constructions (§13.18)
- No invented statistics (§2.2), no Codenest prices (§13.24), no client claims involving AI
- Cross-links the CTO track per §12

## Judgement calls

**Anthropic plan terms are hedged deliberately.** The confidentiality section tells the reader to verify the terms for their specific plan rather than stating plan-level data-retention specifics. Those change, and a wrong compliance claim on a CFO-audience post is the expensive kind of error.

**Reggie / Regeno is deliberately not referenced.** There is a real publishable AI proof point (§13.29), but it belongs to the CTO track and would muddy a CFO-audience post. The piece links to `/services/fractional-cto/` instead. A separate CTO-side post is the honest way to use that story.

## Note for review

This introduces a new `AI` tag. Tags are free-form so nothing breaks, but §13.28 names the capability "agentic AI" — worth settling `AI` vs `Agentic AI` before more AI content lands, to avoid fragmenting the blog index.

## Verification

`npm run build` passes. Page, sitemap entry, RSS entry, title, description, schema and CTA routing all confirmed in the static export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)