### PR TITLE
Correct the timeline against the owner's CV

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -43,8 +43,11 @@ editorial voice for headlines, and claims you could defend in a due-diligence ro
   and claims no London base of its own. Describing a *client* as London-based is
   fine and true; describing *Codenest* that way is not (§13.25).
 - **The operators:** Codenest is founder-led in each track, and the tracks do not
-  overlap. **Ankit Rana, Fractional CTO** — ex-Deloitte Digital, Elavon (US Bancorp),
-  Opayo — leads the technical seat. **Michelle Rana FCCA, Fractional CFO** — strategic
+  overlap. **Ankit Rana, Fractional CTO** — Rated People, Rightmove and Rungway before
+  the firm; the Ministry of Justice, Tesco Bank, HSBC, AstraZeneca and Opayo by Elavon
+  through it — leads the technical seat. It previously read "ex-Deloitte Digital,
+  Elavon (US Bancorp), Opayo", which framed three Codenest engagements as pre-firm
+  background (§13.11). **Michelle Rana FCCA, Fractional CFO** — strategic
   finance at Dishoom — leads the financial seat. Being founder-led is a strength, not a
   secret (see §2 voice rules), but "founder-led" never means one person covering both:
   each seat is named to its own principal in copy and in schema (§2 rule 4, §13 rule 14).
@@ -337,8 +340,21 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
 9. **One FAQPage schema per page, owned by the page.** (4 Aug 2026.)
 10. **ICP phrasing is "pre-seed to Series A"** — one variant, sitewide. (4 Aug 2026.)
 11. **Opayo engagement dates: August 2019 – June 2026** — a Codenest-era engagement.
-    Elavon (US Bancorp) employment 2011-2015 is separate early-career history; never
-    date Opayo work into that window. (Owner, 4 Aug 2026.)
+    (Owner, 4 Aug 2026.)
+    **Corrected against the owner's CV, 5 Aug 2026.** This rule used to add that
+    "Elavon (US Bancorp) employment 2011-2015 is separate early-career history".
+    **There is no such period.** The CV shows one Elavon engagement, Aug 2019 – Jun
+    2026, delivered through Esynergy Solutions — the same engagement as Opayo. The
+    invented window had propagated into `/about`, `/services/fractional-cto`,
+    `/cofounder` and the homepage strip caption before anyone checked it against a
+    source. **Deloitte Digital was Jul 2018 – Aug 2019**, not 2011-2015, and it is
+    where the HSBC and AstraZeneca work was delivered.
+    **The firm's boundary is August 2017** (owner): every engagement from that date
+    is Codenest's. Ankit's own track record is everything before it — University of
+    Leicester (Oct 2011 – Aug 2012), Muddyboots (Sep 2012 – Jul 2013), Rated People
+    (Aug 2013 – Dec 2015), Rightmove (Jan – Jul 2016), Rungway (Aug 2016 – Aug 2017).
+    **Check a date against the CV, never against earlier site copy** — that is how
+    a fabricated Elavon decade survived four pages.
 12. **All three testimonials are verified genuine** (owner, 4 Aug 2026) — real
     clients. Never delete or reword them as "placeholders". All three are
     anonymised: a named attribution is published only against written permission
@@ -366,13 +382,28 @@ WCAG AA (4.5:1) on all text. The specific traps in this palette:
     the same change that adds a CFO study, and never ahead of one.
     **Which engagements are Codenest's** (owner, 5 Aug 2026, correcting an earlier
     mislabel): **Regeno, Opayo by Elavon and AstraZeneca are Codenest client
