### PR TITLE
Size the Cusdis iframe to its content so comments do not scroll internally

### DIFF
--- a/app/components/CusdisComments.js
+++ b/app/components/CusdisComments.js
@@ -1,13 +1,51 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 // The app ID is not a secret — it ships in the client-side embed on every page.
 const CUSDIS_HOST = 'https://cusdis.com'
 const CUSDIS_APP_ID = '6a10cc4a-dff8-4e81-b9b5-edfe7802f7eb'
 const SDK_URL = `${CUSDIS_HOST}/js/cusdis.es.js`
 
+// Cusdis renders the widget into a srcdoc iframe and is supposed to size it from
+// a postMessage the inner frame sends on load. That message never arrives, so the
+// iframe sits at the 150px HTML default and the comments scroll inside it. The
+// same happens with Cusdis's own plain-HTML snippet, so this is not a React
+// problem. A srcdoc iframe is same-origin, so we can measure the real content
+// height ourselves and drop this once upstream fixes the resize event.
+const HEIGHT_POLL_MS = 250
+
+function useAutoHeight(containerRef) {
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    // Polling rather than a ResizeObserver: the height that matters is the body's
+    // scrollHeight, and that changes without the observed box changing — the frame
+    // measures 452px while the widget stylesheet is still loading and settles to
+    // 396px after, which an observer never reports. Re-reading contentDocument on
+    // every tick also survives the SDK reassigning srcdoc, which swaps the
+    // document out from under any listener bound to the old one. Three property
+    // reads a second is cheaper than the machinery needed to catch both cases.
+    const sizeToContent = () => {
+      const iframe = container.querySelector('iframe')
+      const height = iframe?.contentDocument?.body?.scrollHeight
+      if (!height) return
+      if (iframe.style.height !== `${height}px`) iframe.style.height = `${height}px`
+    }
+
+    sizeToContent()
+    const timer = setInterval(sizeToContent, HEIGHT_POLL_MS)
+
+    return () => clearInterval(timer)
+  }, [containerRef])
+}
+
 export default function CusdisComments({ pageId, pageUrl, pageTitle }) {
+  const containerRef = useRef(null)
+
+  useAutoHeight(containerRef)
+
   useEffect(() => {
     // On client-side navigation the SDK is already loaded, so the script tag
     // never fires again — re-initialise it against the new thread element.
@@ -28,6 +66,7 @@ export default function CusdisComments({ pageId, pageUrl, pageTitle }) {
   return (
     <div
       id="cusdis_thread"
+      ref={containerRef}
       data-host={CUSDIS_HOST}
       data-app-id={CUSDIS_APP_ID}
       data-page-id={pageId}


### PR DESCRIPTION
Follow-up to #65. This commit was pushed to that branch after it had already been merged, so it never reached master — the comment widget on production is currently the 150px scrolling version.

## The bug

Cusdis renders the widget into a `srcdoc` iframe and sizes it from a `resize` postMessage the inner frame sends on load. That message never reaches the parent listener, so the iframe stays at the 150px HTML default while its content is ~400px, and the comment form scrolls inside a small box.

This is upstream, not a problem with the React wrapper — Cusdis's own plain-HTML snippet behaves identically in a bare page.

## The fix

The iframe is `srcdoc` and therefore same-origin, so we measure it ourselves: a 250ms poll reads `body.scrollHeight` and applies it to the iframe.

A ResizeObserver was tried first and left a 56px gap. It cannot work here for two reasons:

- The height that matters is `scrollHeight`, which changes without the observed box changing. The frame measures 452px while the widget stylesheet is still loading and settles to 396px after — an observer never reports that transition.
- The SDK reuses one iframe and reassigns `srcdoc`, swapping the document out from under any listener bound to the old one. Re-reading `contentDocument` on each tick survives that.

Three property reads a second is cheaper than the machinery needed to catch both cases. If upstream ever fixes the resize event this poll becomes redundant but stays harmless — it would set the height the SDK already set.

## Verification

- `npm run build` passes.
- `/blog/how-cfos-use-ai-startup-finance/`: iframe 396px, content 396px, gap 0, no inner scrollbar.
- Client-side navigation to `/blog/financial-modeling-seed-stage-startups/`: still exact, correct `pageId`, working form — confirming the document swap is handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)