### PR TITLE
Rewrite the remaining engineer-facing posts for founders

### DIFF
--- a/content/blog/building-your-first-data-room.md
+++ b/content/blog/building-your-first-data-room.md
@@ -49,16 +49,16 @@ For pre-seed and seed rounds, Google Drive or Notion is usually sufficient. Upgr
 Here's the folder structure investors expect:
 
 ```
-📁 [Company Name] Data Room
-├── 📁 1. Company Overview
-├── 📁 2. Corporate Documents
-├── 📁 3. Financials
-├── 📁 4. Legal
-├── 📁 5. Team
-├── 📁 6. Product & Technology
-├── 📁 7. Customers & Traction
-├── 📁 8. Fundraising
-└── 📁 9. Appendix
+[Company Name] Data Room
+├── 1. Company Overview
+├── 2. Corporate Documents
+├── 3. Financials
+├── 4. Legal
+├── 5. Team
+├── 6. Product & Technology
+├── 7. Customers & Traction
+├── 8. Fundraising
+└── 9. Appendix
 ```
 
 ## What Goes in Each Folder

--- a/content/blog/gitops-startup-deployment-github-actions.md
+++ b/content/blog/gitops-startup-deployment-github-actions.md
@@ -1,313 +1,121 @@
 ---
-title: 'GitOps for Startups: When Automated Deployments Are Worth the Investment'
+title: 'GitOps for Startups: Is Automating Your Deployments Worth It?'
 seoTitle: 'GitOps for Startups: Is It Worth the Setup?'
-description: 'When automated deployments are worth the investment. A practical guide to deciding if GitOps is right for your startup stage and team size.'
-date: '2025-05-12'
+description: 'A non-technical guide to deployment automation: what manual deploys really cost, when automating pays back, and the questions to ask before approving the work.'
+date: '2026-08-05'
 author: 'Ankit Rana'
-readTime: '7 min read'
-tags: ['GitOps', 'DevOps']
+readTime: '8 min read'
+tags: ['GitOps', 'DevOps', 'Non-Technical Founders']
 ---
 
-# GitOps for Startups: When Automated Deployments Are Worth the Investment
+# GitOps for Startups: Is Automating Your Deployments Worth It?
 
-"Our deployments are manual and error-prone. Should we implement GitOps?"
+An engineer tells you deployments are manual and error-prone, and asks for time to fix it with something called GitOps. The request sounds reasonable. It also sounds like it could be two weeks or two months, and you have no way to tell which.
 
-This question comes up frequently with scaling startups. The honest answer: it depends on your stage, team size, and how much deployment friction is costing you. This guide helps you decide whether GitOps is right for your startup—and how to implement it without over-engineering.
+This guide is for making that call. It assumes no technical background, and it will not teach you to build a deployment pipeline. It covers what manual deployment actually costs your company, when automating it pays back, and what to ask before you approve the work.
 
-## What Is GitOps (In Plain English)?
+## What a Deployment Is, and Why Yours Might Be Fragile
 
-GitOps is an approach where your Git repository becomes the single source of truth for your infrastructure and application deployments. When you merge code, it automatically deploys. When you need to roll back, you revert a commit.
+A deployment is the act of taking the software your team has written and putting it in front of customers. It happens every time you ship anything.
 
-**Without GitOps:**
-1. Developer finishes a feature
-2. Someone (often the "deployment person") manually runs scripts
-3. They hope they remembered all the steps
-4. If something breaks, they scramble to figure out what changed
+In a young company it usually works like this. An engineer finishes a feature. Someone, often the same person every time, runs a series of steps by hand to push it live. They rely on remembering the order. If something breaks, they work backwards under pressure to find what changed.
 
-**With GitOps:**
-1. Developer merges code to main branch
-2. Automated pipeline builds, tests, and deploys
-3. Every change is tracked in Git history
-4. Rolling back is as simple as reverting a commit
+The automated version replaces that with a rule: when approved code is merged, it goes live by itself, the same way every time, and every change is recorded. Undoing a bad release becomes a single reversal rather than an investigation.
 
-The key insight: GitOps isn't about specific tools—it's about treating your deployment configuration as code that lives in Git.
+GitOps is one name for the disciplined version of this, where the desired state of your system is written down in the same place as your code. The label matters less than the property underneath it: **deployment stops being something a person performs and becomes something the system does.**
 
-## The Decision Framework
+## The Cost You Are Already Paying
 
-Before investing in GitOps, consider where you are:
+Manual deployment rarely appears as a line item, which is why it survives longer than it should. It shows up in four other places.
 
-| Question | If Yes | If No |
-|----------|--------|-------|
-| Are you deploying more than once per week? | GitOps reduces friction | Manual may be fine |
-| Do you have more than 3 engineers? | GitOps prevents "who deployed what?" confusion | One person can manage |
-| Have you had production incidents from deployment mistakes? | GitOps adds safety | Less urgent |
-| Are you running Kubernetes? | GitOps is natural fit | Simpler options exist |
-| Is your deployment process blocking feature velocity? | GitOps unlocks speed | Not a priority |
+**Release pace.** If shipping requires one specific person's attention, you ship at the rate that person is available. Founders usually read this as the team being slow.
 
-**The honest truth:** Most pre-seed startups don't need GitOps. Most Series A startups benefit from it. The question is when the investment pays off.
+**Key-person risk.** When one engineer is the only person who can deploy, their holiday is a business risk and their resignation is an emergency. This is the concern that reaches a board.
 
-## What GitOps Actually Gives You
+**Incident length.** The gap between "production is broken" and "production is fixed" is mostly spent working out what changed. Automation collapses that to a reversal, because the record already exists.
 
-### 1. Deployment Confidence
+**Engineer attention.** Every deployment done by hand is senior time spent on a task with no product value.
 
-Without GitOps, deployments are often stressful events. Someone has to remember the steps, run them in the right order, and hope nothing goes wrong.
+None of this justifies automating on day one. It does mean the cost is real, and it grows with headcount rather than staying flat.
 
-With GitOps, every deployment follows the same automated process. You deploy the same way whether it's 2pm on a Tuesday or 11pm during an incident recovery.
+## The Decision, in One Table
 
-**Real impact:** Teams report 60-80% reduction in deployment-related incidents after implementing GitOps.
+Work through these honestly. The more you answer yes, the stronger the case.
 
-### 2. Instant Rollbacks
+| Question | Yes means | No means |
+|---|---|---|
+| Do you ship more than once a week? | Friction is compounding | Manual is probably fine |
+| Do you have more than three engineers? | Coordination is becoming the cost | One person can hold it |
+| Have deployment mistakes caused a customer-visible incident? | You have already paid for this | Less urgent |
+| Would one engineer's absence stop you shipping? | This is key-person risk | You have cover |
+| Is your host already doing this for you? | You may need nothing | Worth checking first |
 
