### PR TITLE
Add lastVerified frontmatter and a build-time content freshness check

### DIFF
--- a/content/blog/extending-startup-runway-practical-guide.md
+++ b/content/blog/extending-startup-runway-practical-guide.md
@@ -6,6 +6,10 @@ date: '2025-08-10'
 author: 'Michelle Rana'
 readTime: '9 min read'
 tags: ['Cash Management', 'Startup Finance']
+# Carries UK R&D tax relief rates. Corrected and checked against gov.uk on
+# 2026-08-05 after the pre-2024 SME/RDEC figures were found still published.
+lastVerified: '2026-08-05'
+verifyEvery: 6
 ---
 
 # Extending Your Runway: A Practical Guide to Startup Cash Management

--- a/content/blog/how-cfos-use-ai-startup-finance.md
+++ b/content/blog/how-cfos-use-ai-startup-finance.md
@@ -6,6 +6,11 @@ date: '2026-08-05'
 author: 'Michelle Rana'
 readTime: '11 min read'
 tags: ['Fractional CFO', 'AI', 'Startup Finance']
+# Describes a third party's product behaviour and commercial terms, both of
+# which change without notice. The copy deliberately tells readers to verify
+# the terms for their own plan, but the surrounding claims still need a look.
+lastVerified: '2026-08-05'
+verifyEvery: 12
 ---
 
 # How CFOs Can Use AI in Startup Finance: A Practical Guide

--- a/content/blog/how-much-does-fractional-cfo-cost-uk.md
+++ b/content/blog/how-much-does-fractional-cfo-cost-uk.md
@@ -6,6 +6,11 @@ date: '2026-08-04'
 author: 'Michelle Rana'
 readTime: '7 min read'
 tags: ['Fractional CFO', 'Pricing', 'Startup Finance']
+# Market rate bands, and the title carries a year, so BRANDING.md §8 requires a
+# genuine annual refresh. Seeded from the authorship date; the first review
+# cycle is where the ranges get independently re-checked.
+lastVerified: '2026-08-04'
+verifyEvery: 12
 ---
 
 # How Much Does a Fractional CFO Cost in the UK? 2026 Pricing Guide

--- a/content/blog/how-much-does-fractional-cto-cost-uk.md
+++ b/content/blog/how-much-does-fractional-cto-cost-uk.md
@@ -6,6 +6,11 @@ date: '2026-08-04'
 author: 'Ankit Rana'
 readTime: '7 min read'
 tags: ['Fractional CTO', 'Pricing', 'Budgeting']
+# Market rate bands, and the title carries a year, so BRANDING.md §8 requires a
+# genuine annual refresh. Seeded from the authorship date; the first review
+# cycle is where the ranges get independently re-checked.
+lastVerified: '2026-08-04'
+verifyEvery: 12
 ---
 
 # How Much Does a Fractional CTO Cost in the UK? 2026 Pricing Guide

--- a/content/blog/seis-eis-tax-benefits-startup-investors.md
+++ b/content/blog/seis-eis-tax-benefits-startup-investors.md
@@ -6,6 +6,13 @@ date: '2025-01-04'
 author: 'Michelle Rana'
 readTime: '9 min read'
 tags: ['Fundraising', 'Finance', 'UK Startups']
