### PR TITLE
Fact-check the finance posts: correct superseded R&D tax guidance

### DIFF
--- a/content/blog/extending-startup-runway-practical-guide.md
+++ b/content/blog/extending-startup-runway-practical-guide.md
@@ -51,7 +51,7 @@ Runway extension comes down to two variables: reduce burn or increase revenue. H
 
 ### Lever 1: Headcount Optimisation
 
-People costs typically represent 60-80% of startup burn. This is your biggest lever.
+For most early-stage software startups, people are the largest line in the burn by a wide margin. Check your own figure before pulling any other lever, because it decides where the effort is worth spending.
 
 **Before hiring:**
 - Can this role wait 3 months?
@@ -133,12 +133,14 @@ Before raising more equity, explore non-dilutive options:
 Lenders like Clearco, Pipe, and Capchase advance cash against your future revenue. Useful for bridging short-term gaps, but expensive (effective rates of 15-30% annually).
 
 **R&D tax credits:**
-UK startups can claim back a portion of qualifying R&D spend. For SMEs, this can be 25-33% of eligible costs. Many founders leave this money on the table.
+UK startups can claim back a portion of qualifying R&D spend, and many founders leave this money on the table. The rules changed substantially: the separate SME and RDEC schemes were replaced for accounting periods beginning on or after 1 April 2024, so guidance written before then no longer describes what you can claim.
 
-| Scheme | Benefit | Eligibility |
-|--------|---------|------------|
-| SME R&D Relief | 25-33% of qualifying spend | <500 employees, <£86m turnover |
-| RDEC | 13% credit | Larger companies or subcontracted R&D |
+| Scheme | Benefit | Who it is for |
+|---|---|---|
+| Merged R&D expenditure credit | 20% expenditure credit, which is itself taxable | The default route for most companies |
+| Enhanced R&D intensive support (ERIS) | An extra 86% deduction on qualifying costs, plus a payable credit worth up to 14.5% of the surrendered loss | Loss-making SMEs that are R&D intensive |
+
+You cannot claim under both for the same expenditure. Which route applies, and what it is worth after tax, depends on your numbers, so treat this as a prompt to ask your accountant rather than a calculation to run yourself. Rates and thresholds in this area change at most fiscal events; confirm the current position before you build it into a forecast.
 
 **Grants:**
 Innovate UK, Horizon Europe, and sector-specific grants provide non-dilutive funding. Competitive and time-consuming, but worth exploring for the right projects.

--- a/content/blog/financial-modeling-seed-stage-startups.md
+++ b/content/blog/financial-modeling-seed-stage-startups.md
@@ -113,7 +113,7 @@ Create a monthly projection for 24-36 months:
 
 Categorise costs by type:
 
-**People costs** (typically 60-70% of spend):
+**People costs** (usually the largest category):
 - Engineering salaries
 - Sales salaries + commissions
 - Operations/support


### PR DESCRIPTION
## This is a fact-check, not a rewrite — and that is deliberate

The finance posts do **not** have the problem the technical posts had, so applying the same treatment would have damaged them.

The technical posts' code blocks were implementation detail a founder could never act on (Terraform HCL, Kubernetes manifests, CI config). The finance posts' fenced blocks are the substance:

```
CAC = Total Sales & Marketing Spend / Number of New Customers Acquired
Runway (months) = Cash Balance / Monthly Burn Rate
```

Plus the data room folder template, which readers copy directly. A founder learning unit economics needs the formula. Stripping these would leave prose *about* metrics with no way to compute them.

Four of the nine finance posts have zero code and were written recently — they read fine as they are.

## What the scan found instead, which is worse

`extending-startup-runway-practical-guide` published this:

| Scheme | Benefit | Eligibility |
|---|---|---|
| SME R&D Relief | 25-33% of qualifying spend | <500 employees, <£86m turnover |
| RDEC | 13% credit | Larger companies or subcontracted R&D |

Both rows are wrong. The separate SME and RDEC schemes were **replaced for accounting periods beginning on or after 1 April 2024**, and the 13% RDEC rate predates the April 2023 increase. A UK finance advisory site was publishing tax guidance two reforms out of date, in a post about extending runway — the exact context where a founder might act on it.

Replaced with the current position, verified against gov.uk:

- **Merged R&D expenditure credit**, 20%, noting it is itself taxable
- **Enhanced R&D intensive support (ERIS)** for loss-making R&D-intensive SMEs: an extra 86% deduction plus a payable credit worth up to 14.5% of the surrendered loss
- The two cannot be claimed on the same expenditure
- Framed as a prompt to ask an accountant, with a warning that rates move at fiscal events

## Also fixed: two more unsourced statistics (§2.2)

- "People costs typically represent 60-80% of startup burn"
- "typically 60-70% of spend"

Same class of defect as the 60-80% and 30-40% claims removed in #57. Both now describe the shape without asserting a denominator we cannot cite, and the runway post tells the reader to check their own figure.

## Deliberately NOT changed — needs Michelle

The SEIS/EIS post's core rates and limits check out against gov.uk: 50% SEIS relief, 30% EIS, £250k company SEIS limit, £200k investor annual limit, £350k gross assets.

**However, Finance Act 2026 raised EIS investment and gross asset limits with effect from 6 April 2026** — four months ago. The post's EIS figures (£15M assets, £5M/year) need review. I have not touched them, because getting UK tax figures right from search snippets is exactly the kind of confident-but-wrong output the AI post warns about, and Michelle is FCCA-qualified. Flagging rather than guessing.

**Recommendation:** a standing review date on the two tax-fact posts. They fail silently — nothing breaks, the numbers just quietly become wrong, and the site's whole positioning rests on claims that survive scrutiny.

## Verification

`npm run build` passes. Stale figures confirmed absent from the built output.

Sources: [merged scheme and ERIS](https://www.gov.uk/guidance/research-and-development-rd-tax-relief-the-merged-scheme-and-enhanced-rd-intensive-support), [EIS/VCT changes](https://www.gov.uk/government/publications/enterprise-investment-scheme-eis-and-venture-capital-trusts-vct-changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)