-When something goes wrong in production, time matters. With GitOps, rolling back is a Git revert—typically under 5 minutes from decision to deployment.
+The honest position: **most pre-seed startups should not automate deployments, and most Series A startups should have automated them already.** The interesting decision sits at seed, and it usually turns on team size rather than technical sophistication.
 
-Without GitOps, rollbacks often involve:
-- Finding the previous version
-- Remembering the deployment steps
-- Hoping you don't make it worse
+## What It Costs to Do
 
-### 3. Clear Audit Trail
+Three numbers to hold your team to.
 
-Every change to your system is a Git commit with a message, author, and timestamp. When something breaks, you can trace exactly what changed and when.
+**Setup:** one to two weeks of a senior engineer for a straightforward pipeline. Two to four weeks if you want it done thoroughly, with separate environments and a tested rollback.
 
-This matters for:
-- **Debugging:** What changed in the last hour?
-- **Compliance:** Who authorised this change?
-- **Knowledge sharing:** Why was this decision made?
+**Ongoing:** roughly five to ten per cent of one engineer's time. Pipelines need maintaining, dependencies need updating, and failures need diagnosing. This is smaller than the manual cost it replaces at any reasonable team size, but it is not zero, and a proposal that claims zero is incomplete.
 
-### 4. Developer Productivity
+**The learning curve** is real if your team has not done this before. Budget for the first attempt being slower than the estimate.
 
-When developers can merge code and know it will deploy reliably, they spend less time on operational toil and more time building features.
+If the proposal you receive is longer than a month, ask what would be removed to reach two weeks. There is nearly always a smaller version that captures most of the benefit, and starting there is usually right.
 
-**Before GitOps:** "Can someone deploy my changes?" (waits for the one person who knows how)
+## Three Options, From Cheapest Up
 
-**After GitOps:** Merge to main, deployment happens automatically, get on with the next feature.
+Your team may present GitOps as the answer when a simpler rung on the ladder would do.
 
-## What GitOps Costs You
+**A managed platform** such as Heroku, Railway, Render or Vercel does this for you with no configuration. You get automatic deployment and preview environments for free, and you give up fine-grained control. For a pre-seed or early-seed company this is usually the correct answer, and if you are already on one of these, you may need no project at all. Check before approving anything.
 
-### Learning Curve
+**Simple automation** using the tooling built into GitHub or GitLab covers most companies not running complex systems. Code merges, and a script builds, tests and deploys it. This is the sensible middle rung, it works with any host, and it is where most seed-stage teams should land.
 
-GitOps requires understanding concepts like:
-- Declarative configuration
-- Reconciliation loops
-- Environment promotion
-- Secrets management
+**Full GitOps** using tools like ArgoCD or Flux adds automatic correction when the live system drifts from what is written down. It is designed for teams running [Kubernetes](/blog/kubernetes-startups-overkill-essential/), and it earns its complexity there. If your team proposes full GitOps and you are not on Kubernetes, ask what it gives you over the middle rung, because the answer is often not much.
 
-**Real cost:** Expect 1-2 weeks for a senior engineer to set up a basic GitOps pipeline, longer for complex environments.
+The failure mode is skipping to the third rung because it is the one that sounds most rigorous.
 
-### Operational Overhead
+## Four Questions to Ask Before Approving
 
-Even with automation, you still need to:
-- Monitor pipeline health
-- Update dependencies and tools
-- Debug failed deployments
-- Manage secrets and credentials
+**1. What is on the smallest useful version of this, and how long is that?**
 
-**Real cost:** Ongoing maintenance of 5-10% of one engineer's time.
+You are testing whether the scope has been sized to the problem or to the engineer's interest in it.
 
-### Initial Investment
+**2. If a release breaks production at 6pm on a Friday, what happens now, and what happens after this work?**
 
-Setting up GitOps properly requires:
-- Choosing and configuring tools
-- Defining deployment workflows
-- Setting up environments (dev, staging, prod)
-- Training the team
+A good answer names a time. This is the benefit stated in terms you can verify later.
 
-**Real cost:** 2-4 weeks of focused effort to do it well.
+**3. Who can deploy today, and who can deploy after?**
 
-## The Alternatives (And When They're Better)
+The number should go up. If automation leaves one person as the only one who understands the pipeline, you have moved the key-person risk rather than removed it.
 
-### Platform-as-a-Service (Heroku, Railway, Render)
+**4. Are we already paying a platform to do this?**
 
-**Best for:** Early-stage startups with simple deployment needs
+Ask it plainly. Rebuilding something your hosting provider includes is a common and expensive mistake.
 
-**How it works:** Git push triggers automatic deployment. The platform handles everything.
+## What Diligence Asks
 
-**Pros:**
-- Zero configuration
-- Built-in preview environments
-- No infrastructure to manage
+The same ground gets covered in technical due diligence, in a more formal register. Our [technical due diligence checklist](/blog/startup-technical-due-diligence-checklist/) has the fuller picture.
 
-**Cons:**
-- Limited customisation
-- Can be expensive at scale
-- Less control over deployment process
+| Area | What passes | What gets flagged |
+|---|---|---|
+| Releasing | Automated, consistent | Manual steps in production |
+| Rollback | A tested time to recover | "We would work it out" |
+| History | Every change recorded | No visibility into what changed |
+| Environments | Staging resembles production | Surprises only appear live |
+| Knowledge | Written runbooks | It lives in one person's head |
 
-**When to use:** You're pre-product-market fit and need to ship fast. Worry about GitOps later.
+The pattern matches the infrastructure questions in our [AWS infrastructure guide for founders](/blog/terraform-aws-infrastructure-as-code/): diligence cares far more about whether your practice is repeatable than about whether your tooling is advanced.
 
-### Simple CI/CD (GitHub Actions, GitLab CI)
+## The Bottom Line
 
-**Best for:** Teams not running Kubernetes who want automation without full GitOps
+Deployment automation is a stage decision, and the trigger is usually team size rather than technical ambition.
 
-**How it works:** CI pipeline builds, tests, and deploys on merge. Simpler than full GitOps but still automated.
+Pre-seed, use a managed platform and spend the time on product. At seed, once you have more than three engineers or shipping has started to queue behind one person, take the middle rung: simple automation, one to two weeks, done. Save full GitOps for the point where you are running Kubernetes and it has something specific to offer.
 
