### PR TITLE
Mark the trust badges up as a list, once, in one component

### DIFF
--- a/app/components/TrustBadges.js
+++ b/app/components/TrustBadges.js
@@ -1,0 +1,40 @@
+// The reassurance strip above the contact form. It was duplicated verbatim in
+// app/page.js and app/contact/page.js — three parallel claims marked up as bare
+// divs, so assistive tech announced them as loose text with no relationship.
+const BADGES = [
+  {
+    label: 'Typically respond within 24hrs',
+    path: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+  },
+  {
+    label: '100% confidential',
+    path: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+  },
+  {
+    label: 'Free 30-minute consultation',
+    path: 'M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z',
+  },
+]
+
+export default function TrustBadges({ className = '' }) {
+  return (
+    // role="list" is not redundant: Tailwind's preflight sets list-style: none,
+    // which makes Safari/VoiceOver drop list semantics from a ul entirely.
+    <ul role="list" className={`flex flex-wrap justify-center gap-8 ${className}`.trim()}>
+      {BADGES.map((badge) => (
+        <li key={badge.label} className="flex items-center gap-2 text-sm text-slate-600">
+          <svg
+            className="w-5 h-5 text-accent-500 flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={badge.path} />
+          </svg>
+          {badge.label}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -1,6 +1,7 @@
 import Navigation from '../components/Navigation'
 import Footer from '../components/Footer'
 import ContactForm from '../components/ContactForm'
+import TrustBadges from '../components/TrustBadges'
 import JsonLd from '../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 
@@ -62,27 +63,7 @@ export default function ContactPage() {
               </p>
             </div>
 
-            {/* Trust indicators */}
-            <div className="flex flex-wrap justify-center gap-8 mb-12">
-              <div className="flex items-center gap-2 text-sm text-slate-600">
-                <svg className="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                Typically respond within 24hrs
-              </div>
-              <div className="flex items-center gap-2 text-sm text-slate-600">
-                <svg className="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                </svg>
-                100% confidential
-              </div>
-              <div className="flex items-center gap-2 text-sm text-slate-600">
-                <svg className="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
-                </svg>
-                Free 30-minute consultation
-              </div>
-            </div>
+            <TrustBadges className="mb-12" />
 
             {/* The page's only content heading. Without it the sub-h1 outline was
                 empty, and the four footer column labels were the whole of it until

--- a/app/page.js
+++ b/app/page.js
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import Button from './components/Button'
 import Navigation from './components/Navigation'
 import ContactForm from './components/ContactForm'
+import TrustBadges from './components/TrustBadges'
 import Footer from './components/Footer'
 import Testimonials from './components/Testimonials'
 
@@ -615,27 +616,7 @@ export default function Home() {
             </p>
           </div>
 
-          {/* Trust indicators */}
-          <div className="flex flex-wrap justify-center gap-8 mb-12">
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <svg className="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Typically respond within 24hrs
-            </div>
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <svg className="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-              </svg>
-              100% confidential
-            </div>
-            <div className="flex items-center gap-2 text-sm text-slate-600">
-              <svg className="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
-              </svg>
-              Free 30-minute consultation
-            </div>
-          </div>
+          <TrustBadges className="mb-12" />
 
           <div className="max-w-3xl mx-auto">
             <ContactForm />


### PR DESCRIPTION
Follow-up to #63, which flagged this.

The three claims above the contact form — "Typically respond within 24hrs", "100% confidential", "Free 30-minute consultation" — were bare `div`s. Assistive tech announced them as loose text with no relationship to each other, and the decorative icons were not hidden.

## Changes

- **`ul role="list"` with `li` items.** The role is not redundant: Tailwind's preflight sets `list-style: none`, which makes Safari/VoiceOver drop list semantics from a `ul` entirely. Screen readers now announce "list, 3 items".
- **`aria-hidden="true"` on the three icons.**
- **Extracted to `TrustBadges`.** The block was duplicated verbatim between `app/page.js` and `app/contact/page.js` — the same drift shape already seen with the homepage case-study teaser, where a hand-maintained copy went stale twice.

## Verification

- `npm run build` clean
- Built output confirms both pages render `ul role="list"`, 3 `li`, 3 `aria-hidden` icons, identical labels
- Rendering unchanged: same flex row, same 32px gap, all three items on one line at 1280px on both pages, no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)