### PR TITLE
Re-angle CFO AI post to the category query, fix orphan internal linking

### DIFF
--- a/app/guides/fractional-cfo-guide/page.js
+++ b/app/guides/fractional-cfo-guide/page.js
@@ -212,6 +212,11 @@ export default function FractionalCFOGuidePage() {
                     Related reading: Financial modelling for seed-stage startups →
                   </Link>
                 </p>
+                <p className="mt-2">
+                  <Link href="/blog/how-cfos-use-ai-startup-finance/" className="text-primary-600 hover:text-primary-700 font-medium">
+                    Related reading: How CFOs can use AI in startup finance →
+                  </Link>
+                </p>
 
                 <h3 className="text-xl font-bold text-slate-900 mt-8 mb-4">Cash &amp; Runway Management</h3>
                 <ul>

--- a/content/blog/financial-modeling-seed-stage-startups.md
+++ b/content/blog/financial-modeling-seed-stage-startups.md
@@ -191,6 +191,8 @@ They're not looking for perfect predictions—they're assessing whether you unde
 
 For seed-stage startups, Google Sheets is usually sufficient. The tool matters less than the thinking behind the model.
 
+An AI assistant is a useful reviewer at this point rather than a modelling tool in its own right: it will read a finished model and report which assumptions drive the output, where hardcoded numbers sit inside formulas, and where two tabs contradict each other. Our guide to [how CFOs can use AI in startup finance](/blog/how-cfos-use-ai-startup-finance/) covers that review pass, and the checks you should never delegate to it.
+
 ## Template Structure
 
 A well-organised model typically has these tabs:

--- a/content/blog/how-cfos-use-ai-startup-finance.md
+++ b/content/blog/how-cfos-use-ai-startup-finance.md
@@ -1,22 +1,24 @@
 ---
-title: 'How CFOs Can Use Claude: A Practical Guide to AI in Startup Finance'
-seoTitle: 'How CFOs Can Use Claude for Startup Finance'
-description: 'A plain-English guide for finance leaders: what Claude does well, where it cannot be trusted, how to handle confidential data, and how to trial it in two weeks.'
+title: 'How CFOs Can Use AI in Startup Finance: A Practical Guide'
+seoTitle: 'How CFOs Can Use AI in Startup Finance'
+description: 'Plain-English guide for finance leaders: seven jobs AI does well, where it cannot be trusted, how to handle confidential data, and how to trial it in two weeks.'
 date: '2026-08-05'
 author: 'Michelle Rana'
 readTime: '11 min read'
 tags: ['Fractional CFO', 'AI', 'Startup Finance']
 ---
 
-# How CFOs Can Use Claude: A Practical Guide to AI in Startup Finance
+# How CFOs Can Use AI in Startup Finance: A Practical Guide
 
 Most finance leaders have now had the same week. Someone forwards an article about AI, the board asks what the company is doing about it, and the honest answer is a shrug. The material available tends to fall into two piles: breathless claims about replacing the finance function, or technical documentation written for engineers.
 
-This guide is neither. It is written for a founder or finance lead who wants to know what an AI assistant like Claude actually does inside a finance function, what it does badly, and what a sensible first month looks like. No coding knowledge is assumed.
+This guide is neither. It is written for a founder or finance lead who wants to know what an AI assistant actually does inside a finance function, what it does badly, and what a sensible first month looks like. No coding knowledge is assumed.
 
-## What Claude Actually Is, in Plain Terms
+Every example below uses Claude, the AI assistant built by Anthropic, because a guide written against a specific tool is more useful than one written against a category. The use cases, the failure modes and the confidentiality rules apply broadly to the assistants a UK startup is likely to be choosing between.
 
-Claude is an AI assistant built by Anthropic. You use it much as you would a chat window or a document editor: you type a request, attach any files it needs, and it responds in writing. It can read what you give it, including PDFs, spreadsheets and exports from your accounting system, and it can produce written analysis, tables, drafts and summaries in return.
+## What an AI Assistant Actually Is, in Plain Terms
+
+You use an assistant like Claude much as you would a chat window or a document editor: you type a request, attach any files it needs, and it responds in writing. It can read what you give it, including PDFs, spreadsheets and exports from your accounting system, and it can produce written analysis, tables, drafts and summaries in return.
 
 Three things about it matter to a finance leader.
 
@@ -28,7 +30,7 @@ Three things about it matter to a finance leader.
 
 There is one honest caveat before any of the use cases below. Claude is a drafting and analysis tool that sits under your review. It is not a filing system of record, it is not an auditor, and it does not carry professional liability. Your name still goes on the board pack.
 
-## Seven Places It Earns Its Keep
+## Seven Finance Jobs AI Does Well
 
 ### 1. Turning Management Accounts Into a Board Narrative
 
@@ -86,7 +88,7 @@ Expenses policy. Approval matrix. Month-end close checklist. Revenue recognition
 
 Describe your company, your stage and your controls, and ask for a first draft. Editing a competent draft into something that fits your business is a different order of task from starting cold.
 
-## Where It Should Not Be Trusted
+## Where AI Should Not Be Trusted With Finance
 
 An honest guide has to be specific about the failure modes.
 
@@ -100,7 +102,7 @@ An honest guide has to be specific about the failure modes.
 
 **Reproducibility is imperfect.** Ask the same question twice and the wording will differ. For anything reported repeatedly, fix the format in a template and require the same structure each time, rather than trusting the assistant to remember what you liked last month.
 
-## Confidentiality and Compliance
+## Confidentiality, UK GDPR and Your Auditor
 
 This is the part finance leaders are right to ask about first, and it is largely a procurement question rather than a technology one.
 

--- a/content/blog/when-to-hire-fractional-cfo.md
+++ b/content/blog/when-to-hire-fractional-cfo.md
@@ -51,7 +51,7 @@ You raised, and now you owe monthly or quarterly updates. Each one is a night-be
 
 **The problem:** Inconsistent reporting does more damage than founders realise. When a metric changes definition between board packs, investors notice — and start quietly discounting everything else in the pack.
 
-**A fractional CFO helps by:** Establishing a monthly close rhythm, building a standing board pack with consistent KPI definitions, and writing the narrative that connects the numbers to strategy — so reporting becomes a strength investors remember at the next round.
+**A fractional CFO helps by:** Establishing a monthly close rhythm, building a standing board pack with consistent KPI definitions, and writing the narrative that connects the numbers to strategy — so reporting becomes a strength investors remember at the next round. Some of the mechanical work here is now worth automating: see [how CFOs can use AI in startup finance](/blog/how-cfos-use-ai-startup-finance/) for what a first-draft board commentary looks like and where it still needs a human.
 
 ## 5. Pricing Decisions Are Made on Gut Feel
 


### PR DESCRIPTION
Follow-up to #54, which is already merged. Two SEO defects in that post.

## 1. Query targeting

The title led with "Claude" — a brand-name query with thin volume from UK founders. The audience with this problem searches *"AI for CFOs"*, *"AI in finance"*, *"can AI do financial modelling"*. The post was well-optimised for a query almost nobody types.

Title, `seoTitle`, H1, slug and three section headings now lead with the category term. Claude stays as the named worked example throughout, and the intro says so explicitly rather than pretending to be tool-agnostic:

> Every example below uses Claude, the AI assistant built by Anthropic, because a guide written against a specific tool is more useful than one written against a category.

**Slug change:** `/blog/how-cfos-use-claude-ai-finance/` → `/blog/how-cfos-use-ai-startup-finance/`. The old URL was live for minutes and is not indexed. Static export cannot issue redirects, so this is the last cheap moment to change it — after this it would cost a dead URL.

## 2. The post was an orphan

Grepping the built export showed it reachable only from the paginated `/blog/` index. No guide, no service page, no other post linked to it. That breaches `BRANDING.md` §12 ("every new page gets a contextual link from a related page at launch") and is the single biggest lever on whether a new URL gets crawled and ranked.

Added contextual inbound links from:

- `content/blog/when-to-hire-fractional-cfo.md` — in the board-reporting-burden section
- `content/blog/financial-modeling-seed-stage-startups.md` — after the modelling tools table, framed as a review pass
- `app/guides/fractional-cfo-guide/page.js` — the CFO track hub, beside the existing modelling link

All three are contextual prose links, not a link dump.

## Verification

- `npm run build` passes
- Description 160 chars, title 49 with the `| Codenest` suffix
- `sitemap.xml` carries the new slug with trailing slash; old slug gone from the export
- Fractional CFO CTA routing intact
- Page renders in the dev server with no console errors
- Three inbound links confirmed present in the built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)