-```yaml
-# .github/workflows/deploy.yaml
-name: Deploy
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Deploy to production
-        run: |
-          # Your deployment script here
-          ./deploy.sh
-        env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-```
-
-**Pros:**
-- Familiar to most developers
-- Works with any hosting provider
-- Gradual path to full GitOps
-
-**Cons:**
-- Less powerful reconciliation than GitOps tools
-- Manual rollback process
-- No built-in drift detection
-
-**When to use:** You want automation but aren't ready for Kubernetes or full GitOps complexity.
-
-### Full GitOps (ArgoCD, Flux)
-
-**Best for:** Teams running Kubernetes who need robust, declarative deployments
-
-**How it works:** A GitOps operator watches your Git repository and automatically applies changes to your cluster.
-
-**Pros:**
-- Automatic drift correction
-- Declarative, version-controlled state
-- Built-in rollback and health checks
-
-**Cons:**
-- Requires Kubernetes knowledge
-- Additional tools to manage
-- More complex initial setup
-
-**When to use:** You're already on Kubernetes and deploying multiple services regularly.
-
-## Signals It's Time for GitOps
-
-1. **Deployment mistakes are causing production incidents**
-2. **Only one person knows how to deploy** (bus factor risk)
-3. **Deployments are blocking feature development**
-4. **You're scaling the engineering team** beyond 5 people
-5. **You're running Kubernetes** and want to leverage its full capabilities
-
-## Signals It's Too Early
-
-1. **You're still finding product-market fit** (focus on product, not process)
-2. **You deploy less than weekly** (overhead outweighs benefits)
-3. **You have fewer than 3 engineers** (manual is manageable)
-4. **Your platform handles deployments** (Heroku, Vercel, etc.)
-
-## Implementation Approach
-
-If you decide GitOps is right for you:
-
-### Phase 1: Start with CI/CD
-
-Before full GitOps, ensure you have:
-- Automated testing on every pull request
-- Automated builds on merge
-- Consistent deployment scripts
-
-This foundation makes GitOps adoption smoother.
-
-### Phase 2: Add Declarative Configuration
-
-Define your deployment configuration in code:
-
-```yaml
-# k8s/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: api-server
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: api-server
-  template:
-    spec:
-      containers:
-      - name: api
-        image: your-registry/api:latest
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
-```
-
-This file lives in Git alongside your application code.
-
-### Phase 3: Implement GitOps Operator
-
-Choose a GitOps tool (ArgoCD for most teams) and configure it to watch your repository:
-
-```yaml
-# argocd-application.yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: api-server
-  namespace: argocd
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/your-org/your-repo.git
-    targetRevision: main
-    path: k8s
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: production
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-```
-
-### Phase 4: Add Environment Promotion
-
-Set up a clear path from development to production:
-
-```
-dev → staging → production
-```
-
-Each environment has its own configuration, and promotions are Git merges or tags.
-
-## What Investors Look For
-
-If you're using GitOps, technical due diligence will examine:
-
-| Area | Good Signal | Red Flag |
-|------|-------------|----------|
-| **Automation** | Deployments are fully automated | Manual steps in production deployments |
-| **Rollback** | Can rollback in minutes | "We'd have to figure it out" |
-| **Audit trail** | Clear history of all changes | No visibility into what changed |
-| **Environment parity** | Staging mirrors production | "It works on staging" problems |
-| **Documentation** | Clear runbooks for common scenarios | Tribal knowledge only |
-
-## Summary
-
-GitOps is a powerful approach to deployment automation, but it's not for everyone:
-
-**Pre-seed / Early Seed:** Use platform-as-a-service (Heroku, Railway). Focus on product, not deployment pipelines.
-
-**Late Seed / Series A:** Evaluate GitOps if you're on Kubernetes and deployment friction is slowing you down.
-
-**Series A+:** GitOps becomes standard practice for teams with multiple services and regular deployments.
-
-The goal isn't to use the most sophisticated tools—it's to have reliable, repeatable deployments that don't block your team from shipping features.
+The goal is releases that are boring. Sophisticated tooling that nobody can maintain is worse than a simple pipeline the whole team understands.
 
 ---
 
-*Need help setting up automated deployments or evaluating GitOps for your startup? [Get in touch](/contact/) for a consultation.*
+*Not sure whether your deployment process is a real constraint or a distraction? Our [Fractional CTO service](/services/fractional-cto/) covers engineering practice, infrastructure and diligence readiness, or [get in touch](/contact/) to talk it through.*

--- a/content/blog/infrastructure-as-code-for-startups.md
+++ b/content/blog/infrastructure-as-code-for-startups.md
@@ -1,292 +1,120 @@
 ---
 title: 'Infrastructure as Code for Startups: Why It Matters for Your Next Raise'
 seoTitle: 'Infrastructure as Code for Startups'
-description: 'Why "we click around in the AWS console" raises red flags during due diligence, and how to implement IaC without derailing product development.'
-date: '2025-07-18'
+description: 'Why "we click around in the AWS console" is a red flag in due diligence, what investors ask, and how to fix it in the months before you open a round.'
+date: '2026-08-05'
 author: 'Ankit Rana'
 readTime: '8 min read'
-tags: ['Infrastructure', 'Due Diligence']
+tags: ['Infrastructure', 'Due Diligence', 'Non-Technical Founders']
 ---
 
 # Infrastructure as Code for Startups: Why It Matters for Your Next Raise
 
-When investors conduct technical due diligence, one of the first questions they ask is: "How do you manage your infrastructure?" The answer reveals a lot about your engineering maturity, operational risk, and ability to scale.
+In technical due diligence, one of the earliest questions is how you manage your infrastructure. It sounds like a question for your engineers. It is actually a question about operational risk, and the answer changes how the rest of the diligence conversation goes.
 
-If your answer is "we click around in the AWS console" or "our lead developer knows how it all works," you're raising red flags. If your answer is "everything is defined in code, version-controlled, and automatically deployed," you're demonstrating the operational discipline that serious investors expect.
+Two answers, and what each one tells an investor:
 
-This guide explains what Infrastructure as Code (IaC) is, why it matters for your startup, and how to implement it without derailing your product development.
+**"Our lead developer set it up and knows how it works."** One person holds knowledge the company depends on. If they leave, the buyer inherits a system nobody can safely change.
 
-## What Investors Actually Care About
+**"It is defined in code, version-controlled, and deployed automatically."** The system is documented by construction, changes are reviewed, and any competent engineer can pick it up.
 
-Technical due diligence typically examines five areas. IaC directly addresses three of them:
+This guide explains the difference in plain terms, why it carries weight in a raise, and how to close the gap in the months before you open a round. No technical background assumed.
 
