### PR TITLE
Give /contact a content heading and name the form landmark

### DIFF
--- a/app/components/ContactForm.js
+++ b/app/components/ContactForm.js
@@ -23,7 +23,10 @@ const COMMON_TYPOS = {
   'yaho.com': 'yahoo.com',
 }
 
-const ContactForm = () => {
+// labelledBy: id of the heading that names this form. An unnamed <form> is not
+// exposed as a landmark at all, so without a name it cannot be reached by landmark
+// navigation. Pages that have no heading to point at fall back to the aria-label.
+const ContactForm = ({ labelledBy }) => {
   const formRef = useRef()
   const [formData, setFormData] = useState({
     name: '',
@@ -236,7 +239,13 @@ const ContactForm = () => {
 
   return (
     <div className="bg-white rounded-2xl shadow-lg p-8 border border-slate-200">
-      <form ref={formRef} onSubmit={handleSubmit} className="space-y-6">
+      <form
+        ref={formRef}
+        onSubmit={handleSubmit}
+        className="space-y-6"
+        aria-labelledby={labelledBy}
+        aria-label={labelledBy ? undefined : 'Request a strategy call'}
+      >
         <div>
           <label htmlFor="name" className="block text-sm font-semibold text-slate-700 mb-2">
             Your Name *

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -84,8 +84,15 @@ export default function ContactPage() {
               </div>
             </div>
 
+            {/* The page's only content heading. Without it the sub-h1 outline was
+                empty, and the four footer column labels were the whole of it until
+                they became h3s. "Let's Talk" carries the tone; this carries the
+                query, and matches both the page title and the §6 CTA label. */}
             <div className="max-w-3xl mx-auto">
-              <ContactForm />
+              <h2 id="contact-form-heading" className="font-serif text-2xl md:text-3xl font-bold text-slate-900 text-center mb-8">
+                Request a Strategy Call
+              </h2>
+              <ContactForm labelledBy="contact-form-heading" />
             </div>
           </div>
         </section>


### PR DESCRIPTION
Follow-up to #58, which flagged this.

`/contact` was the **only page on the site** with no content `h2`. Its entire sub-`h1` outline was the four footer column labels; once #58 demoted those to `h3`, the outline was empty.

## Changes

- **`h2` "Request a Strategy Call"** above the form. "Let's Talk" carries the tone as the `h1`; this carries the query, and matches both the page title (`Contact | Request a Strategy Call`) and the §6 CTA label. No content was invented — the heading names the thing that was already there.
- **`ContactForm` takes an optional `labelledBy`**, falling back to an `aria-label`. An unnamed `<form>` is not exposed as a landmark at all, so on both pages that render it the form could not be reached by landmark navigation. `/contact` points at the new heading; the homepage, whose section already has its own "Let's Talk" `h2`, uses the fallback label.

## Scope

I scanned every built page for the same problem — `/contact` was the only one. All 40 others have real content `h2`s.

The three trust badges ("Typically respond within 24hrs" / "100% confidential" / "Free 30-minute consultation") are still unlabelled `div`s rather than a list. That is list semantics rather than heading structure, so it is left alone here.

## Verification

- `npm run build` clean
- Zero WCAG AA contrast failures on the page (every text node walked against its effective background)
- No horizontal overflow at 1280px or 375px; heading renders on one line at both (30px / 24px)
- Built output confirms `/contact` outline is now `H1: Let's Talk` → `H2: Request a Strategy Call`, and the form carries `aria-labelledby="contact-form-heading"` on `/contact` and `aria-label="Request a strategy call"` on `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)