-    engagements.** Only **Rungway** (predates the firm; Ankit was interim CTO) and
+    engagements.** Only **Rungway** (Aug 2016 – Aug 2017, a month short of the firm's
+    Aug 2017 boundary; Ankit was Lead Software Engineer there) and
     **Dishoom** (Michelle's employer) are founder track record. Opayo and AstraZeneca
     were briefly published as founder track record — wrong, and §13.11 already dated
     Opayo Aug 2019 – Jun 2026 as Codenest-era. **Understating the client base is as
     inaccurate as overstating it**; check this list before labelling anything.
     Every card carries a `kind` label above its title saying which it is —
     "Codenest client engagement" or "Founder track record".
+    **The full engagement list, from the owner's CV (5 Aug 2026).** Codenest
+    engagements, all on or after the Aug 2017 boundary: **Ministry of Justice**
+    (Aug 2017 – Mar 2018), **Tesco Bank** (Mar – Jul 2018), **Deloitte Digital**
+    delivering for **HSBC** and **AstraZeneca** (Jul 2018 – Aug 2019), **LDN Labs
+    (Hitachi)** (May – Nov 2019), **Opayo by Elavon** via Esynergy (Aug 2019 – Jun
+    2026), **Frekkel** (Nov 2025 – Apr 2026), **Regeno** (2026 – present). Founder
+    track record, all before it: **Rated People**, **Rightmove**, **Rungway**, plus
+    Muddyboots and the University of Leicester. Michelle's **Dishoom** is founder
+    track record on her side. The owner cleared every name above for publication.
+    **Rungway's title was Lead Software Engineer, not interim CTO** (owner, 5 Aug
+    2026). The scope was CTO-level and copy may say he led engineering there; it may
+    not claim the title. "Interim CTO" was published on the homepage stat, the strip
+    comment and inside the Rungway case study, and is now out of all three.
+
     Do not drop those labels to make the page look like a client wall; the whole
     reason the distinction is drawn in copy is that the page can no longer rely on
     "none of these are clients" being true. Any study added later needs a `kind`.

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -41,9 +41,14 @@ const peopleSchema = [
     name: 'Ankit Rana',
     jobTitle: 'Fractional CTO',
     worksFor: codenest,
+    // Pre-Codenest employers only. Deloitte Digital and Elavon were removed on
+    // 5 Aug 2026: both post-date Aug 2017 and are client engagements delivered
+    // through the firm, so alumniOf mislabelled them as employment (BRANDING §13.11).
     alumniOf: [
-      { '@type': 'Organization', name: 'Deloitte Digital' },
-      { '@type': 'Organization', name: 'Elavon (US Bancorp)' },
+      { '@type': 'CollegeOrUniversity', name: 'University of Leicester' },
+      { '@type': 'Organization', name: 'Rated People' },
+      { '@type': 'Organization', name: 'Rightmove' },
+      { '@type': 'Organization', name: 'Rungway' },
     ],
     knowsAbout: [
       'Fractional CTO services',
@@ -119,13 +124,20 @@ export default function AboutPage() {
       accent: "primary",
       linkedin: "https://www.linkedin.com/in/arana198",
       credentials: ["AWS Certified", "15+ Years Engineering", "Kubernetes & Cloud", "Agentic AI"],
-      bio: "Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. Has led engineering teams from 5 to 50+, run a near seven-year platform transformation at Opayo by Elavon, and sat on the receiving end of technical due diligence. Currently building agentic AI platforms.",
+      bio: "Fifteen years building and scaling technology platforms. Consumer-scale Java at Rated People and Rightmove, then leading engineering at Rungway. Since 2017, through Codenest: regulated delivery for the Ministry of Justice, Tesco Bank, HSBC and AstraZeneca, a near seven-year payments transformation at Opayo by Elavon, and now agentic AI platforms. Has led engineering teams from 5 to 50+, and sat on the receiving end of technical due diligence.",
       proof: "Scaled Rungway from 5 to 1,000+ concurrent users",
+      // The Aug 2017 line is the firm's boundary: everything from the Ministry of
+      // Justice onward is a Codenest engagement, everything before it is Ankit's own
+      // track record. Corrected against the owner's CV on 5 Aug 2026 — the first two
+      // blocks previously read "Enterprise Foundations" and "Scaling Startups" and
+      // dated Deloitte Digital and Elavon to 2011-2015. Deloitte was Jul 2018 - Aug
+      // 2019 and the only Elavon period is Aug 2019 - Jun 2026 (BRANDING §13.11).
       tracks: [
-        { year: "2011-2015", title: "Enterprise Foundations", description: "Payment processors and financial services platforms at Deloitte Digital and Elavon (US Bancorp) — learning what enterprise-grade actually costs, and what startups can borrow from it." },
-        { year: "2015-2017", title: "Scaling Startups", description: "Led engineering teams from 5 to 50+ across fintech and healthtech. Hypergrowth firsthand: the technical debt, the hiring mistakes, the architecture decisions that come back to haunt you." },
-        { year: "2019-2026", title: "Payments at Scale", description: "Platform transformation at Opayo by Elavon — AWS EKS migration, GitOps and Infrastructure as Code, moving a payments monolith to microservices without dropping a transaction." },
-        { year: "2026-present", title: "Agentic AI Platforms", description: "Leading the Regeno engagement for Codenest: a company brain over the client's own records, and an AI factory that drives a ticket to a merged pull request unattended, with bounded review loops and a ledger of every decision." },
+        { year: "2011-2016", title: "Foundations", description: "Java and platform engineering at the University of Leicester, Muddyboots, then Rated People (2013-2015) and Rightmove in 2016 — consumer-scale systems, and the habits that come from being on call for them." },
+        { year: "2016-2017", title: "Leading Engineering", description: "Lead Software Engineer at Rungway with the scope of a CTO: rebuilt the platform, took it from 5 to 1,000+ concurrent users, and ran a zero-downtime database migration. The last engagement before Codenest." },
+        { year: "2017-2019", title: "Codenest: Regulated Delivery", description: "The firm's first engagements: the Ministry of Justice, then Tesco Bank, then Deloitte Digital delivering for HSBC and AstraZeneca. Government, banking and pharma — where the compliance bar is set before the first line of code." },
+        { year: "2019-2026", title: "Codenest: Payments at Scale", description: "A near seven-year platform transformation at Opayo by Elavon — AWS EKS migration, GitOps and Infrastructure as Code, moving a payments monolith to microservices without dropping a transaction — alongside a 0→1 identity platform for LDN Labs (Hitachi)." },
+        { year: "2025-present", title: "Codenest: Agentic AI Platforms", description: "0→1 backend and AI infrastructure for Frekkel, then the Regeno engagement: a company brain over the client's own records, and an AI factory that drives a ticket to a merged pull request unattended, with bounded review loops and a ledger of every decision." },
       ],
     },
     {

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -101,7 +101,7 @@ const caseStudies = [
     title: "Rungway: Scaling a Social Mentoring Platform",
     kind: "Founder track record",
     challenge: "A London-based HR-tech startup needed fractional CTO support to scale their social mentoring platform. The system could only handle 5 concurrent users before experiencing severe performance degradation — completely inadequate for their UK enterprise client base.",
-    solution: "As Rungway's interim CTO, Ankit delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
+    solution: "Leading engineering at Rungway, Ankit delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
     results: ["Scaled from 5 to 1000+ concurrent users", "Zero-downtime database migration", "Modern DevOps foundations established", "Event-driven microservices architecture"],
     tags: ["Backend Architecture", "AWS", "DevOps", "Scalability", "Microservices"],
     image: "/img/photos/case-rungway.jpg",

--- a/app/cofounder/page.js
+++ b/app/cofounder/page.js
@@ -93,7 +93,7 @@ export default function CofounderPage() {
   ]
 
   const whatIBring = [
-    '15+ years building scalable platforms (Deloitte Digital, Elavon, startups)',
+    '15+ years building scalable platforms (Opayo by Elavon, HSBC, AstraZeneca, startups)',
     'Full-stack technical leadership (architecture, engineering, DevOps)',
     'Financial modeling and investor-readiness expertise',
     'Experience scaling teams from 5 to 50+ engineers',

--- a/app/page.js
+++ b/app/page.js
@@ -154,7 +154,10 @@ export default function Home() {
                 <div className="flex-1 bg-primary-800 p-6 sm:p-8 flex flex-col justify-center">
                   <p className="text-xs uppercase tracking-[0.2em] text-accent-300 mb-4 font-semibold">Fractional CTO</p>
                   <p className="font-serif text-4xl md:text-5xl font-bold text-white mb-3">5 &rarr; 1,000+</p>
-                  <p className="text-slate-300 text-sm mb-4">Concurrent users at Rungway, where Ankit was interim CTO</p>
+                  {/* Not "interim CTO": the title was Lead Software Engineer. The
+                      scope was CTO-level and the copy may say so, but the title is
+                      the CV's (owner, 5 Aug 2026 — BRANDING §13.15). */}
+                  <p className="text-slate-300 text-sm mb-4">Concurrent users at Rungway, where Ankit led engineering</p>
                   <p className="text-slate-300 text-xs">Architecture, engineering leadership, delivery</p>
                 </div>
 
@@ -340,7 +343,8 @@ export default function Home() {
 
           <p className="text-center text-xs text-slate-500 mb-8 uppercase tracking-[0.2em] font-medium">Founder track record includes</p>
           <div className="flex flex-wrap justify-center items-center gap-8 md:gap-12">
-            {/* Rungway - HR Tech. Predates Codenest; Ankit was interim CTO. */}
+            {/* Rungway - HR Tech. Aug 2016 - Aug 2017, so it predates the firm by a
+                month; Ankit was Lead Software Engineer with CTO-level scope. */}
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/rungway.webp"
@@ -367,7 +371,7 @@ export default function Home() {
 
           </div>
           <p className="text-center text-sm text-slate-600 mt-8">
-            <a href="/about/" className="font-semibold text-primary-700 hover:text-primary-800">Ankit Rana</a>, Fractional CTO, brings 15+ years across Deloitte Digital, Elavon (US Bancorp) and Opayo. <a href="/about/" className="font-semibold text-primary-700 hover:text-primary-800">Michelle Rana FCCA</a>, Fractional CFO, led strategic finance at Dishoom through &pound;35m to &pound;165m revenue growth and a four-point EBITDA margin improvement.
+            <a href="/about/" className="font-semibold text-primary-700 hover:text-primary-800">Ankit Rana</a>, Fractional CTO, has delivered for the Ministry of Justice, Tesco Bank, HSBC, AstraZeneca and Opayo by Elavon. <a href="/about/" className="font-semibold text-primary-700 hover:text-primary-800">Michelle Rana FCCA</a>, Fractional CFO, led strategic finance at Dishoom through &pound;35m to &pound;165m revenue growth and a four-point EBITDA margin improvement.
           </p>
         </div>
       </section>

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -254,12 +254,13 @@ export default function FractionalCTOPage() {
         role="Fractional CTO"
         accent="primary"
         credentials={['AWS Certified', '15+ years engineering', 'Kubernetes & Cloud', 'Agentic AI']}
-        bio="Fifteen years building and scaling technology platforms: payment processors at Deloitte Digital and Elavon (US Bancorp), then startups going through hypergrowth across fintech, healthtech and proptech. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
+        bio="Fifteen years building and scaling technology platforms: consumer-scale Java at Rated People and Rightmove, then leading engineering at Rungway, then a decade of regulated delivery through Codenest across government, banking, pharma and payments. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
         highlights={[
           'Leads the Regeno engagement, a current Codenest client: a company brain over their own records, and an AI factory that drives a ticket to a merged pull request unattended',
           'Led engineering teams from 5 to 50+ across fintech and healthtech',
           'Ran a near seven-year platform transformation at Opayo by Elavon: AWS EKS migration, GitOps, a payments monolith moved to microservices',
-          'Rebuilt Rungway as its interim CTO, taking the platform from 5 to 1,000+ concurrent users with a zero-downtime migration',
+          'Delivered under regulatory scrutiny for the Ministry of Justice, Tesco Bank, HSBC and AstraZeneca',
+          'Rebuilt Rungway as its lead engineer, taking the platform from 5 to 1,000+ concurrent users with a zero-downtime migration',
         ]}
         proof="Rungway: 5 → 1,000+ concurrent users"
         linkedin="https://www.linkedin.com/in/arana198"


### PR DESCRIPTION
Checked every date and affiliation on the site against the CV. The core framing was wrong on both dates and classification. Supersedes #66, now closed.

## What was false

**1. There is no 2011–2015 Elavon.** `BRANDING.md` §13.11 asserted *"Elavon (US Bancorp) employment 2011-2015 is separate early-career history"* as a standing fact, and it had propagated into `/about`, `/services/fractional-cto`, `/cofounder` and the homepage strip caption. The CV shows one Elavon engagement: **Aug 2019 – Jun 2026**, via Esynergy — the same engagement as Opayo.

**2. Deloitte Digital was dated 2011–2015** on `/about`. It was **Jul 2018 – Aug 2019**, and it is where the HSBC and AstraZeneca work was delivered.

**3. "ex-Deloitte Digital, Elavon (US Bancorp), Opayo"** framed three Codenest engagements as pre-firm background. All three post-date the firm's **August 2017** boundary, so all three are client work. Same understating-the-client-base error as the earlier Opayo/AstraZeneca mislabel, one layer up.

**4. Rungway was captioned "interim CTO"** on the homepage stat, the strip comment, and inside the case study (*"As Rungway's interim CTO, Ankit delivered…"*). The CV title is **Lead Software Engineer**. Per the owner the scope was CTO-level, so the copy says he led engineering there and no longer claims the title. The `interim CTO UK` search keyword on the CTO service page stays — that is a service Codenest sells, not a claim about Rungway.

## The rebuilt timeline

Five tracks, with the Aug 2017 boundary visible:

| Years | Track | |
|---|---|---|
| 2011–2016 | Foundations | Leicester, Muddyboots, Rated People (2013–2015), Rightmove (2016) |
| 2016–2017 | Leading Engineering | Rungway — the last engagement before Codenest |
| 2017–2019 | **Codenest:** Regulated Delivery | Ministry of Justice, Tesco Bank, Deloitte Digital for HSBC and AstraZeneca |
| 2019–2026 | **Codenest:** Payments at Scale | Opayo by Elavon, LDN Labs (Hitachi) |
| 2025–present | **Codenest:** Agentic AI Platforms | Frekkel, Regeno |

All eight client names were cleared by the owner for publication.

`Person.alumniOf` is now pre-Codenest only — `['University of Leicester', 'Rated People', 'Rightmove', 'Rungway']`. Deloitte and Elavon came out: they were client engagements delivered through the firm, so `alumniOf` mislabelled them as employment.

Team size stays **5 to 50+** on the owner's instruction; the CV quantifies only the 25+ at Elavon.

## Not in this PR

The homepage logo strip still lacks Rightmove and Rated People — I have the images in the conversation but not as files on disk. The timeline that supports them now exists, so that change is unblocked once the assets do.

## Verification

- `npm run build` clean
- Swept all 45 built pages: zero occurrences of `2011-2015`, `ex-Deloitte`, or `Deloitte Digital, Elavon`; the one remaining `interim CTO` is the service keyword above
- All eight new names present on `/about`; five track years render as expected
- No horizontal overflow at 1280px
- The two contrast "failures" the audit reports on `/about` are the letter-avatar placeholders (white on a gradient the checker cannot resolve). Pre-existing, and still a known §5 violation pending real headshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)