-| Due Diligence Area | What IaC Demonstrates |
-|-------------------|----------------------|
-| **Scalability** | Infrastructure can grow with the business automatically |
-| **Operational risk** | No single point of failure (the "bus factor" problem) |
-| **Engineering maturity** | Team follows professional practices |
-| **Security posture** | Changes are reviewed and auditable |
-| **Technical debt** | Foundation is solid, not held together with scripts |
+## What "Infrastructure as Code" Means
 
-When investors see properly implemented IaC, they're reassured that:
-- You can scale without hiring an army of DevOps engineers
-- Critical knowledge isn't trapped in one person's head
-- You've invested in foundations, not just features
+Your product runs on cloud resources: servers, databases, networks, security rules. There are two ways they come into existence.
 
-## What Is Infrastructure as Code?
+Someone can create them by hand, clicking through Amazon's web console and filling in forms. It works, and it leaves no record of what was done or why.
 
-Infrastructure as Code means defining your cloud resources—servers, databases, networks, security rules—in configuration files rather than clicking through web consoles.
+Or the whole setup can be written down in files that a tool reads and applies. Those files sit alongside your product code, changes to them get reviewed like any other change, and the entire environment can be rebuilt from them.
 
-**Without IaC:**
-1. Developer logs into AWS console
-2. Clicks through menus to create a database
-3. Tries to remember the settings they used last time
-4. Hopes they didn't miss anything
+The second approach is infrastructure as code. The practical difference is not elegance. It is that **your infrastructure stops being something one person remembers and becomes something the company owns.**
 
-**With IaC:**
-1. Developer writes a configuration file describing the database
-2. Runs a command to create it
-3. Configuration is saved in version control
-4. Anyone can recreate the exact same database anytime
+Our [AWS infrastructure guide for founders](/blog/terraform-aws-infrastructure-as-code/) covers the tool choice and what the work should cost at each stage. This post is about what it means for your raise.
 
-Here's what a database definition looks like in Terraform (the most popular IaC tool):
+## The Four Questions, and the Answers That Land
 
-```terraform
-resource "aws_db_instance" "main" {
-  identifier           = "myapp-production"
-  engine               = "postgres"
-  engine_version       = "14.7"
-  instance_class       = "db.t3.medium"
-  allocated_storage    = 100
+Technical diligence is more predictable than founders expect. These four come up almost every time, and the difference between a good and bad answer is stark enough that you can assess your own position today.
 
-  db_name              = "myapp"
-  username             = "admin"
-  password             = var.db_password  # Stored securely, not in code
+**"How is your infrastructure defined?"**
 
-  backup_retention_period = 7
-  multi_az               = true
+*Good:* "It is all in Terraform, in our main repository, deployed through our pipeline."
+*Bad:* "Our CTO set it up. They know how it works."
 
-  tags = {
-    Environment = "production"
-    ManagedBy   = "terraform"
-  }
-}
-```
+**"Could you recreate your production environment?"**
 
-This file is checked into Git alongside your application code. Anyone on the team can see exactly how the database is configured, when it was changed, and why.
+*Good:* "Yes. We have done it, and it takes about two hours."
+*Bad:* "It would take a while. We would need to check our notes."
 
-## The Business Case for IaC
+The word doing the work in the good answer is *have*. An untested recovery plan is only a belief about a capability, and experienced technical reviewers will ask when you last tried it.
 
-Beyond impressing investors, IaC delivers concrete business benefits:
+**"How do infrastructure changes happen?"**
 
-### 1. Faster Onboarding
+*Good:* "A change request, a review by another engineer, then automatic deployment."
+*Bad:* "We make changes in the console when we need to."
 
-New developers can spin up a complete development environment with one command instead of following a 20-page setup guide that's probably out of date.
+**"Who has access to production?"**
 
-**Before IaC:** "Ask Sarah how to set up the dev database. She's the only one who knows."
+*Good:* "Two senior engineers hold admin access. Everything else goes through the pipeline."
+*Bad:* "Everyone has the main account credentials."
 
-**After IaC:** `terraform apply -var-file=dev.tfvars`
+Ask your engineering lead these four questions this week. You will learn where you stand in about ten minutes, and there is no version of this where finding out during diligence is better.
 
-### 2. Reliable Disaster Recovery
+## Why This Weighs More Than It Looks
 
-If your production environment disappeared tomorrow, how quickly could you rebuild it? With IaC, the answer is "within hours" instead of "we'd have to figure it out."
+Investors are not grading your engineering taste. They are pricing risk, and infrastructure held in one person's head is a specific, familiar risk with a name attached to it.
 
-### 3. Consistent Environments
+Three things follow from getting this right, and they matter whether or not you ever raise again.
 
-"Works on my machine" becomes "works everywhere" when every environment is built from the same configuration files.
+**Key-person exposure drops.** The most common technical diligence finding at seed and Series A is that one engineer is load-bearing. Writing infrastructure down is the cheapest available reduction in that exposure.
 
-### 4. Auditable Changes
+**Recovery becomes a number.** "How long to rebuild after a serious failure?" has an answer you have tested rather than an answer you hope for. That question also arrives from enterprise customers and insurers, not only investors.
 
-Every infrastructure change is a code commit with a description, author, and timestamp. When something breaks, you can trace exactly what changed and when.
+**Changes become reviewable.** A misconfigured security rule can expose a production database to the internet. When infrastructure changes go through review like any other change, a second person sees it first.
 
-### 5. Reduced Operational Costs
+## When to Do It
 
-Manual infrastructure management doesn't scale. The startup that invests in automation early can grow faster without proportionally growing their operations team.
+| Stage | What is appropriate |
+|---|---|
+| Pre-product | Use a managed platform. Do not start this yet. |
+| First paying customers | Write down the pieces you could not survive losing |
+| Post-seed, scaling | It should be the normal way things change |
+| Series A and beyond | Assume it will be examined |
 
-## When to Implement IaC
+**The inflection point is your first paying customers**, because that is when losing the environment stops being an inconvenience and starts being an existential problem.
 
-The right time depends on your stage:
+Doing this properly is two to four weeks of one engineer's time. Compared with the cost of a diligence process that surfaces avoidable findings, or a raise that slows while you remediate them, that is a small number.
 
-| Stage | Recommendation |
-|-------|---------------|
-| **Pre-product** | Use managed services (Heroku, Vercel, Railway). Don't invest in IaC yet. |
-| **MVP with first customers** | Start simple IaC for core infrastructure (database, cache, storage). |
-| **Post-seed, scaling** | Comprehensive IaC should be standard. Automate everything. |
-| **Series A+** | IaC is mandatory. Investors will check. |
+## The Timeline Before a Raise
 
-**The inflection point:** Once you have paying customers and are thinking about your next raise, invest in IaC. It takes 2-4 weeks to implement properly, and that investment pays off in due diligence confidence.
+If you expect to open a round in the next six to nine months, work backwards.
 
