### PR TITLE
Rework the footer: link budget, heading semantics, mobile height

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -527,3 +527,37 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     **Never publish:** any other client or tenant name found in those repos, and
     the internal improvement plans or audit findings. Naming the stack at the level
     the Opayo study does is fine; publishing another party's name is not ours to do.
+30. **The footer is navigation, not a sitemap.** (5 Aug 2026, after an audit.) It
+    carried all 21 routes on the site, 9 of them in Resources, where seven guides sat
+    beside a link to the guides index. That handed the least commercial pages the
+    largest sitewide internal-link footprint — seven links each against **one** for
+    either service page. **Link budget: four groups, at most four destinations each,
+    plus Privacy and the logo.** The five comparison guides are reached from `/guides/`
+    and from in-content links; they do not belong on every page. Before adding a
+    footer link, remove one.
+    - **Column labels are `h3` inside `<nav aria-labelledby>`, never `h2`.** They
+      render on every page, so as `h2` they polluted every document outline — and on
+      `/contact`, which has no content `h2` of its own, the entire sub-`h1` outline
+      was "Advisory / Resources / Company / Partner With Us". The `nav` landmarks also
+      split what was one `contentinfo` region holding 21 undifferentiated links.
+    - **No CTA button in the footer.** `Navigation.js` pins a gold "Request a Strategy
+      Call" at this scroll depth on **both** breakpoints (`fixed bottom-6 right-6` on
+      desktop, a full-width bar on mobile), so a footer button puts two identical gold
+      CTAs on screen at once. The label stays a text link in Partner With Us. This was
+      tried and reverted — do not re-add it without first removing the sticky CTA.
+    - **Nav groups go two-up from the smallest breakpoint** (`grid-cols-2
+      lg:grid-cols-5`, brand block `col-span-2 lg:col-span-1`). Stacked one per row
+      with a 48px gap, the footer was **1452px — 46% of the whole of `/contact`** at
+      375px. Now 939px (35%). Measure the footer as a share of page height at 375px
+      after any change to it; the link count is not the thing that drives it.
+    - **No copyright year.** `new Date().getFullYear()` in a server component under
+      `output: 'export'` is evaluated once, at build, and baked in — deploys fire on
+      push, so the year goes stale silently. "© Codenest Ltd. All rights reserved."
+      needs no year to stand. Do not reintroduce a computed one.
+    - **The logo links home.** The footer's only other reference to `/` is the
+      `/#how-we-work` anchor, so without it `/privacy` offered no route back.
+      It carries `width`/`height` so it does not shift layout on load.
+    - **Say "boutique" once.** The bottom bar used to repeat the brand blurb as
+      "Boutique technical & financial advisory for UK startups", beside the Privacy
+      link where it read as part of the legal row. The brand column now carries the
+      one description, and it uses the §1 ICP phrasing "pre-seed to Series A".

--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -1,91 +1,146 @@
 import Link from 'next/link'
 