+# Statutory rates and limits. Core SEIS/EIS reliefs were checked against gov.uk
+# on 2026-08-05, but Finance Act 2026 changed EIS investment and gross asset
+# limits from 6 April 2026 and those figures here are NOT yet confirmed.
+# lastVerified stays at the content date until an accountant signs the EIS
+# section off. It is meant to be flagging.
+lastVerified: '2025-01-04'
+verifyEvery: 6
 ---
 
 # SEIS and EIS Explained: UK Tax Benefits for Startup Investors

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/check-content-freshness.js",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "check:freshness": "node scripts/check-content-freshness.js",
+    "check:freshness:strict": "node scripts/check-content-freshness.js --strict"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/check-content-freshness.js
+++ b/scripts/check-content-freshness.js
@@ -1,0 +1,145 @@
+/**
+ * Content freshness check.
+ *
+ * Some posts rest on facts that expire: UK tax rates, statutory thresholds,
+ * market rate bands, third-party product terms. Nothing breaks when they go
+ * stale. The build passes, the page renders, and the numbers are quietly wrong
+ * on a site whose whole positioning is that its claims survive scrutiny.
+ *
+ * A post opts in by declaring how long its facts stay trustworthy:
+ *
+ *   lastVerified: '2026-08-05'   # when a human last checked the facts
+ *   verifyEvery: 6              # months before it needs checking again
+ *
+ * `lastVerified` means someone actually confirmed the numbers against source.
+ * It is not the publish date and it is not the date the file was last edited:
+ * fixing a typo does not re-verify a tax rate. Only move it when you have
+ * genuinely re-checked.
+ *
+ * Runs as a prebuild hook, so it reports before the Next.js output rather than
+ * scrolling past underneath it. Warns by default; pass --strict to fail the
+ * build instead (intended for CI).
+ */
+
+const fs = require('fs')
+const path = require('path')
+const matter = require('gray-matter')
+
+const BLOG_DIR = path.join(process.cwd(), 'content/blog')
+const DEFAULT_VERIFY_EVERY_MONTHS = 12
+const STRICT = process.argv.includes('--strict')
+
+// Warn ahead of the deadline so a review can be scheduled rather than discovered.
+const DUE_SOON_DAYS = 30
+
+const RED = '\x1b[31m'
+const YELLOW = '\x1b[33m'
+const DIM = '\x1b[2m'
+const BOLD = '\x1b[1m'
+const RESET = '\x1b[0m'
+
+function monthsAfter(date, months) {
+  const due = new Date(date)
+  due.setMonth(due.getMonth() + months)
+  return due
+}
+
+function daysBetween(from, to) {
+  return Math.round((to - from) / (1000 * 60 * 60 * 24))
+}
+
+function readPosts() {
+  if (!fs.existsSync(BLOG_DIR)) return []
+
+  return fs
+    .readdirSync(BLOG_DIR)
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => {
+      const { data } = matter(fs.readFileSync(path.join(BLOG_DIR, file), 'utf8'))
+      return { slug: file.replace(/\.md$/, ''), frontmatter: data }
+    })
+}
+
+function assess(post, now) {
+  const { lastVerified, verifyEvery } = post.frontmatter
+  if (!lastVerified) return null
+
+  const verifiedAt = new Date(lastVerified)
+  if (Number.isNaN(verifiedAt.getTime())) {
+    return { ...post, state: 'invalid', detail: `lastVerified is not a date: ${lastVerified}` }
+  }
+
+  const months = Number(verifyEvery) || DEFAULT_VERIFY_EVERY_MONTHS
+  const dueAt = monthsAfter(verifiedAt, months)
+  const daysRemaining = daysBetween(now, dueAt)
+
+  if (daysRemaining < 0) {
+    return { ...post, state: 'overdue', days: Math.abs(daysRemaining), dueAt, months }
+  }
+  if (daysRemaining <= DUE_SOON_DAYS) {
+    return { ...post, state: 'due-soon', days: daysRemaining, dueAt, months }
+  }
+  return { ...post, state: 'fresh', days: daysRemaining, dueAt, months }
+}
+
+function formatDate(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function main() {
+  const now = new Date()
+  const tracked = readPosts()
+    .map((post) => assess(post, now))
+    .filter(Boolean)
+
+  if (tracked.length === 0) {
+    console.log(`${DIM}Content freshness: no posts declare lastVerified.${RESET}`)
+    return
+  }
+
+  const invalid = tracked.filter((p) => p.state === 'invalid')
+  const overdue = tracked.filter((p) => p.state === 'overdue')
+  const dueSoon = tracked.filter((p) => p.state === 'due-soon')
+  const fresh = tracked.filter((p) => p.state === 'fresh')
+
+  for (const post of invalid) {
+    console.log(`${RED}${BOLD}  INVALID${RESET} ${post.slug} — ${post.detail}`)
+  }
+
+  if (overdue.length > 0) {
+    console.log('')
+    console.log(`${RED}${BOLD}  Content freshness: ${overdue.length} post(s) overdue for fact-checking${RESET}`)
+    for (const post of overdue) {
+      console.log(
+        `${RED}    ${post.slug}${RESET}\n` +
+          `${DIM}      last verified ${formatDate(new Date(post.frontmatter.lastVerified))}, ` +
+          `due ${formatDate(post.dueAt)} (${post.months}-month cycle), ${post.days} days overdue${RESET}`
+      )
+    }
+    console.log(
+      `${DIM}    Re-check the facts against source, then move lastVerified. ` +
+        `Do not bump the date without checking.${RESET}`
+    )
+    console.log('')
+  }
+
+  for (const post of dueSoon) {
+    console.log(
+      `${YELLOW}  DUE SOON${RESET} ${post.slug} ${DIM}— fact-check due ${formatDate(post.dueAt)} (${post.days} days)${RESET}`
+    )
+  }
+
+  // Always state the denominator. "1 overdue" on its own hides whether the
+  // other volatile posts are tracked at all or just never opted in.
+  console.log(
+    `${DIM}Content freshness: ${tracked.length} tracked post(s) — ` +
+      `${fresh.length} fresh, ${dueSoon.length} due soon, ${overdue.length} overdue.${RESET}`
+  )
+
+  if (STRICT && (overdue.length > 0 || invalid.length > 0)) {
+    console.error(`${RED}Failing build: --strict and ${overdue.length + invalid.length} post(s) need attention.${RESET}`)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
Follow-up to #59, which found UK R&D tax figures **two reforms out of date** sitting in a runway post. Nothing had broken: the build passed, the page rendered, the numbers were just quietly wrong. This makes that class of decay visible.

## How it works

A post opts in by declaring how long its facts stay trustworthy:

```yaml
lastVerified: '2026-08-05'
verifyEvery: 6          # months; defaults to 12
```

`scripts/check-content-freshness.js` reports overdue posts and warns 30 days ahead, so a review gets scheduled rather than discovered.

Wired as a **`prebuild`** hook so it prints *before* the Next.js output instead of scrolling past underneath it. Warns by default; `--strict` exits non-zero for CI:

```bash
npm run check:freshness
npm run check:freshness:strict
```

**`lastVerified` means a human checked the facts against source.** Deliberately not the publish date and not the file mtime — fixing a typo does not re-verify a tax rate. The script's header says so, and so does the message it prints when something is overdue.

## Actual output today

```
  Content freshness: 1 post(s) overdue for fact-checking
    seis-eis-tax-benefits-startup-investors
      last verified 2025-01-04, due 2025-07-03 (6-month cycle), 398 days overdue
    Re-check the facts against source, then move lastVerified. Do not bump the date without checking.

Content freshness: 5 tracked post(s) — 4 fresh, 0 due soon, 1 overdue.
```

## Two honesty notes on the seeded dates

**The SEIS/EIS post is stamped with its content date, not today** — even though I checked its core reliefs against gov.uk this morning. Finance Act 2026 changed EIS investment and gross asset limits from 6 April 2026 and those figures remain unconfirmed. Stamping it verified would have made the tool lie on the day it shipped. It flags as 398 days overdue, which is correct, and it is the item that needs Michelle.

**The two cost guides are seeded from their authorship date**, which is an assumption rather than a verification. Each file carries a comment saying so; their first review cycle is where the ranges get independently re-checked. Both also carry a year in the title, which `BRANDING.md` §8 already obliges to be refreshed annually — the 12-month cycle turns an existing rule into something enforceable.

| Post | lastVerified | Cycle | State |
|---|---|---|---|
| `seis-eis-tax-benefits-startup-investors` | 2025-01-04 | 6mo | **overdue** |
| `extending-startup-runway-practical-guide` | 2026-08-05 | 6mo | fresh |
| `how-much-does-fractional-cfo-cost-uk` | 2026-08-04 | 12mo | fresh |
| `how-much-does-fractional-cto-cost-uk` | 2026-08-04 | 12mo | fresh |
| `how-cfos-use-ai-startup-finance` | 2026-08-05 | 12mo | fresh |

## Verification

- Check reports 5 tracked, 4 fresh, 1 overdue (output above)
- `--strict` exits 1
- `prebuild` fires ahead of `next build`
- `npm run build` passes
- New frontmatter does not leak into rendered HTML
- Sitemap unchanged at 40 URLs

## Worth considering separately

The check warns but does not block. If you want it to actually gate deploys, add `npm run check:freshness:strict` to the GitHub Actions workflow. I have not done that unasked — it would fail your next deploy on the SEIS/EIS post, which is arguably the point, but that is your call rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)