-## Choosing Your Tools
+**Six months out.** Ask the four questions above and write down the honest answers. This is diagnosis, and it costs an afternoon.
 
-The two main options for startups:
+**Four to five months out.** Do the work: core infrastructure written down, secrets moved out of code and into a proper store, access narrowed to named people. Two to four weeks of engineering.
 
-### Terraform
+**Three months out.** Test the recovery. Actually rebuild the environment somewhere and time it. This converts your answer to question two from a belief into a fact, and it is the step teams skip.
 
-**Best for:** Most startups
+**Two months out.** Write the short document that explains your setup, so diligence questions get answered from a page rather than from an engineer's memory under pressure.
 
-Terraform uses a declarative configuration language. You describe what you want, and Terraform figures out how to create it.
+Remediating during diligence is possible and always worse. It happens under time pressure, with an investor watching, at exactly the moment your attention is needed elsewhere. Our [technical due diligence checklist](/blog/startup-technical-due-diligence-checklist/) covers the rest of what gets examined.
 
-**Pros:**
-- Huge community and ecosystem
-- Works with any cloud provider
-- Well-documented, easy to learn
-- Industry standard (investors recognise it)
+## Three Mistakes That Show Up Repeatedly
 
-**Cons:**
-- Separate language to learn (HCL)
-- State file management requires attention
+**Secrets in the code.** Passwords and keys committed into the repository. Once a secret is in version history it should be treated as compromised, and rotating it later does not remove it from the history. This is the single most common serious finding, and it is straightforward to fix.
 
-### Pulumi
+**Over-engineering it.** A two-person team does not need an elaborate, highly configurable setup. Simple and readable beats clever, and the version your next hire can understand is the version that survives.
 
-**Best for:** Teams with strong TypeScript/Python developers who prefer familiar languages
+**Doing it once and stopping.** Infrastructure written down in March and then modified by hand in June is worse than either approach on its own, because the files now describe something that no longer exists. If changes stop going through the process, you have the overhead without the benefit.
 
-Pulumi lets you write infrastructure code in TypeScript, Python, Go, or C# instead of a separate configuration language.
+## The Bottom Line
 
-**Pros:**
-- Use languages your team already knows
-- Better IDE support (autocomplete, type checking)
-- Full programming capabilities (loops, conditionals)
+Infrastructure as code is not a sophistication signal. It is the difference between a company that owns its systems and one that rents them from an employee's memory.
 
-**Cons:**
-- Smaller community than Terraform
-- Can be over-engineered ("just because you can doesn't mean you should")
+The work is small and the window is wide: two to four weeks, best done six months before you need it. The four questions above tell you where you stand today, and you can ask them this week without knowing anything technical.
 
-**Our recommendation:** Start with Terraform unless you have a strong reason not to. It's the industry standard, which means more documentation, more examples, and easier hiring.
-
-If you are the founder rather than the engineer making this call, our guide to [AWS infrastructure decisions for founders](/blog/terraform-aws-infrastructure-as-code/) covers the same choice without the code: what to spend at each stage, and the five questions to ask your engineering lead.
-
-## Implementation Roadmap
-
-### Week 1: Foundation
-
-1. **Set up Terraform and a remote state backend**
-
-   State files track what infrastructure exists. Store them in S3 (not locally) so your whole team can access them safely.
-
-   ```terraform
-   terraform {
-     backend "s3" {
-       bucket         = "mycompany-terraform-state"
-       key            = "production/terraform.tfstate"
-       region         = "eu-west-2"
-       encrypt        = true
-       dynamodb_table = "terraform-locks"
-     }
-   }
-   ```
-
-2. **Import existing infrastructure**
-
-   Don't recreate everything from scratch. Terraform can import resources you've already created manually.
-
-### Week 2: Core Infrastructure
-
-Define your essential resources:
-- VPC and networking
-- Database (RDS)
-- Cache (ElastiCache/Redis)
-- Object storage (S3)
-- Load balancer (if applicable)
-
-### Week 3: Automation
-
-1. **Add Terraform to your CI/CD pipeline**
-
-   - Run `terraform plan` on every pull request (shows what would change)
-   - Run `terraform apply` when changes are merged to main
-
-2. **Set up environments**
-
-   Use separate configuration files for dev, staging, and production:
-
-   ```
-   environments/
-   ├── dev.tfvars
-   ├── staging.tfvars
-   └── production.tfvars
-   ```
-
-### Week 4: Documentation and Handover
-
-1. Document your setup for the team
-2. Train developers on the basic workflow
-3. Establish code review process for infrastructure changes
-
-## Common Mistakes to Avoid
-
-### 1. Storing Secrets in Code
-
-Never put passwords, API keys, or other secrets in your Terraform files. Use:
-- AWS Secrets Manager or Parameter Store
-- Environment variables
-- HashiCorp Vault
-
-### 2. Over-Engineering
-
-You don't need complex module abstractions for a seed-stage startup. Keep it simple:
-
-**Too complex:**
-```terraform
-module "super_flexible_database" {
-  source = "./modules/database"
-
-  # 47 configurable parameters...
-}
-```
-
-**Just right:**
-```terraform
-resource "aws_db_instance" "main" {
-  # Direct, readable configuration
-}
-```
-
-### 3. Ignoring State Management
-
-If multiple people run Terraform simultaneously without state locking, you'll corrupt your infrastructure. Always use remote state with locking enabled.
-
-### 4. No Code Review
-
-Infrastructure changes should go through pull requests like any other code. A misconfigured security group can expose your entire database to the internet.
-
-## What Due Diligence Looks Like
-
-When investors (or their technical advisors) examine your infrastructure, they'll typically ask:
-
-1. **"How is your infrastructure defined?"**
-   - Good answer: "Terraform, stored in our main repo, deployed via GitHub Actions"
-   - Bad answer: "Our CTO set it up. He knows how it works."
-
-2. **"Can you recreate your production environment?"**
-   - Good answer: "Yes, we can spin up an identical environment in about 2 hours"
-   - Bad answer: "It would take a while. We'd need to check our notes."
-
-3. **"How do you handle infrastructure changes?"**
-   - Good answer: "Pull request, code review, automated deployment"
-   - Bad answer: "We make changes directly in the console when needed"
-
-4. **"Who has access to production infrastructure?"**
-   - Good answer: "Two senior engineers have admin access. All changes go through our IaC pipeline."
-   - Bad answer: "Everyone has the AWS root credentials."
-
-## Starting Today
-
-If you don't have IaC yet, here's how to start without disrupting your product work:
-
-1. **Install Terraform** and do the official tutorial (2 hours)
-2. **Pick one resource** (your database is a good choice) and write the Terraform for it
-3. **Import it** into Terraform state
-4. **Make a small change** via Terraform to verify it works
-5. **Gradually expand** to cover more infrastructure
-
-You don't need to convert everything overnight. Start with the most critical resources and expand from there.
-
-## Summary
-
-Infrastructure as Code isn't just a technical best practice—it's a signal to investors that you're building a serious company with proper foundations. The startups that invest in operational maturity early are the ones that scale smoothly when growth accelerates.
-
-The time to implement IaC is before you need it for due diligence, not during. A few weeks of focused effort now saves you from scrambling later—and positions you as a well-run company that investors can trust with their capital.
+Fix it before it is on an investor's list rather than after.
 
 ---
 