-export default function Footer() {
-  const currentYear = new Date().getFullYear()
+// Link budget: the footer is navigation, not a sitemap. Four groups, at most four
+// destinations each, plus the CTA and Privacy. It used to carry all 21 routes on the
+// site — 9 of them in Resources, where seven guides sat beside a link to the guides
+// index. That gave the least commercial pages the largest sitewide internal-link
+// footprint (7 links each) while either service page had one. See BRANDING.md §13.30.
+const GROUPS = [
+  {
+    id: 'footer-advisory',
+    heading: 'Advisory',
+    // Only real destinations. "0-to-1 Product Builds" and "AI & Data Engineering"
+    // used to sit here pointing at /services/ — capabilities dressed as pages
+    // (BRANDING.md §13.26).
+    links: [
+      { href: '/services/fractional-cto/', label: 'Fractional CTO' },
+      { href: '/services/fractional-cfo/', label: 'Fractional CFO' },
+      { href: '/services/', label: 'All Services' },
+    ],
+  },
+  {
+    id: 'footer-resources',
+    heading: 'Resources',
+    // The five comparison guides are reached from /guides/ and from in-content
+    // links, not from every page on the site.
+    links: [
+      { href: '/guides/', label: 'All Guides' },
+      { href: '/guides/fractional-cto-guide/', label: 'Fractional CTO Guide' },
+      { href: '/guides/fractional-cfo-guide/', label: 'Fractional CFO Guide' },
+      { href: '/tools/runway-calculator/', label: 'Runway Calculator' },
+    ],
+  },
+  {
+    id: 'footer-company',
+    heading: 'Company',
+    links: [
+      { href: '/case-studies/', label: 'Case Studies' },
+      { href: '/#how-we-work', label: 'Our Methodology' },
+      { href: '/about/', label: 'Our Story' },
+      { href: '/blog/', label: 'Insights' },
+    ],
+  },
+  {
+    id: 'footer-partner',
+    heading: 'Partner With Us',
+    // "Request a Strategy Call" stays a text link here, and the footer has no CTA
+    // button of its own: Navigation.js pins a gold CTA at this scroll depth on both
+    // breakpoints, so a footer button would put two identical gold CTAs on screen
+    // at once — the duplication the comment in Navigation.js already records.
+    links: [
+      { href: '/contact/', label: 'Request a Strategy Call' },
+      { href: '/cofounder/', label: 'Co-founder Opportunities' },
+      { href: '/refer/', label: 'Referral Program' },
+      {
+        href: 'https://www.linkedin.com/company/codenest-ltd',
+        label: 'LinkedIn',
+        external: true,
+      },
+    ],
+  },
+]
 
+const LINK_CLASS = 'text-slate-400 hover:text-accent-400 transition-colors'
+
+function FooterLink({ href, label, external }) {
+  if (external) {
+    return (
+      <a href={href} className={LINK_CLASS} target="_blank" rel="noopener noreferrer">
+        {label}
+      </a>
+    )
+  }
+  return (
+    <Link href={href} className={LINK_CLASS}>
+      {label}
+    </Link>
+  )
+}
+
+export default function Footer() {
   return (
     <footer className="bg-slate-900 text-white py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-12 mb-12">
-          <div>
-            <img
-              src="/img/companylogo-light.svg"
-              alt="Codenest - Fractional CTO & CFO for UK startups"
-              className="h-10 w-auto mb-4"
-            />
+        {/* The nav groups go two-up from the smallest breakpoint. Stacked one per row
+            with a 48px gap, the four groups plus the brand block made the footer 46%
+            of the total height of /contact on a 375px screen. */}
+        <div className="grid grid-cols-2 lg:grid-cols-5 gap-x-6 gap-y-10 lg:gap-12 mb-12">
+          <div className="col-span-2 lg:col-span-1">
+            {/* The logo is the way home: the footer otherwise has no link to "/",
+                only the /#how-we-work anchor. */}
+            <Link href="/" className="inline-block mb-4" aria-label="Codenest home">
+              <img
+                src="/img/companylogo-light.svg"
+                alt="Codenest - Fractional CTO &amp; CFO for UK startups"
+                width={217}
+                height={40}
+                className="h-10 w-auto"
+              />
+            </Link>
             <p className="text-slate-400 text-sm leading-relaxed">
-              Boutique advisory for ambitious founders. Big 4 rigour meets founder empathy.
+              Boutique advisory for UK founders, pre-seed to Series A.
+              Big 4 rigour meets founder empathy.
             </p>
             <p className="text-accent-400 text-sm font-medium mt-3">
               Executive firepower. Startup agility.
             </p>
+            {/* "London-based" removed: the only address this site publishes is
+                the registered office in Reigate, Surrey, and the schema in
+                app/layout.js now states that one. Put a locality claim back
+                only alongside an address that supports it (BRANDING.md §13.25). */}
+            <p className="text-slate-400 text-xs mt-4">
+              Serving select founders across the UK and Europe.
+            </p>
           </div>
-          <div>
-            <h2 className="font-semibold mb-4">Advisory</h2>
-            <ul className="space-y-2 text-sm">
-              {/* Only real destinations. "0-to-1 Product Builds" and "AI & Data
-                  Engineering" used to sit here pointing at /services/ — capabilities
-                  dressed as pages, which is the same bait the service cards had. */}
-              <li><Link href="/services/fractional-cto/" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CTO</Link></li>
-              <li><Link href="/services/fractional-cfo/" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CFO</Link></li>
-              <li><Link href="/services/" className="text-slate-400 hover:text-accent-400 transition-colors">All Services</Link></li>
-            </ul>
-          </div>
-          <div>
-            <h2 className="font-semibold mb-4">Resources</h2>
-            <ul className="space-y-2 text-sm">
-              <li><Link href="/guides/" className="text-slate-400 hover:text-accent-400 transition-colors">All Guides</Link></li>
-              <li><Link href="/guides/fractional-cto-guide/" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CTO Guide</Link></li>
-              <li><Link href="/guides/fractional-cfo-guide/" className="text-slate-400 hover:text-accent-400 transition-colors">Fractional CFO Guide</Link></li>
-              <li><Link href="/guides/fractional-cto-vs-full-time/" className="text-slate-400 hover:text-accent-400 transition-colors">CTO vs Full-Time</Link></li>
-              <li><Link href="/guides/fractional-cfo-vs-full-time/" className="text-slate-400 hover:text-accent-400 transition-colors">CFO vs Full-Time</Link></li>
-              <li><Link href="/guides/fractional-cto-vs-agency/" className="text-slate-400 hover:text-accent-400 transition-colors">CTO vs Agency</Link></li>
-              <li><Link href="/guides/fractional-cfo-vs-outsourced-finance/" className="text-slate-400 hover:text-accent-400 transition-colors">CFO vs Outsourced Finance</Link></li>
-              <li><Link href="/guides/technical-cofounder-alternatives/" className="text-slate-400 hover:text-accent-400 transition-colors">Co-founder Alternatives</Link></li>
-              <li><Link href="/tools/runway-calculator/" className="text-slate-400 hover:text-accent-400 transition-colors">Runway Calculator</Link></li>
-            </ul>
-          </div>
-          <div>
-            <h2 className="font-semibold mb-4">Company</h2>
-            <ul className="space-y-2 text-sm">
-              <li><a href="/case-studies/" className="text-slate-400 hover:text-accent-400 transition-colors">Case Studies</a></li>
-              <li><a href="/#how-we-work" className="text-slate-400 hover:text-accent-400 transition-colors">Our Methodology</a></li>
-              <li><a href="/about/" className="text-slate-400 hover:text-accent-400 transition-colors">Our Story</a></li>
-              <li><Link href="/blog/" className="text-slate-400 hover:text-accent-400 transition-colors">Insights</Link></li>
-            </ul>
-          </div>
-          <div>
-            <h2 className="font-semibold mb-4">Partner With Us</h2>
-            <ul className="space-y-2 text-sm">
-              <li><a href="/contact/" className="text-slate-400 hover:text-accent-400 transition-colors">Request a Strategy Call</a></li>
-              <li><a href="/cofounder/" className="text-slate-400 hover:text-accent-400 transition-colors">Co-founder Opportunities</a></li>
-              <li><Link href="/refer/" className="text-slate-400 hover:text-accent-400 transition-colors">Referral Program</Link></li>
-              <li><a href="https://www.linkedin.com/company/codenest-ltd" className="text-slate-400 hover:text-accent-400 transition-colors" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
-            </ul>
-            <div className="mt-6">
-              {/* "London-based" removed: the only address this site publishes is
-                  the registered office in Reigate, Surrey, and the schema in
-                  app/layout.js now states that one. Put a locality claim back
-                  only alongside an address that supports it (BRANDING.md §13.25). */}
-              <p className="text-slate-400 text-xs">
-                Serving select founders across the UK and Europe.
-              </p>
-            </div>
-          </div>
+          {GROUPS.map((group) => (
+            <nav key={group.id} aria-labelledby={group.id}>
+              {/* h3, not h2: these labels are on every page, and on thin pages such
+                  as /contact they were the only h2s in the document outline. */}
+              <h3 id={group.id} className="font-semibold mb-4">
+                {group.heading}
+              </h3>
+              <ul className="space-y-2 text-sm">
+                {group.links.map((link) => (
+                  <li key={link.href}>
+                    <FooterLink {...link} />
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
         </div>
         <div className="pt-8 border-t border-slate-800 space-y-4">
           <div className="flex flex-col md:flex-row justify-between items-center gap-4">
+            {/* No year: this is a static export deployed on push, so a build-time
+                new Date().getFullYear() bakes in whichever year the last push
+                happened and then goes stale silently. A year is not required for
+                the notice to stand. */}
             <p className="text-slate-400 text-sm">
-              © {currentYear} Codenest Ltd. All rights reserved.
+              &copy; Codenest Ltd. All rights reserved.
             </p>
-            <div className="flex items-center gap-6">
-              <Link href="/privacy/" className="text-slate-400 hover:text-accent-400 transition-colors text-sm">
-                Privacy Policy
-              </Link>
-              <p className="text-slate-400 text-xs">
-                Boutique technical & financial advisory for UK startups
-              </p>
-            </div>
+            <Link href="/privacy/" className={`${LINK_CLASS} text-sm`}>
+              Privacy Policy
+            </Link>
           </div>
           {/* Statutory trading disclosures — a limited company must show its
               registered name, number, place of registration and registered office


### PR DESCRIPTION
The footer carried **all 21 routes on the site** with no editorial ranking, and at 375px it was **1452px tall — 46% of the whole of `/contact`**.

## Results

| | Before | After |
|---|---|---|
| Links | 21 (every route) | 17 |
| Resources column | 9 links | 4 |
| Mobile footer | 1452px, **46%** of `/contact` | 939px, **35%** |
| Desktop footer | 568px | 538px |
| Footer `h2`s | 4 on every page | 0 (now `h3`) |
| `<nav>` landmarks | 0 | 4 |

## What changed

- **Link budget — four groups, at most four destinations each.** Resources drops from 9 to 4. The five comparison guides are reached from `/guides/` and from in-content links rather than from every page on the site; sitewide they had given the least commercial pages a **seven-link** internal footprint against **one** for either service page.
- **Column labels become `h3` inside `<nav aria-labelledby>`.** As `h2` they polluted every document outline, and on `/contact` — which has no content `h2` of its own — they were the entire sub-`h1` outline. The `nav` landmarks also split what was one `contentinfo` region holding 21 undifferentiated links.
- **Nav groups go two-up from the smallest breakpoint** (`grid-cols-2 lg:grid-cols-5`, brand block `col-span-2 lg:col-span-1`). This, not the link count, is what drove the mobile height: trimming links alone only moved it 46% → 44%.
- **Drop the computed copyright year.** `new Date().getFullYear()` in a server component under `output: 'export'` is evaluated once at build and baked in; deploys fire on push, so it goes stale silently. The notice stands without one.
- **The logo links home** — the footer's only other reference to `/` was the `/#how-we-work` anchor, so `/privacy` offered no route back — and carries `width`/`height` so it does not shift layout on load.
- **Say "boutique" once**, in the brand column, using the §1 ICP phrasing "pre-seed to Series A". The bottom bar repeated it beside the Privacy link, where it read as part of the legal row.
- **Internal destinations all go through `next/link`**; six were raw anchors forcing full document reloads.

## No footer CTA button

The audit claimed the footer had no CTA while the nav had a gold button. That was wrong: `Navigation.js` pins a gold "Request a Strategy Call" at exactly this scroll depth on **both** breakpoints (`fixed bottom-6 right-6` desktop, full-width bar mobile). A button was built, showed two identical gold CTAs on screen at once, and was reverted — the same duplication the comment at `Navigation.js:192` records being fixed once already. The label stays a text link in Partner With Us.

`/#how-we-work` was left under Company: footers linking to homepage anchors is conventional.

## Verification

- `npm run build` clean
- Zero WCAG AA contrast failures at 1280px and 375px (every text node walked against its effective background)
- No horizontal overflow at either width
- Built output confirmed: 17 links, 4 `nav`, 0 `h2`, 4 `h3`, no baked year, home link present, "boutique" once

BRANDING.md §13.30 records the link budget, the heading rule, the two-up breakpoint with the measured numbers, the year rationale, and the CTA revert so it is not re-added.

## Flagged, not fixed

`/contact/` now has **zero** `h2`s. Its whole sub-`h1` outline was footer column labels; removing them exposed a real content gap on that page, which is a contact-page issue rather than a footer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)