### PR TITLE
Gate the GitHub Pages deploy on content freshness

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      skip_freshness_check:
+        description: >-
+          Deploy despite overdue fact-checks. For urgent fixes only. The overdue
+          content still ships stale — this defers the review, it does not do it.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -34,6 +41,16 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Gates the deploy on posts whose facts have expired: UK tax rates,
+      # statutory thresholds, market rate bands, third-party terms. These decay
+      # silently — the build passes and the page renders while the numbers go
+      # wrong. Runs before the build so it fails in seconds rather than after a
+      # full compile. `npm run build` also runs the non-strict check via its
+      # prebuild hook, which is what surfaces due-soon warnings locally.
+      - name: Check content freshness
+        if: ${{ inputs.skip_freshness_check != true }}
+        run: npm run check:freshness:strict
 
       - name: Build Next.js site
         run: npm run build


### PR DESCRIPTION
Follow-up to #60. Adds `npm run check:freshness:strict` to the deploy workflow, so content whose facts have expired no longer reaches production silently.

The step sits **between install and build**, so it fails in seconds rather than after a full compile.

## Read this before merging

**This will fail the next push to master.**

`seis-eis-tax-benefits-startup-investors` is 398 days past its review date. Blocking it is the point of the gate, not a side effect. Simulating the exact command CI will run:

```
  Content freshness: 1 post(s) overdue for fact-checking
    seis-eis-tax-benefits-startup-investors
      last verified 2025-01-04, due 2025-07-03 (6-month cycle), 398 days overdue

Content freshness: 5 tracked post(s) — 4 fresh, 0 due soon, 1 overdue.
Failing build: --strict and 1 post(s) need attention.
exit code: 1
```

Clearing it means verifying the EIS investment and gross asset limits changed by Finance Act 2026 from 6 April 2026, then moving `lastVerified`. That is Michelle's call — it is not something the site can assert for itself, and it is not something I will do from search snippets.

## The escape hatch, and why it exists

A permanently red pipeline with no path forward blocks unrelated urgent fixes too. So `workflow_dispatch` now takes a `skip_freshness_check` input:

- **Defaults to false**, so ordinary pushes to master are always gated
- Skipping is a deliberate manual act, with the reason visible in the run history
- Its description says plainly: *"The overdue content still ships stale — this defers the review, it does not do it."*

I deliberately did not make the gate warn-only or auto-skip on some condition. A gate that silently lets things through is the thing this whole series has been removing.

## Unchanged

The `prebuild` hook still runs the **non-strict** check on every local build. That is what surfaces due-soon warnings 30 days ahead, before they ever become blocking.

## Verification

- Workflow YAML parses; steps in order: Checkout → Setup Node → Install → **Check content freshness** → Build → .nojekyll → Upload
- `workflow_dispatch` input declared correctly as a boolean defaulting to false
- The exact command CI runs exits 1 against today's content

## Your two paths after merging

1. Get the SEIS/EIS post verified and bump `lastVerified` — the intended path
2. Deploy via **Actions → Run workflow → skip_freshness_check: true** if something urgent needs to ship first

🤖 Generated with [Claude Code](https://claude.com/claude-code)