-*Need help implementing Infrastructure as Code or preparing for technical due diligence? [Get in touch](/contact/) for a consultation.*
+*Preparing for a raise and unsure whether your infrastructure will hold up? Our [Fractional CTO service](/services/fractional-cto/) covers due diligence readiness, or [get in touch](/contact/) to talk through where you stand.*

--- a/content/blog/kubernetes-startups-overkill-essential.md
+++ b/content/blog/kubernetes-startups-overkill-essential.md
@@ -1,298 +1,108 @@
 ---
 title: "Kubernetes for Startups: When It Makes Sense (And When It Doesn't)"
 seoTitle: 'Kubernetes for Startups: Overkill or Essential?'
-description: 'The honest answer to "should we use Kubernetes?" Avoid premature optimisation and painful re-architecture with this stage-appropriate guide.'
-date: '2025-06-25'
+description: 'A non-technical guide to the Kubernetes decision: what it costs in engineer time, the cheaper options your team may have skipped, and when it pays off.'
+date: '2026-08-05'
 author: 'Ankit Rana'
-readTime: '7 min read'
-tags: ['Kubernetes', 'Infrastructure']
+readTime: '8 min read'
+tags: ['Kubernetes', 'Infrastructure', 'Non-Technical Founders']
 ---
 
 # Kubernetes for Startups: When It Makes Sense (And When It Doesn't)
 
-"Should we use Kubernetes?"
+Someone on your team wants to move to Kubernetes. It is the most consequential infrastructure decision a startup gets asked to approve, and it is almost always put to the founder as a technical detail.
 
-This question comes up in almost every technical strategy conversation with early-stage founders. The honest answer is: probably not yet, but maybe sooner than you think.
+It is not a technical detail. Kubernetes changes how much of your engineering capacity goes into running software rather than building it, and that trade is yours to make. This guide explains what you are actually deciding, with no technical background assumed.
 
-Kubernetes has become the default choice for scaling container workloads, but it comes with real complexity. This guide helps you make the right decision for your stage—and avoid both premature optimisation and painful re-architecture later.
+## What Kubernetes Is, in One Paragraph
 
-## The Decision Framework
+As a company grows, its product usually splits into several separate programs that have to run at once, survive individual failures, and grow or shrink with demand. Kubernetes is the system that manages that: it decides what runs where, restarts things that crash, and adds capacity under load.
 
-Before diving into technical details, here's the framework we use with clients:
+It is genuinely good at this. It is also a substantial system in its own right, which your team then has to run. That second sentence is the whole decision.
 
-| Question | If Yes | If No |
-|----------|--------|-------|
-| Do you have more than 5-10 services to deploy? | Consider Kubernetes | Simpler options work |
-| Are you scaling beyond 3-5 engineers? | Kubernetes helps standardise | Keep it simple |
-| Do you need zero-downtime deployments? | Kubernetes excels here | Managed platforms can handle it |
-| Is your infrastructure spend >£5k/month? | Kubernetes can optimise costs | Overhead outweighs benefits |
-| Are you preparing for Series A+ due diligence? | Kubernetes signals maturity | Focus on product first |
+## The Honest Default
 
-**The honest truth:** Most seed-stage startups don't need Kubernetes. Most Series A+ startups benefit from it. The question is when to make the transition.
+**Most seed-stage startups should not use Kubernetes. Most Series A startups with several services benefit from it.** The interesting question is where your company sits on that line, and the answer depends more on how many separate services you run and how many engineers you have than on anything about your product.
 
-## What Kubernetes Actually Gives You
+Work through these:
 
-Let's cut through the marketing and focus on practical benefits:
+| Question | Yes points toward Kubernetes | No means simpler options win |
+|---|---|---|
+| Do you run more than five separate services? | Coordinating them by hand is the cost | Fewer moving parts, less to gain |
+| Are you going beyond five engineers? | Standardisation starts to pay | One team can hold it in their heads |
+| Is infrastructure spend above £5k/month? | Efficiency gains become material | Overhead outweighs savings |
+| Has anyone on the team run Kubernetes before? | The learning cost is already paid | You are buying a system and a curriculum |
+| Are you hitting hard limits on your current platform? | You have a real forcing function | Do not fix what is not constraining you |
 
-### 1. Consistent Deployment Process
+If you answered no to most of these, the answer is not yet, and revisiting in six months costs you nothing.
 
-Without Kubernetes, each service might deploy differently. One uses a shell script, another uses GitHub Actions directly to EC2, a third uses Elastic Beanstalk. This becomes chaotic as you grow.
+## What It Costs
 
-With Kubernetes, every service deploys the same way:
-1. Build a container image
-2. Push to registry
-3. Apply a deployment manifest
+The benefits get presented clearly. The costs usually do not, so here they are in the terms you budget in.
 
-This consistency reduces cognitive load and makes onboarding engineers faster.
+**The first deployment takes several times longer** than the same thing on a simpler platform. This evens out, but the initial slowdown is real and lands during the migration.
 
-### 2. Built-In Scaling
+**Ongoing operations run at roughly ten to twenty per cent of one engineer's time,** even using a managed service where the provider runs the hardest parts. Clusters need upgrading, networking and access need configuring, certificates need rotating, and failures need diagnosing. On a five-person team that is most of a day a week, permanently.
 
-Kubernetes can automatically scale your services based on load:
+**Everything else has to learn about it.** Local development, testing, deployment, monitoring: each needs to understand Kubernetes concepts. The complexity does not stay in one box.
 
-```yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: api-server
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: api-server
-  minReplicas: 2
-  maxReplicas: 10
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 70
-```
+Against this, teams do generally get better hardware efficiency by packing services onto shared machines rather than running one machine per service. Treat any specific percentage you are quoted as something to verify against your own bill rather than a number to plan around.
 
-When CPU usage crosses 70%, Kubernetes adds more instances. When it drops, it scales down. This is powerful for handling traffic spikes without over-provisioning.
+## The Cheaper Options Your Team May Have Skipped
 
-### 3. Self-Healing
+There are three rungs below Kubernetes, and skipping past them is the most common expensive mistake.
 
-If a container crashes, Kubernetes restarts it automatically. If a server fails, Kubernetes moves your workloads to healthy servers. This resilience is built in, not bolted on.
+**Managed platforms** such as Heroku, Railway and Render run everything for you. You deploy in minutes with no infrastructure knowledge. They cost more per unit of computing at scale and give you less control. Pre-seed to early seed, this is nearly always right: ship product, and revisit when something actually hurts.
 
-### 4. Resource Efficiency
+**Container services such as AWS ECS** give you most of what Kubernetes offers with considerably less to learn, provided you are content to stay on AWS. For a company with three to eight services, this is frequently the correct answer, and it is the rung most often skipped. If your team has proposed Kubernetes, ask specifically why ECS was ruled out.
 
-Kubernetes bins multiple services onto the same servers efficiently. Instead of running 10 t3.small instances (one per service), you might run 3 t3.large instances with all services distributed across them—often saving 30-40% on compute costs.
+**Serverless, such as AWS Lambda,** removes servers from the picture for workloads that are naturally bursty. It suits some products very well and others badly, and your engineers will know which yours is.
 
-## What Kubernetes Costs You
+## The Bad Reason, Stated Plainly
 
-The benefits above don't come free:
+Kubernetes is sometimes recommended on the basis that it looks mature in technical due diligence. Ignore that argument.
 
-### Learning Curve
+Diligence does not reward sophisticated infrastructure. It rewards infrastructure that matches the size of the business and that the team can demonstrably operate. An investor's technical advisor who finds Kubernetes at a company with two services and no one who has run it before draws a conclusion about judgement, and it is not a favourable one. Our [technical due diligence checklist](/blog/startup-technical-due-diligence-checklist/) covers what is actually examined.
 
-Kubernetes has a steep learning curve. Concepts like pods, deployments, services, ingresses, config maps, secrets, namespaces—each takes time to understand and use correctly.
+Choosing tools to impress a future investor is how startups acquire systems they cannot staff.
 
-**Real cost:** Your first Kubernetes deployment will take 3-5x longer than the equivalent on a simpler platform. This evens out over time, but the initial investment is significant.
+## Four Questions to Ask Before Approving
 
-### Operational Overhead
+**1. What is forcing this now?**
 
-Even with managed Kubernetes (EKS, GKE), you still need to:
-- Manage cluster upgrades
-- Configure networking and security
-- Monitor cluster health
-- Handle certificate rotation
-- Debug pod scheduling issues
+You want a specific constraint you are currently hitting. "It is what we will need eventually" is a reason to revisit in six months.
 
-**Real cost:** Expect at least 10-20% of one engineer's time on cluster operations, or budget for managed DevOps support.
+**2. Why not ECS, or staying where we are?**
 
-### Complexity Tax
+The answer should be concrete. If the cheaper rung was never seriously considered, the proposal is not finished.
 
-Every tool and process needs to integrate with Kubernetes. Your local development setup, your CI/CD pipeline, your monitoring—all need to understand Kubernetes concepts.
+**3. Who on the team has run this in production, and what happens when they are away?**
 
-**Real cost:** Added complexity in every part of your development workflow.
+Adopting a system nobody has operated means learning it during your first incident.
 
-## The Alternatives (And When They're Better)
+**4. What ongoing time does this take, every week, forever?**
 
-### Heroku / Railway / Render
+Anyone who answers "not much" has not run one. You are looking for a number, and for that number to be in the plan.
 
-**Best for:** Pre-seed to early seed, single applications, fast iteration
+## If You Go Ahead
 
-**Pros:**
-- Deploy in minutes, not hours
-- No infrastructure knowledge required
-- Built-in databases, caching, logging
-- Reasonable pricing at small scale
+A reasonable shape, roughly six to eight weeks alongside other work:
 
-**Cons:**
-- Expensive at scale
-- Limited customisation
-- Vendor lock-in
-- Less impressive in technical due diligence
+1. **Use a managed service** such as EKS, GKE or AKS. Building your own cluster is a decision with no upside for a startup.
+2. **Migrate one unimportant service first**, and learn on something whose failure does not reach customers.
+3. **Automate deployment** before migrating anything critical, so releases do not become manual again. Our guide to [deployment automation](/blog/gitops-startup-deployment-github-actions/) covers that decision.
+4. **Move the rest gradually.** Each migration is a chance to tidy up the service, and rushing removes that benefit.
 
-**When to use:** You're pre-product-market fit and need to ship fast. Worry about infrastructure later.
+Then hold the line on scope. Kubernetes has an enormous surface area, and the number of features you actually need is small.
 
-### AWS ECS (Elastic Container Service)
-
-**Best for:** AWS-native teams who want container orchestration without full Kubernetes
-
-**Pros:**
-- Simpler than Kubernetes
-- Tight AWS integration
-- Fargate option eliminates server management
-- Lower learning curve
+## The Bottom Line
 
-**Cons:**
-- AWS-only (no portability)
-- Less ecosystem tooling than Kubernetes
-- Some features lag behind Kubernetes
-
-**When to use:** You're committed to AWS, have 3-8 services, and want container benefits without Kubernetes complexity.
-
-### AWS Lambda / Serverless
-
-**Best for:** Event-driven workloads, APIs with variable traffic
-
-**Pros:**
-- No servers to manage
-- Automatic scaling
-- Pay-per-use pricing
-- Fast deployments
-
-**Cons:**
-- Cold start latency
-- Vendor lock-in
-- Awkward for long-running processes
-- Can get expensive at high volume
-
-**When to use:** Your workload is naturally event-driven, or you have highly variable traffic with long quiet periods.
+Kubernetes is a good answer to problems most startups do not yet have. Adopted at the right time, it standardises how a growing team ships and removes real coordination pain. Adopted early, it converts scarce engineering capacity into operating a platform that serves a handful of services.
 
-## When to Move to Kubernetes
+Pre-seed and early seed, use a managed platform. At seed with a handful of services, look hard at the middle rung before the top one. By Series A, if you are running many services with a growing team, it is a reasonable default.
 
-Based on our experience with startups at various stages:
-
-### Signals It's Time
-
-1. **You're running 5+ services** and coordination is becoming painful
-2. **You're about to scale the team** beyond 5 engineers
-3. **Deployment inconsistency** is causing production issues
-4. **You're hitting platform limits** on Heroku/Railway/etc
-5. **You're preparing for Series A** and want to demonstrate infrastructure maturity
-
-### Signals It's Too Early
-
-1. **You're still searching for product-market fit** (focus on product, not infrastructure)
-2. **You have fewer than 3 services** (overhead outweighs benefits)
-3. **No one on the team has Kubernetes experience** (cost of learning is high)
-4. **Your infrastructure spend is under £2k/month** (optimisation gains are minimal)
-
-## The Transition Path
-
-If you decide Kubernetes is right for you, here's a sensible approach:
-
-### Phase 1: Start with Managed Kubernetes (Week 1-2)
-
-Use EKS (AWS), GKE (Google), or AKS (Azure). Don't build your own cluster.
-
-```bash
-# Example: Create an EKS cluster with eksctl
-eksctl create cluster \
-  --name production \
-  --region eu-west-2 \
-  --nodes 3 \
-  --node-type t3.medium
-```
-
-Managed services handle the control plane, reducing operational burden significantly.
-
-### Phase 2: Migrate One Service (Week 2-3)
-
-Pick a non-critical service and migrate it first. This lets you learn without risking core functionality.
-
-```yaml
-# deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: background-worker
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: background-worker
-  template:
-    metadata:
-      labels:
-        app: background-worker
-    spec:
-      containers:
-      - name: worker
-        image: your-registry/background-worker:latest
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
-```
-
-### Phase 3: Set Up CI/CD (Week 3-4)
-
-Integrate Kubernetes deployments into your existing pipeline:
-
-```yaml
-# .github/workflows/deploy.yaml
-deploy:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v4
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-west-2
-
-    - name: Update kubeconfig
-      run: aws eks update-kubeconfig --name production
-
-    - name: Deploy to Kubernetes
-      run: kubectl apply -f k8s/
-```
-
-### Phase 4: Migrate Remaining Services (Week 4-8)
-
-Gradually move services over. Don't rush—each migration is an opportunity to improve the service's configuration and documentation.
-
-### Phase 5: Optimise (Ongoing)
-
-Once everything is running, optimise:
-- Right-size resource requests
-- Implement proper health checks
-- Set up monitoring and alerting
-- Configure auto-scaling
-
-## What Investors Look For
-
-If you're using Kubernetes, investors (or their technical advisors) will check:
-
-| Area | Good Signal | Red Flag |
-|------|------------|----------|
-| **Cluster management** | Managed service (EKS/GKE) | Self-managed cluster |
-| **Deployments** | Automated via CI/CD | Manual kubectl apply |
-| **Monitoring** | Prometheus + Grafana or equivalent | "We check the logs when something's wrong" |
-| **Security** | RBAC configured, secrets properly managed | Default service accounts, secrets in plain text |
-| **Documentation** | Clear runbooks for common tasks | Tribal knowledge only |
-
-## Summary
-
-Kubernetes is a powerful tool, but it's not for everyone. The right decision depends on your stage, team capabilities, and operational needs.
-
-**Pre-seed / Early Seed:** Use Heroku, Railway, or similar. Ship fast, learn what customers want.
-
-**Late Seed / Series A:** Evaluate Kubernetes seriously. If you're scaling the team and services, the investment pays off.
-
-**Series A+:** Kubernetes becomes the default. It demonstrates maturity and provides the foundation for growth.
-
-The goal isn't to use the coolest technology—it's to make the right trade-off between simplicity and capability for where you are today, while positioning yourself for where you'll be in 18 months.
+The question is never whether Kubernetes is good technology. It is whether running it is the best use of the engineering time you are paying for this quarter. For the wider infrastructure picture, our [AWS infrastructure guide for founders](/blog/terraform-aws-infrastructure-as-code/) covers the decisions around it.
 
 ---
 
-*Not sure whether Kubernetes is right for your startup? [Get in touch](/contact/) for a technical strategy session.*
+*Weighing up an infrastructure change and want an independent read? Our [Fractional CTO service](/services/fractional-cto/) covers architecture and scaling decisions, or [get in touch](/contact/) for a technical strategy session.*


### PR DESCRIPTION
Applies the treatment from #56 to the three other technical posts that carried code. Net **-554 lines**.

The zero-code posts (`startup-technical-due-diligence-checklist`, `mvp-vs-mlp-what-to-build-first`, `non-technical-founder-hiring-developers`) were already founder-facing and are untouched.

## The three rewrites

**GitOps** — reframed around what manual deployment actually costs the business: release pace, key-person risk, incident length, engineer attention. Adds the three rungs below full GitOps, because skipping to the top rung is the common expensive mistake. Four questions to ask before approving the work. 4 code blocks removed.

**Kubernetes** — reframed around the trade the founder is really making, which is how much engineering capacity goes into running software rather than building it. Adds the AWS ECS rung that proposals usually skip past. 4 code blocks removed.

**Infrastructure as code** — kept its distinct raise/diligence angle so it does not cannibalise the AWS post from #56, and went deeper there instead. Now leads on the four questions diligence asks with good and bad answers verbatim, plus a six-month pre-raise timeline. 3 code blocks removed.

## Truth-first fixes (§2.2)

Two unsourced firm-wide statistics, both removed:

- GitOps claimed *"Teams report 60-80% reduction in deployment-related incidents"*
- Kubernetes claimed compute savings of *"often 30-40%"*

Neither had a citable basis. The Kubernetes efficiency point now tells the reader to verify any quoted percentage against their own bill.

## A content judgement worth flagging

The Kubernetes post twice advised adopting it because it *"signals maturity"* / *"demonstrates maturity"* in due diligence. I removed that and replaced it with the opposite argument, because the original is bad advice:

> Diligence does not reward sophisticated infrastructure. It rewards infrastructure that matches the size of the business and that the team can demonstrably operate. An investor's technical advisor who finds Kubernetes at a company with two services and no one who has run it before draws a conclusion about judgement, and it is not a favourable one.

Telling founders to adopt infrastructure to impress investors is how startups acquire systems they cannot staff. Happy to revert if you disagree, but I did not want to leave it standing silently.

## Unrelated fix while in the area

Ten folder emojis in the data room post's directory tree, breaching §13.7 ("No emojis. Anywhere."). Removed.

I left the tick glyphs in `app/guides/fractional-cto-vs-full-time/page.js` alone — those read as functional UI marks in a comparison table rather than decorative emoji. Flagging rather than deciding unilaterally.

## Preserved

All four posts keep their **slugs and seoTitles** to protect existing rankings. Dates refreshed since the content is materially new. Every post now has at least one inbound internal link (§12); before this series, three of them had none.

## Verification

`npm run build` passes. Zero code fences in the three rewrites, zero em-dashes, descriptions 149-161 chars, Fractional CTO CTA routing intact on all four, no emojis in the built output, inbound links confirmed in the built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)