### PR TITLE
Fix the dead referral form and the unsourced case-study claims

### DIFF
--- a/WEBSITE_REVIEW_2026-08-05.md
+++ b/WEBSITE_REVIEW_2026-08-05.md
@@ -1,0 +1,343 @@
+# Codenest Site Review — August 5th
+
+**Scope:** full site, user journey, branding, trust, SEO, accessibility.
+**Method:** every page's source and built HTML, plus the running site at 1280px and 375px.
+Contrast measured programmatically on every rendered text node across 13 pages; internal
+links resolved against the build output; the referral form exercised in the browser.
+This report does not repeat `WEBSITE_REVIEW.md` (4 Aug) or `WEBSITE_REVIEW_FOLLOWUP.md` —
+it states what is true today.
+
+---
+
+> **Status, end of 5 August 2026.** Everything in this report that could be fixed without
+> owner input has been, on branch `claude/website-review-branding-f56680`. Each finding
+> below carries its state. Four items remain open and all four need the owner:
+> **H4** (Michelle's Codenest dates), **H5** (founder photographs), **M6** (photography at
+> ≥1600px), and one CFO case study.
+
+---
+
+## Verdict
+
+The remediation work landed. The naming problem is gone, the contrast problem is gone,
+the legal disclosures are in, and the new copy — the Regeno case study, the `/services`
+decision page, the agentic AI band, the two PrincipalBands — is genuinely good writing that
+sounds like an operator rather than a marketing department.
+
+Two things are now holding the site back, and they are not the things the earlier reviews
+were about:
+
+1. **One page actively loses business and leaks personal data.** The referral form submits
+   nowhere and puts both people's names and email addresses in the URL.
+2. **The site is now two sites in one voice.** Rewritten surfaces are excellent. The
+   surfaces nobody has been through yet — three of the four case studies, most of the
+   service-page FAQs, the `/about` values block — still carry the generic-consultancy copy
+   and the unbounded statistics that were stripped from the homepage a day ago. A founder
+   who diligences you will read the case studies, which is exactly where the old claims
+   survived.
+
+The CFO half remains under-proved. That is now the *only* strategic gap, and it is an
+owner-input problem, not a build problem.
+
+---
+
+## What is genuinely solid (verified, not assumed)
+
+- **Contrast: zero failures sitewide.** Every text node on 13 pages measured against its
+  effective background. The `accent-600` drift from the follow-up review is fully cleared.
+- **No broken internal links** anywhere in the 41-page build.
+- **Metadata is clean**: every page has a self-canonical with a trailing slash, a real
+  1200×630 OG image, and a title inside budget (longest: 63 chars). One `FAQPage` per page,
+  none sitewide. Blog posts are `BlogPosting`. Sitemap `lastmod` comes from content dates,
+  not build time.
+- **Sticky mobile CTA fix verified** — at 375px on `/contact` the bar is hidden and
+  "Request My Call" is fully clear. Follow-up 2.1 is closed.
+- **Privacy notices sit at both live collection points** (contact form, calculator email
+  capture), statutory disclosures are in the footer, freshness gate green,
+  `prefers-reduced-motion` honoured, no horizontal overflow at 375px, footer down to 7% of
+  homepage height.
+
+---
+
+## Critical
+
+### C1. ✅ FIXED — The referral form submits nowhere and leaks both parties' details into the URL
+
+`app/refer/page.js` is a server component. Its `<form>` has no `action`, no `onSubmit`, no
+EmailJS call — nothing. Exercised in the browser, pressing **Submit Referral** does a GET to
+the same page:
+
+```
+/refer/?referrer_name=TESTNAME&referrer_email=&founder_name=&founder_email=founder%40example.com&company_name=&context=
+```
+
+Three separate problems, one bug:
+
+- **The referral is silently lost.** The page appears to succeed — it just reloads. Nobody
+  at Codenest ever sees it. The page promises "We'll reach out to them within 48 hours" and
+  "Earn Up to £2,000" against a mechanism that cannot deliver either.
+- **Personal data goes into the query string** — the referrer's name and email *and a third
+  party's name and email* — landing in browser history, server access logs and the
+  `Referer` header of every subsequent request. This is the one thing a privacy policy
+  should never have to explain.
+- **No privacy notice at the point of collection, and `/privacy` does not list this form.**
+  It names only the strategy-call form and the calculator. BRANDING §13.21 requires the
+  notice and the listing in the same change that adds the form. Art. 14 also bites here:
+  you would be collecting a third party's data without their knowledge.
+
+The page carries 40 sitewide footer links — the same internal-link footprint as either
+service page — pointing at a dead conversion path.
+
+**Fix:** wire it to EmailJS the way `ContactForm` and `RunwayCalculator` already are (add
+`'use client'` and a submit handler), add the privacy line, add the referral form to
+`/privacy`. If wiring it is not wanted this week, replace the form with the `mailto:` route
+the page already offers above it — a working mailto beats a form that eats submissions.
+
+---
+
+## High
+
+### H1. ✅ FIXED — The old unbounded claims survived on `/case-studies`
+
+The homepage's "100% due diligence pass rate" and "40% average runway extension" were
+retired under §2.2 and §13.4. The same class of claim is still live on the page an investor
+reads hardest:
+
+| Study | Claim | Problem |
+|---|---|---|
+| Opayo | "maintaining **100% uptime**" | Absolute claim, no basis stated |
+| Opayo | "Contributed to **10% revenue increase** through faster feature delivery" | A revenue claim about Elavon; "contributed to" is the tell |
+| AstraZeneca | "Accelerated delivery by **40%** compared to manual processes" | No denominator, no source |
+| AstraZeneca | "Cut deployment errors by **30%**" | Same |
+| Opayo | "Reduced CI pipeline failures through automated testing" | Unbounded |
+
+Compare the Regeno study directly above them, which prints *"Outcome figures go up once
+they are measured and the client has approved them"* and publishes no numbers at all. The
+same page argues both positions. Under ASA/CAP rules these are substantiable claims about
+named third parties.
+
+**Fix:** bound each one or cut it. Apply the Regeno standard uniformly.
+
+### H2. ✅ FIXED — The Rungway study reintroduces the exact mislabel §13.15 bans
+
+> "A London-based HR-tech startup needed **fractional CTO support** to scale their social
+> mentoring platform."
+
+Rungway was Aug 2016 – Aug 2017, a month before the firm's boundary, and the title was Lead
+Software Engineer. The card's `kind` label correctly says "Founder track record" — and then
+the body sells it as a fractional CTO engagement. The homepage stat and the strip comment
+were both corrected for precisely this; the case study body was missed.
+
+**Fix:** "As lead engineer at Rungway, Ankit…" — the same framing the PrincipalBand uses.
+
+### H3. ⚠️ PARTLY FIXED — The CFO track is still measurably the thinner half
+
+| | CTO page | CFO page |
+|---|---|---|
+| FAQs | 11 | 5 |
+| Benefit tiles containing a number | 1 of 4 ("Save 60-80%") | **0 of 4** |
+| Differentiating section | Agentic AI band | none |
+| Hero CTAs | 2 (call + case studies) | 1 |
+| Case studies to link | 3 | **0** |
+
+Michelle's numbers sit in the PrincipalBand one screen above four benefit tiles that contain
+no figures at all — £35m→£165m, +4% EBITDA, ±3% forecast accuracy, 14→8 day close, £6m
+procurement. The proof is on the page and not being used where it converts.
+
+This was follow-up item 1.2 and has not moved. The FAQ gap writes itself ("Do we still need
+a bookkeeper?", "How does this work alongside our accountant?", "What happens during a
+raise?").
+
+### H4. ⛔ OPEN (owner) — `/about` shows the practice in only one of its two careers
+
+The timeline is headed **"Two Careers, One Practice"**. Ankit gets four Codenest rows
+(2017-2019, 2019-2026, 2025-present). Michelle's track runs 2012 → 2026 and ends at Dishoom.
+**There is no Codenest row on her side at all.**
+
+A founder reads this as: she is new, or she is not really in the firm. That directly
+undercuts §13.14, the single differentiator the whole site is built on. Either her Codenest
+period is missing or it has not started — and the page needs to say which.
+
+Related, smaller: the card reads "Michelle Rana", the brand law says "Michelle Rana FCCA"
+(the service page gets it right).
+
+### H5. ⛔ OPEN (owner) — Letter avatars are still in production
+
+`/about` renders **A** and **M** gradient initials. BRANDING §5: *"Never a letter-avatar
+placeholder in production."* For a two-person advisory selling "two real executives", this
+is the cheapest trust upgrade available and it has been outstanding across three reviews.
+Owner action — the files do not exist.
+
+### H6. ✅ FIXED — The contact form's failure message points at an email address it does not show
+
+`ContactForm.js:232` — *"Please try again or email us directly."* There is no email address
+on `/contact`, in the form, or in the footer. §11 requires `hello@codenest.uk` to be visible
+wherever the form can fail. The runway calculator gets this right (`RunwayCalculator.js:132`
+prints the address); the primary conversion path does not.
+
+Also: success says "We will get back to you soon" while the microcopy under the button
+promises "within 24 hours with times". Pick the 24 hours — it is the stronger promise and
+the one you have already made.
+
+---
+
+## Medium
+
+### M1. ✅ FIXED — Two voices, and the older one makes claims you cannot bound
+
+The rewritten surfaces are excellent. The un-rewritten ones read like a different firm:
+
+> "Absolutely. Due diligence preparation is one of our core strengths."
+> "We **excel at** translating complex concepts into clear business terms."
+> "**Many of our clients** are first-time founders…"
+> "**Many clients** transition from intensive builds to lighter advisory after launch."
+> "We've supported raises from pre-seed through Series A **across fintech, healthtech and
+> B2B SaaS**."
+
+The last three are volume and coverage claims from a firm whose published client list is
+seven names. §16 says claim the capability, do not attach invented specifics. "Comprehensive",
+"robust", "seamless", "world-class" appear across the same blocks and nowhere in the new copy.
+
+Worst affected: both service-page FAQ blocks (the *new* agentic AI FAQs sit directly above
+the old ones, which makes the seam visible), the three legacy case studies, and the `/about`
+"What We Believe" / "How We Work" blocks.
+
+### M2. ✅ FIXED — "A decade of regulated delivery through Codenest"
+
+`/services/fractional-cto/` PrincipalBand. The boundary is August 2017; today is August 2026.
+That is nine years, and `/about` dates every span precisely. Rounding up on the one subject
+where a fabricated timeline already survived four pages is a bad trade for one word.
+"Nine years" or "since 2017" costs nothing.
+
+### M3. ✅ FIXED — Two different answers to "how do you work"
+
+The homepage `#how-we-work` gives four things ("The roadmap and the model are built
+together", "You own the output", "You know the commercial shape up front", "We say when you
+should not hire us") — all sharp and specific. `/about` gives a *different* four
+("Founder-First", "No Fluff", "Long-Term Thinking", "Radical Honesty") — all generic. The
+footer link labelled "Our Methodology" points at the homepage set.
+
+Two canonical answers to the same question, and the weaker one is on the page people read
+when they are deciding whether to trust you.
+
+### M4. ✅ FIXED — British English is not holding
+
+§2.7 is explicit, and `app/layout.js` breaks it against itself: `knowsAbout` says
+"Financial **Modeling**" while `hasOfferCatalog` in the same object says "Financial
+**Modelling** & Strategy".
+
+Visible instances: the homepage two-track bullet "Financial Modeling & FP&A", the `/services`
+card title "Financial Modeling", the CFO page subhead "FP&A, financial modeling…", plus
+"modernize" and "containerizing" in the case studies, and "optimize" on the runway
+calculator two blocks below its own "optimisation".
+
+### M5. ✅ FIXED — Footer labels drift from nav labels
+
+Nav says **About** and **Blog**; the footer says **Our Story** and **Insights** for the same
+two destinations. The blog index `h1` is a bare "Insights" while its title tag targets
+"Fractional CTO & CFO Insights for UK Founders". Three names for one page, and the anchor
+text pointing at it from all 40 pages is the one that carries no keyword.
+
+### M6. ⛔ OPEN (owner) — Photography is still half the resolution the brand law requires
+
+All nine files in `public/img/photos/` are ~800×533. Five are still in use: both service-page
+heroes and the three legacy case-study images, rendering into slots that need ~1400px at 2×.
+§5 sets a 1600px minimum. This has been open since the first review.
+
+The two service hero photos also remain interchangeable stock (a post-it workshop and two
+people at laptops) — the follow-up's point that the team already reached this conclusion for
+service *cards* and never applied it to the heroes still stands.
+
+### M7. ✅ FIXED — Nine images ship without dimensions
+
+Seven client logos on the homepage, one case-study image, and the nav logo are raw `<img>`
+with no `width`/`height` and no `loading="lazy"`. The strip collapses and re-expands on load.
+The footer logo does it correctly — copy that. This is straight CLS against a Lighthouse > 90
+Definition of Done.
+
+### M8. ✅ FIXED — Footer tap targets are 17px tall on mobile
+
+Measured at 375px: every footer link renders 15–20px high. WCAG 2.2 AA (2.5.8) wants 24×24
+minimum; 44px is the platform guideline. `space-y-2` on the `<li>` gives visual separation
+without giving the anchor a hit area. Add `inline-block py-2` to `LINK_CLASS`.
+
+---
+
+## Low
+
+- **`/refer` and `/cofounder` each carry 40 sitewide footer links** — identical footprint to
+  either service page. §13.30 set a link budget precisely to stop this; these two slipped
+  through. `/refer` currently leads to a dead form (C1).
+- **`<br>` inside `h1`s concatenates words** in extracted text: "Built by Operators,for
+  Founders", "The Complete Guide toFractional CTO Services", "Know a Founder WhoNeeds
+  Technical Help?". Affects `/about`, both guide indexes, `/refer`, `/cofounder`. Put a
+  space before the break.
+- **The 404 page emits two conflicting robots tags** — `noindex` and `index, follow`.
+  `noindex` wins, so behaviour is right and the markup is not.
+- **Dead CSS**: `.cta-bounce` (an infinite animation, which §5 bans anyway) is defined in
+  `globals.css` and used nowhere.
+- **Lowercase service name**: "our fractional CFO service" twice on the runway calculator.
+  §2.1 capitalises it everywhere.
+- **`/about` h1 carries neither target term** — "Built by Operators, for Founders" against a
+  title of "Meet Our Fractional CTO & CFO". The line is the best on the site; a keyword-bearing
+  `h2` beneath it would settle §8 without touching it.
+
+---
+
+## Priority order
+
+**This week**
+1. Fix or remove the referral form, and add it to `/privacy` (C1)
+2. Bound or cut the five unsupported case-study claims (H1)
+3. Reframe the Rungway study as lead engineer, not fractional CTO (H2)
+4. Put `hello@codenest.uk` in the form's error state; align the success message to 24 hours (H6)
+
+**Next**
+5. Numbers into the four CFO benefit tiles; FAQ parity (H3)
+6. Michelle's Codenest row on the `/about` timeline, or a statement of when the seat started (H4)
+7. Rewrite the legacy FAQ and values copy to the standard the new copy already sets, dropping
+   the "many of our clients" class of claim (M1)
+8. Reconcile the two "How We Work" blocks into one (M3)
+9. British English pass, starting with the two spellings inside `layout.js` (M4)
+
+**Then**
+10. Image dimensions + lazy-loading (M7); footer tap targets (M8); footer/nav label alignment (M5)
+11. Re-source the five 800px photos at ≥1600px, or replace the two service heroes the way the
+    homepage hero was replaced (M6)
+12. "A decade" → nine years (M2); the low-severity list
+
+**Owner input still required (unchanged across three reviews)**
+- Founder photographs — blocking H5
+- One CFO case study. Dishoom framed as pedigree with dates needs no client permission and
+  closes the largest remaining gap on the site
+- Whether Michelle's Codenest involvement has a start date to publish (H4)
+- A decision on "Big 4 rigour meets founder empathy", which still has no Big 4 support on the
+  finance half
+
+---
+
+## What changed on 5 August 2026
+
+Verified against a clean `npm run build` (45 pages) and the running site at 1280px and 375px.
+
+| # | Change |
+|---|---|
+| C1 | `ReferralForm` client component wired to the existing EmailJS template. Submits properly, prints a real success/error state, and no longer puts anything in the URL — confirmed by submitting in the browser. The referred founder's email is now optional and gated behind an explicit "they know about this introduction" confirmation. Privacy line at the point of collection; `/privacy` gains the referral form as a third collection point plus an "If someone referred you to us" section covering the Art. 14 position. |
+| H1 | Five unsupported claims removed from `/case-studies`. Each replaced by a named artefact or a bounded fact. A comment on the data array now states the rule and lists what was removed, so it does not come back. |
+| H2 | Rungway reframed: "Ankit joined as Lead Software Engineer, with the scope of a CTO, a year before Codenest existed." |
+| H3 | Each CFO benefit tile carries an attributed proof line (±3% forecasts, 14→8 day close, Board and investor reporting, the testimonial-backed Series A). FAQs 5 → 10, exact parity with the CTO page. Dishoom figures stay attached to Michelle's role per §13.15. |
+| H6 | Contact form's error state now prints `hello@codenest.uk` as a live mailto. Success message matches the 24-hour promise under the button. Status region gained `role="status"`/`aria-live`. |
+| M1 | "Absolutely", "we excel at", "many of our clients", "many clients", "comprehensive" and the unsupported sector claim rewritten across both service pages and `/refer`. |
+| M2 | "A decade of regulated delivery" → "regulated delivery through Codenest since 2017". |
+| M3 | The duplicate "How We Work" block deleted from `/about`; the homepage keeps the canonical four. |
+| M4 | British English applied across `app/` and `content/`: modelling, optimise/optimisation, professionalise, specialise, mobilise, organisation. The blog slug `financial-modeling-...` is deliberately left alone — changing it would break a live URL that GitHub Pages cannot redirect. |
+| M5 | Footer labels aligned to the nav: About, Blog, How We Work. |
+| M7 | `width`/`height` on all seven client logos and the nav logo; `loading="lazy"` on the strip. |
+| M8 | Footer links 17px → 32px tall at 375px. Footer share of `/contact` moves 35% → 36%. |
+| Low | Space before `<br />` in five headings; explicit `robots: noindex, nofollow` on the 404; dead `.cta-bounce` infinite animation removed; "Fractional CFO service" capitalised on the calculator; blog `h1` → "Fractional CTO & CFO Insights"; `/about` eyebrow → "Meet Your Fractional CTO & CFO"; "Michelle Rana FCCA" on the `/about` card. |
+
+Re-verified after the changes: zero contrast failures across seven pages, no broken internal
+links, freshness gate green, no console errors, no horizontal overflow at 375px.
+
+**Still open, all four needing the owner:** H4 (Michelle's Codenest dates), H5 (founder
+photographs), M6 (photography at ≥1600px), and one CFO case study.

--- a/app/about/page.js
+++ b/app/about/page.js
@@ -141,7 +141,10 @@ export default function AboutPage() {
       ],
     },
     {
-      name: "Michelle Rana",
+      // "Michelle Rana FCCA" everywhere she is named in copy (§1) — the
+      // PrincipalBand and the homepage strip caption already do. Only the Person
+      // schema above keeps the bare legal name.
+      name: "Michelle Rana FCCA",
       role: "Fractional CFO",
       initial: "M",
       accent: "accent",
@@ -157,44 +160,6 @@ export default function AboutPage() {
     },
   ]
 
-  const values = [
-    {
-      title: "Founder-First",
-      description: "We're here to make you self-sufficient. Billable hours are not the measure.",
-      icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-        </svg>
-      )
-    },
-    {
-      title: "No Fluff",
-      description: "We don't do PowerPoint consulting. Every recommendation comes with implementation. We build alongside you.",
-      icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-        </svg>
-      )
-    },
-    {
-      title: "Long-Term Thinking",
-      description: "We build systems that scale. No shortcuts that create technical debt. No financial models that fall apart under scrutiny.",
-      icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
-        </svg>
-      )
-    },
-    {
-      title: "Radical Honesty",
-      description: "We'll tell you if your idea won't work. We'll push back on bad decisions. Honest guidance beats comfortable agreement.",
-      icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-        </svg>
-      )
-    }
-  ]
 
   // Two technical categories, two financial — the grid itself has to read 50/50.
   const expertise = [
@@ -219,9 +184,12 @@ export default function AboutPage() {
       <section className="pt-24 md:pt-32 pb-20 bg-gradient-to-b from-slate-50 to-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Our Story</p>
+            {/* The eyebrow carries the terms the h1 does not: "Built by Operators,
+                for Founders" is the strongest line on the site and is not worth
+                trading for keywords, so the structural opener does that job (§8). */}
+            <p className="text-sm uppercase tracking-[0.2em] text-accent-700 mb-4 font-medium">Meet Your Fractional CTO &amp; CFO</p>
             <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">
-              Built by Operators,<br />for Founders
+              Built by Operators, <br />for Founders
             </h1>
             <p className="text-xl text-slate-600 max-w-2xl mx-auto">
               Codenest is two executives, not one generalist. A CTO who has scaled the systems, and a CFO who has scaled the numbers.
@@ -382,27 +350,14 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* Values Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="font-serif text-3xl font-bold text-slate-900 mb-4">How We Work</h2>
-            <p className="text-slate-600">The principles that guide every engagement</p>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            {values.map((value, index) => (
-              <div key={index} className="bg-slate-50 rounded-xl p-8 border border-slate-200 hover:border-accent-300 hover:shadow-md transition-all">
-                <div className="w-12 h-12 bg-accent-100 rounded-lg flex items-center justify-center text-accent-700 mb-4">
-                  {value.icon}
-                </div>
-                <h3 className="text-xl font-bold text-slate-900 mb-2">{value.title}</h3>
-                <p className="text-slate-600">{value.description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      {/* The second "How We Work" block lived here — Founder-First / No Fluff /
+          Long-Term Thinking / Radical Honesty. The homepage already answers that
+          question at #how-we-work, in four sharper and more specific statements,
+          and the footer's "Our Methodology" link points there. Two canonical
+          answers to one question, with the weaker one on the page a founder reads
+          while deciding whether to trust us. Removed rather than kept in sync
+          (site review, 5 Aug 2026). "What We Believe" above stays: it is this
+          page's own material, not a restatement of the homepage's. */}
 
       {/* Expertise Section */}
       <section className="py-20 bg-slate-50">

--- a/app/blog/[slug]/page.js
+++ b/app/blog/[slug]/page.js
@@ -138,7 +138,7 @@ export default async function BlogPost({ params }) {
   // Route the end-of-post CTA to the service the post actually supports:
   // finance-tagged posts sell the Fractional CFO service unless an explicitly
   // technical tag overrides (e.g. technical due-diligence, CTO cost guides).
-  const FINANCE_TAGS = ['Fractional CFO', 'Finance', 'Startup Finance', 'Financial Modeling', 'Fundraising', 'Cash Management', 'Unit Economics', 'Data Room', 'Metrics']
+  const FINANCE_TAGS = ['Fractional CFO', 'Finance', 'Startup Finance', 'Financial Modelling', 'Fundraising', 'Cash Management', 'Unit Economics', 'Data Room', 'Metrics']
   const TECH_OVERRIDE_TAGS = ['Fractional CTO', 'Technical Leadership', 'Infrastructure']
   const postTags = post.tags ?? []
   const isFinancePost =
@@ -147,7 +147,7 @@ export default async function BlogPost({ params }) {
   const cta = isFinancePost
     ? {
         heading: 'Need investor-ready financials?',
-        body: 'Our Fractional CFO service covers financial modeling, runway planning, and data rooms that stand up to due diligence.',
+        body: 'Our Fractional CFO service covers financial modelling, runway planning, and data rooms that stand up to due diligence.',
         href: '/services/fractional-cfo/',
         label: 'Explore Fractional CFO Services',
       }

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -8,7 +8,7 @@ import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 export const metadata = {
   title: 'Fractional CTO & CFO Insights for UK Founders',
   description: 'Practical guidance for startup founders on technical leadership, startup finance, fundraising, and scaling from 0 to 1.',
-  keywords: ['fractional CTO', 'fractional CFO', 'startup engineering blog', 'startup finance blog', 'financial modeling', 'fundraising', 'GitOps', 'Infrastructure as Code', 'startup scaling'],
+  keywords: ['fractional CTO', 'fractional CFO', 'startup engineering blog', 'startup finance blog', 'financial modelling', 'fundraising', 'GitOps', 'Infrastructure as Code', 'startup scaling'],
   openGraph: {
     title: 'Codenest Blog — Fractional CTO & CFO Insights',
     description: 'Practical lessons on technical leadership, startup finance, fundraising, and scaling from 0 to 1.',
@@ -64,8 +64,11 @@ export default function BlogPage() {
       {/* Hero Section */}
       <section className="pt-24 md:pt-32 pb-12 bg-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          {/* Not a bare "Insights": the h1 carried no term the page is trying to
+              rank for while its own title tag targeted both seats (§8). The nav
+              and footer both call this page Blog. */}
           <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-4">
-            Insights
+            Fractional CTO &amp; CFO Insights
           </h1>
           <p className="text-lg text-slate-600">
             Practical guidance for startup founders on technical leadership, finance, and scaling.

--- a/app/case-studies/page.js
+++ b/app/case-studies/page.js
@@ -38,11 +38,21 @@ export const metadata = {
 // and §13.11 already dated Opayo as Codenest-era. Understating the client base
 // is as inaccurate as overstating it. Every study states which it is.
 //
-// Three of these are completed engagements with measured outcomes. Regeno is
-// live, so it carries `status` and its third block is scope rather than results
-// — the card renderer relabels the headings from `labels` and prints `note`
-// instead of inventing figures nobody has measured yet (§4, §13.28). Fill in
-// real numbers and drop `status`/`note` when the engagement produces them.
+// Three of these are completed engagements. Regeno is live, so it carries
+// `status` and its third block is scope rather than results — the card renderer
+// relabels the headings from `labels` and prints `note` instead of inventing
+// figures nobody has measured yet (§4, §13.28). Fill in real numbers and drop
+// `status`/`note` when the engagement produces them.
+//
+// `results` entries state what was built or what changed, with a bound or a
+// named artefact. They must not carry a bare percentage. The claims stripped from
+// the homepage under §2.2 survived here until 5 Aug 2026: "maintaining 100%
+// uptime", "contributed to 10% revenue increase" (a revenue claim about a third
+// party), "accelerated delivery by 40%" and "cut deployment errors by 30%" — four
+// figures with no denominator and no source, on the page a diligence-minded
+// investor reads hardest, directly above a study that prints "outcome figures go
+// up once they are measured". If a number cannot be sourced, name the artefact
+// instead.
 const caseStudies = [
   {
     title: "Regeno: A Company Brain and an AI Factory",
@@ -80,9 +90,9 @@ const caseStudies = [
   {
     title: "Opayo by Elavon: Payment Platform Transformation",
     kind: "Codenest client engagement",
-    challenge: "Leading UK fintech payment provider needed Kubernetes consulting to modernize their infrastructure and integrate new payment channels (Apple Pay, Google Pay) while maintaining 100% uptime for critical transaction processing across Europe.",
-    solution: "Working inside the Opayo platform team from August 2019 to June 2026, Ankit orchestrated a comprehensive AWS EKS migration with Kubernetes and Helm, implementing GitOps workflows and Infrastructure as Code using Terraform — managing the transition from monolithic architecture to microservices, establishing Jenkins CI/CD pipelines on Kubernetes, and scaling engineering culture across distributed teams.",
-    results: ["Accelerated releases from every 2 weeks to multiple times per day", "Contributed to 10% revenue increase through faster feature delivery", "Reduced CI pipeline failures through automated testing", "Successfully integrated Apple Pay and Google Pay"],
+    challenge: "A UK payments provider needed to move off self-managed infrastructure and add new payment channels (Apple Pay, Google Pay), on a platform that had to keep processing transactions across Europe throughout.",
+    solution: "Working inside the Opayo platform team from August 2019 to June 2026, Ankit led an AWS EKS migration with Kubernetes and Helm, GitOps workflows and Infrastructure as Code in Terraform, the move from a payments monolith to microservices, and Jenkins CI/CD pipelines running on Kubernetes.",
+    results: ["Releases went from every two weeks to multiple times per day", "Apple Pay and Google Pay integrated as new payment channels", "Automated test gates in the pipeline, so a failing build stops before a release branch", "Monolith decomposed to microservices on AWS EKS, migrated in place"],
     tags: ["Payment Systems", "AWS EKS", "Kubernetes", "Terraform", "GitOps", "Team Leadership"],
     image: "/img/photos/case-opayo.jpg",
     imageAlt: "Secure payment processing and mobile payment integration"
@@ -91,8 +101,8 @@ const caseStudies = [
     title: "AstraZeneca: Drug Delivery Tracking System MVP",
     kind: "Codenest client engagement",
     challenge: "AstraZeneca needed to replace manual spreadsheet-based drug delivery tracking with a modern web-based tool to improve efficiency and accelerate time-to-market for pharmaceutical products. The system required integration with existing workflows while maintaining regulatory compliance.",
-    solution: "Ankit built a production-grade web application with REST APIs and automated CI/CD pipelines, collaborating closely with stakeholders and business analysts to define requirements and align delivery with business goals — architecting scalable deployments on Kubernetes using Docker and Jenkins (config-as-code), and establishing robust testing practices with JUnit and Spock.",
-    results: ["Accelerated delivery by 40% compared to manual processes", "Cut deployment errors by 30% through automated pipelines", "Improved stakeholder confidence through transparent roadmap planning", "Delivered production-ready MVP on Kubernetes infrastructure"],
+    solution: "Ankit built a web application with REST APIs behind it, defining requirements with stakeholders and business analysts, deploying on Kubernetes with Docker and Jenkins as config-as-code, and putting the test suite in JUnit and Spock behind the pipeline.",
+    results: ["Production-ready MVP delivered on Kubernetes infrastructure", "Spreadsheet-based tracking replaced by a single web tool", "Deployments automated end to end, with tests as a release gate", "Requirements agreed with stakeholders before each delivery increment"],
     tags: ["Healthcare", "Team Leadership", "Kubernetes", "CI/CD", "REST APIs", "Stakeholder Management"],
     image: "/img/photos/case-astrazeneca.jpg",
     imageAlt: "Healthcare technology and pharmaceutical tracking systems"
@@ -100,9 +110,9 @@ const caseStudies = [
   {
     title: "Rungway: Scaling a Social Mentoring Platform",
     kind: "Founder track record",
-    challenge: "A London-based HR-tech startup needed fractional CTO support to scale their social mentoring platform. The system could only handle 5 concurrent users before experiencing severe performance degradation — completely inadequate for their UK enterprise client base.",
-    solution: "Leading engineering at Rungway, Ankit delivered a complete architectural transformation: migrating from Neo4J to a hybrid MySQL/NoSQL architecture for the primary data store (retaining Neo4J for AI/ML), implementing microservices with domain-driven design, establishing Infrastructure as Code with AWS, building CI/CD pipelines, introducing event-driven architecture with SQS, and containerizing the entire stack.",
-    results: ["Scaled from 5 to 1000+ concurrent users", "Zero-downtime database migration", "Modern DevOps foundations established", "Event-driven microservices architecture"],
+    challenge: "A London-based HR-tech startup needed its social mentoring platform rebuilt to carry an enterprise client base. The system degraded badly beyond 5 concurrent users. Ankit joined as Lead Software Engineer, with the scope of a CTO, a year before Codenest existed.",
+    solution: "Ankit led the rebuild: migrating from Neo4J to a hybrid MySQL/NoSQL primary data store (keeping Neo4J for AI/ML), microservices along domain boundaries, Infrastructure as Code on AWS, CI/CD pipelines, event-driven messaging over SQS, and containerising the stack.",
+    results: ["Scaled from 5 to 1,000+ concurrent users", "Zero-downtime database migration", "Event-driven microservices replacing the original architecture", "CI/CD and Infrastructure as Code established from scratch"],
     tags: ["Backend Architecture", "AWS", "DevOps", "Scalability", "Microservices"],
     image: "/img/photos/case-rungway.jpg",
     imageAlt: "Data analytics dashboard showing platform scalability metrics"

--- a/app/cofounder/page.js
+++ b/app/cofounder/page.js
@@ -95,7 +95,7 @@ export default function CofounderPage() {
   const whatIBring = [
     '15+ years building scalable platforms (Opayo by Elavon, HSBC, AstraZeneca, startups)',
     'Full-stack technical leadership (architecture, engineering, DevOps)',
-    'Financial modeling and investor-readiness expertise',
+    'Financial modelling and investor-readiness expertise',
     'Experience scaling teams from 5 to 50+ engineers',
     'Series A due diligence and fundraising support',
     'AWS, Kubernetes, microservices, AI/ML integration'
@@ -164,7 +164,7 @@ export default function CofounderPage() {
               Technical Co-founder
             </p>
             <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-bold mb-6">
-              Looking for a Technical<br />Co-founder in the UK?
+              Looking for a Technical <br />Co-founder in the UK?
             </h1>
             <p className="text-xl text-slate-300 mb-8 max-w-2xl mx-auto leading-relaxed">
               I'm selectively open to co-founding the right company. If you're an exceptional founder with a compelling vision, let's explore whether we're a fit.

--- a/app/components/ContactForm.js
+++ b/app/components/ContactForm.js
@@ -222,14 +222,27 @@ const ContactForm = ({ labelledBy }) => {
 
       setSubmitStatus({
         type: 'success',
-        message: 'Thank you! Your message has been sent successfully. We will get back to you soon.'
+        // Matches the promise printed under the button. The two used to disagree
+        // ("we will get back to you soon" against "within 24 hours with times").
+        message: "Thank you — that's with us. We'll reply within 24 hours with some times."
       })
       setFormData({ name: '', email: '', company: '', engagement: '', message: '' })
       setEmailValidation({ status: 'idle', message: '', suggestion: null })
     } catch (error) {
+      // The address has to be in the message itself. This used to say "email us
+      // directly" while no email address appeared anywhere on the page — the one
+      // moment the fallback matters was the one moment it was missing (§11).
       setSubmitStatus({
         type: 'error',
-        message: 'Sorry, there was an error sending your message. Please try again or email us directly.'
+        message: (
+          <>
+            Sorry, that didn&apos;t send. Please try again, or email us at{' '}
+            <a href="mailto:hello@codenest.uk" className="font-semibold underline">
+              hello@codenest.uk
+            </a>
+            .
+          </>
+        )
       })
       console.error('EmailJS Error:', error)
     } finally {
@@ -414,6 +427,8 @@ const ContactForm = ({ labelledBy }) => {
 
         {submitStatus.message && (
           <div
+            role="status"
+            aria-live="polite"
             className={`p-4 rounded-xl ${
               submitStatus.type === 'success'
                 ? 'bg-green-50 border border-green-200 text-green-800'

--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -33,11 +33,14 @@ const GROUPS = [
   {
     id: 'footer-company',
     heading: 'Company',
+    // Labels match the nav's. "Our Story" and "Insights" pointed at /about and
+    // /blog, which the nav calls About and Blog — three names for two pages, and
+    // the sitewide anchor text (40 pages) was the one carrying no keyword.
     links: [
       { href: '/case-studies/', label: 'Case Studies' },
-      { href: '/#how-we-work', label: 'Our Methodology' },
-      { href: '/about/', label: 'Our Story' },
-      { href: '/blog/', label: 'Insights' },
+      { href: '/#how-we-work', label: 'How We Work' },
+      { href: '/about/', label: 'About' },
+      { href: '/blog/', label: 'Blog' },
     ],
   },
   {
@@ -60,7 +63,11 @@ const GROUPS = [
   },
 ]
 
-const LINK_CLASS = 'text-slate-400 hover:text-accent-400 transition-colors'
+// `inline-block py-1.5` gives the anchor a hit area rather than leaving it at the
+// 17px of its own line box. Measured at 375px, every footer link was 15-20px tall
+// against the 24px WCAG 2.2 (2.5.8) minimum: `space-y-2` on the <li> separated
+// them visually without making any of them easier to hit.
+const LINK_CLASS = 'inline-block py-1.5 text-slate-400 hover:text-accent-400 transition-colors'
 
 function FooterLink({ href, label, external }) {
   if (external) {
@@ -119,7 +126,7 @@ export default function Footer() {
               <h3 id={group.id} className="font-semibold mb-4">
                 {group.heading}
               </h3>
-              <ul className="space-y-2 text-sm">
+              <ul className="space-y-1 text-sm">
                 {group.links.map((link) => (
                   <li key={link.href}>
                     <FooterLink {...link} />

--- a/app/components/Navigation.js
+++ b/app/components/Navigation.js
@@ -267,9 +267,13 @@ export default function Navigation() {
         <div className="flex justify-between items-center h-20">
           <div className="flex items-center">
             <a href="/" className="flex items-center" aria-label="Codenest Home">
+              {/* width/height so the header does not reflow when the logo lands.
+                  Not lazy: this is the first thing painted. */}
               <img
                 src="/img/companylogo.svg"
                 alt="Codenest - Fractional CTO & CFO for UK startups"
+                width={260}
+                height={48}
                 className="h-12 w-auto company-logo"
               />
             </a>

--- a/app/components/ReferralForm.js
+++ b/app/components/ReferralForm.js
@@ -1,0 +1,247 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import emailjs from '@emailjs/browser'
+
+// This form used to be markup only: a <form> inside a server component with no
+// action and no submit handler. Pressing "Submit Referral" did a GET back to
+// /refer/, which lost the referral entirely AND put both people's names and email
+// addresses into the URL query string — and so into browser history, server logs
+// and the Referer header of every request after it. (Site review, 5 Aug 2026.)
+//
+// It sends through the same EmailJS template as ContactForm and the runway
+// calculator rather than adding a fourth one: the referral detail is packed into
+// `message`, and `engagement` tags the lead so referrals are filterable at the
+// other end.
+//
+// The referred founder's email is optional and gated behind an explicit
+// confirmation that the referrer has their permission. Sharing a third party's
+// contact details is the referrer's disclosure to make, not ours to assume
+// (UK GDPR Art. 14; PECR for the approach that follows).
+const INITIAL = {
+  referrer_name: '',
+  referrer_email: '',
+  founder_name: '',
+  founder_email: '',
+  company_name: '',
+  context: '',
+  consent: false,
+}
+
+const FIELD_CLASS =
+  'w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-400 focus:ring-2 focus:ring-accent-500 focus:border-transparent'
+const LABEL_CLASS = 'block text-sm font-medium text-slate-300 mb-2'
+
+export default function ReferralForm() {
+  const formRef = useRef(null)
+  const [values, setValues] = useState(INITIAL)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [status, setStatus] = useState({ type: '', message: '' })
+
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target
+    setValues((previous) => ({ ...previous, [name]: type === 'checkbox' ? checked : value }))
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setIsSubmitting(true)
+    setStatus({ type: '', message: '' })
+
+    const summary = [
+      'Referral submitted from /refer/',
+      `Referrer: ${values.referrer_name} <${values.referrer_email}>`,
+      `Founder: ${values.founder_name || 'not given'}${values.founder_email ? ` <${values.founder_email}>` : ''}`,
+      `Company: ${values.company_name || 'not given'}`,
+      `Permission to contact the founder confirmed by referrer: ${values.consent ? 'yes' : 'no'}`,
+      '',
+      `What they need: ${values.context || 'not given'}`,
+    ].join('\n')
+
+    try {
+      await emailjs.send(
+        process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID,
+        process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID,
+        {
+          name: `Referral from ${values.referrer_name}`,
+          email: values.referrer_email,
+          company: values.company_name,
+          engagement: 'referral',
+          message: summary,
+        },
+        process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY
+      )
+      setStatus({
+        type: 'success',
+        message: "Thank you — we have your referral. We'll be in touch within 48 hours and will let you know the outcome either way.",
+      })
+      setValues(INITIAL)
+    } catch (error) {
+      console.error('EmailJS Error:', error)
+      setStatus({
+        type: 'error',
+        message: 'Sorry, that did not send. Please try again, or email the details to hello@codenest.uk.',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit} className="space-y-6" aria-labelledby="refer-form-heading">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label htmlFor="referrer_name" className={LABEL_CLASS}>
+            Your Name *
+          </label>
+          <input
+            type="text"
+            id="referrer_name"
+            name="referrer_name"
+            value={values.referrer_name}
+            onChange={handleChange}
+            required
+            className={FIELD_CLASS}
+            placeholder="Jane Smith"
+          />
+        </div>
+        <div>
+          <label htmlFor="referrer_email" className={LABEL_CLASS}>
+            Your Email *
+          </label>
+          <input
+            type="email"
+            id="referrer_email"
+            name="referrer_email"
+            value={values.referrer_email}
+            onChange={handleChange}
+            required
+            className={FIELD_CLASS}
+            placeholder="jane@company.com"
+          />
+        </div>
+      </div>
+
+      <fieldset className="border-t border-slate-700 pt-6 space-y-6">
+        <legend className="text-sm text-slate-400">Founder you&apos;re referring</legend>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label htmlFor="founder_name" className={LABEL_CLASS}>
+              Founder&apos;s Name
+            </label>
+            <input
+              type="text"
+              id="founder_name"
+              name="founder_name"
+              value={values.founder_name}
+              onChange={handleChange}
+              className={FIELD_CLASS}
+              placeholder="Alex Johnson"
+            />
+          </div>
+          <div>
+            <label htmlFor="founder_email" className={LABEL_CLASS}>
+              Founder&apos;s Email <span className="text-slate-400 font-normal">(optional)</span>
+            </label>
+            <input
+              type="email"
+              id="founder_email"
+              name="founder_email"
+              value={values.founder_email}
+              onChange={handleChange}
+              className={FIELD_CLASS}
+              placeholder="alex@startup.com"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="company_name" className={LABEL_CLASS}>
+            Company Name
+          </label>
+          <input
+            type="text"
+            id="company_name"
+            name="company_name"
+            value={values.company_name}
+            onChange={handleChange}
+            className={FIELD_CLASS}
+            placeholder="Startup Ltd"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="context" className={LABEL_CLASS}>
+            What do they need help with?
+          </label>
+          <textarea
+            id="context"
+            name="context"
+            value={values.context}
+            onChange={handleChange}
+            rows={4}
+            className={`${FIELD_CLASS} resize-none`}
+            placeholder="e.g. They're building a fintech app, need help with architecture decisions and preparing for their seed round..."
+          ></textarea>
+        </div>
+
+        {/* Only asked for when their details are actually supplied: the referrer is
+            the one who can say whether the founder is happy to be introduced. */}
+        {(values.founder_email || values.founder_name) && (
+          <label className="flex items-start gap-3 text-sm text-slate-300 cursor-pointer">
+            <input
+              type="checkbox"
+              name="consent"
+              checked={values.consent}
+              onChange={handleChange}
+              required
+              className="mt-1 w-4 h-4 rounded border-slate-600 bg-slate-800 text-accent-500 focus:ring-2 focus:ring-accent-500"
+            />
+            <span>
+              They know about this introduction and are happy for me to share their details.
+            </span>
+          </label>
+        )}
+      </fieldset>
+
+      {status.message && (
+        <div
+          role="status"
+          className={`p-4 rounded-lg text-sm ${
+            status.type === 'success'
+              ? 'bg-emerald-950 border border-emerald-800 text-emerald-200'
+              : 'bg-red-950 border border-red-800 text-red-200'
+          }`}
+        >
+          {status.message}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className={`w-full px-8 py-4 rounded-lg text-lg font-semibold transition-all ${
+          isSubmitting
+            ? 'bg-slate-600 text-slate-300 cursor-not-allowed'
+            : 'bg-accent-400 text-primary-900 hover:bg-accent-500 shadow-gold hover:shadow-gold-lg'
+        }`}
+      >
+        {isSubmitting ? 'Sending...' : 'Submit Referral'}
+      </button>
+
+      <p className="text-xs text-slate-400 text-center">
+        We&apos;ll reach out within 48 hours and keep you updated on the progress.
+      </p>
+      {/* Privacy information belongs where the data is collected, not only in the
+          footer (UK GDPR, Art. 13). /privacy lists this form as a collection point. */}
+      <p className="text-xs text-slate-400 text-center">
+        We use these details only to follow up on the referral — never for marketing lists. See our{' '}
+        <a href="/privacy/" className="underline hover:text-slate-200">
+          Privacy Policy
+        </a>
+        .
+      </p>
+    </form>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,20 +103,10 @@
   }
 }
 
-/* Subtle pulse animation for CTAs */
-/* Attention-grabbing bounce for sticky CTA */
-@keyframes subtleBounce {
-  0%, 100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-3px);
-  }
-}
-
-.cta-bounce {
-  animation: subtleBounce 2s ease-in-out infinite;
-}
+/* `subtleBounce`/`.cta-bounce` lived here: an infinite attention animation on the
+   sticky CTA, referenced by nothing since `cta-pulse` was retired. BRANDING §5
+   bans infinite attention animations outright, so it was dead code that could
+   only be revived into a rule violation. Removed 5 Aug 2026. */
 
 /* Safe area for iPhone notch/home indicator */
 .safe-area-bottom {

--- a/app/guides/fractional-cfo-guide/page.js
+++ b/app/guides/fractional-cfo-guide/page.js
@@ -129,7 +129,7 @@ export default function FractionalCFOGuidePage() {
                 Complete Guide
               </span>
               <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-bold text-slate-900 mb-6">
-                The Complete Guide to<br />Fractional CFO Services in the UK
+                The Complete Guide to <br />Fractional CFO Services in the UK
               </h1>
               <p className="text-xl text-slate-600 max-w-2xl mx-auto mb-8">
                 Everything UK founders need to know about hiring a fractional CFO: what they do, what they cost, when to bring one in, and how to choose the right one.

--- a/app/guides/fractional-cto-guide/page.js
+++ b/app/guides/fractional-cto-guide/page.js
@@ -134,7 +134,7 @@ export default function FractionalCTOGuidePage() {
               Complete Guide
             </span>
             <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-bold text-slate-900 mb-6">
-              The Complete Guide to<br />Fractional CTO Services
+              The Complete Guide to <br />Fractional CTO Services
             </h1>
             <p className="text-xl text-slate-600 max-w-2xl mx-auto mb-8">
               Everything UK founders need to know about hiring a fractional CTO: costs, benefits, timing, and how to make it work for your startup.
@@ -179,7 +179,7 @@ export default function FractionalCTOGuidePage() {
                 A <strong>fractional CTO</strong> is a senior technology executive who provides part-time technical leadership to companies that need strategic guidance but aren't ready for, or can't afford, a full-time Chief Technology Officer.
               </p>
               <p>
-                Unlike consultants who provide advice and leave, a fractional CTO becomes embedded in your organization. They attend your standups, join your Slack channels, participate in investor meetings, and take accountability for technical outcomes.
+                Unlike consultants who provide advice and leave, a fractional CTO becomes embedded in your organisation. They attend your standups, join your Slack channels, participate in investor meetings, and take accountability for technical outcomes.
               </p>
               <p>
                 The "fractional" model has become increasingly popular among UK startups, particularly in the pre-seed to Series A stages. It allows founders to access executive-level expertise while preserving runway and avoiding premature scaling of their leadership team.
@@ -231,7 +231,7 @@ export default function FractionalCTOGuidePage() {
               <ul>
                 <li>Implementing DevOps and CI/CD pipelines</li>
                 <li>Security architecture and compliance</li>
-                <li>Performance optimization</li>
+                <li>Performance optimisation</li>
                 <li>Vendor negotiation (cloud providers, tools)</li>
               </ul>
             </section>
@@ -283,7 +283,7 @@ export default function FractionalCTOGuidePage() {
                 How Much Does a Fractional CTO Cost?
               </h2>
               <p>
-                Fractional CTO costs in the UK vary based on experience level, engagement intensity, and industry specialization. Here's what to expect:
+                Fractional CTO costs in the UK vary based on experience level, engagement intensity, and industry specialisation. Here's what to expect:
               </p>
 
               <div className="overflow-x-auto my-8 not-prose">

--- a/app/layout.js
+++ b/app/layout.js
@@ -160,7 +160,7 @@ export default function RootLayout({ children }) {
       'Fractional CFO Services',
       'Startup Engineering',
       'MVP Development',
-      'Financial Modeling',
+      'Financial Modelling',
       'Fundraising',
       'Startup Financial Strategy',
       'Technical Co-founder Partnerships',

--- a/app/not-found.js
+++ b/app/not-found.js
@@ -6,10 +6,14 @@ import Navigation from './components/Navigation'
 // crawlable soft-404). Next already adds noindex to not-found pages, but not a
 // canonical — so without this the 404 inherited the root layout's and told Google the
 // 404 page IS the homepage.
+// `robots` is set here as well: the page inherited the root layout's
+// "index, follow" alongside Next's own noindex, so the built page shipped two
+// contradictory robots tags. noindex wins either way, but only by accident.
 export const metadata = {
   title: 'Page Not Found',
   description: 'The page you are looking for does not exist or has been moved.',
   alternates: { canonical: 'https://codenest.uk/404/' },
+  robots: { index: false, follow: false },
 }
 
 export default function NotFound() {

--- a/app/page.js
+++ b/app/page.js
@@ -29,7 +29,7 @@ export default function Home() {
     {
       title: "Opayo by Elavon: Payment Platform Transformation",
       kind: "Codenest client engagement",
-      results: ["Releases accelerated from fortnightly to multiple times per day"]
+      results: ["Releases went from every two weeks to multiple times per day"]
     },
     {
       title: "AstraZeneca: Drug Delivery Tracking System MVP",
@@ -39,7 +39,7 @@ export default function Home() {
     {
       title: "Rungway: Scaling a Social Mentoring Platform",
       kind: "Founder track record",
-      results: ["Scaled from 5 to 1000+ concurrent users"]
+      results: ["Scaled from 5 to 1,000+ concurrent users"]
     }
   ]
 
@@ -47,7 +47,7 @@ export default function Home() {
   const faqs = [
     {
       question: "How quickly can we start?",
-      answer: "Most engagements start within 1-2 weeks after our initial discovery call. For urgent projects, we can mobilize faster."
+      answer: "Most engagements start within 1-2 weeks after our initial discovery call. For urgent projects, we can mobilise faster."
     },
     {
       question: "What does a typical engagement look like?",
@@ -214,7 +214,7 @@ export default function Home() {
                   <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  Financial Modeling & FP&A
+                  Financial Modelling & FP&A
                 </li>
                 <li className="flex items-center text-slate-700">
                   <svg className="w-5 h-5 text-accent-500 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -315,6 +315,9 @@ export default function Home() {
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/regeno.png"
+                width={40}
+                height={40}
+                loading="lazy"
                 alt="Regeno"
                 className="w-10 h-10 rounded-lg object-contain"
               />
@@ -328,6 +331,9 @@ export default function Home() {
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/opayo.png"
+                width={100}
+                height={32}
+                loading="lazy"
                 alt="Opayo by Elavon"
                 className="h-8 w-auto object-contain"
               />
@@ -337,6 +343,9 @@ export default function Home() {
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/astrazeneca.png"
+                width={128}
+                height={32}
+                loading="lazy"
                 alt="AstraZeneca"
                 className="h-8 w-auto object-contain"
               />
@@ -349,6 +358,9 @@ export default function Home() {
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/hsbc.png"
+                width={118}
+                height={32}
+                loading="lazy"
                 alt="HSBC"
                 className="h-8 w-auto object-contain"
               />
@@ -357,6 +369,9 @@ export default function Home() {
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/deloitte.png"
+                width={119}
+                height={32}
+                loading="lazy"
                 alt="Deloitte Digital"
                 className="h-8 w-auto object-contain"
               />
@@ -370,6 +385,9 @@ export default function Home() {
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/rungway.webp"
+                width={40}
+                height={40}
+                loading="lazy"
                 alt="Rungway"
                 className="w-10 h-10 rounded-lg object-contain"
               />
@@ -386,6 +404,9 @@ export default function Home() {
             <div className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-white hover:shadow-sm transition-all cursor-default">
               <img
                 src="/img/clients/dishoom.svg"
+                width={176}
+                height={20}
+                loading="lazy"
                 alt="Dishoom"
                 className="h-5 w-auto object-contain"
               />

--- a/app/privacy/page.js
+++ b/app/privacy/page.js
@@ -44,9 +44,10 @@ const pageSchema = [
   },
 ]
 
-// Kept as data so the two collection points stay in sync with the forms
-// themselves — if a field is added to ContactForm or RunwayCalculator, it is
-// added here in the same change.
+// Kept as data so the collection points stay in sync with the forms themselves —
+// if a field is added to ContactForm, RunwayCalculator or ReferralForm, it is
+// added here in the same change. The referral form was missing from this list
+// entirely while it was live (site review, 5 Aug 2026).
 const collectionPoints = [
   {
     name: 'Strategy call request form',
@@ -67,6 +68,15 @@ const collectionPoints = [
       'The figures you enter into the calculator, which are sent alongside that projection',
     ],
   },
+  {
+    name: 'Referral form',
+    where: '/refer',
+    fields: [
+      'Your name and email address (both required)',
+      "The referred founder's name, company and email address (all optional) — we ask you to confirm they are happy for you to share these before you send them",
+      'What you tell us they need help with (optional)',
+    ],
+  },
 ]
 
 export default function PrivacyPolicyPage() {
@@ -84,7 +94,7 @@ export default function PrivacyPolicyPage() {
               <p className="text-xl text-slate-600">
                 What we collect when you contact us, who else touches it, and how to get it removed.
               </p>
-              <p className="text-sm text-slate-500 mt-4">Last updated: 4 August 2026</p>
+              <p className="text-sm text-slate-500 mt-4">Last updated: 5 August 2026</p>
             </div>
 
             <div className="space-y-12 text-slate-600 leading-relaxed">
@@ -111,8 +121,8 @@ export default function PrivacyPolicyPage() {
               <section>
                 <h2 className="text-2xl font-bold text-slate-900 mb-4">What we collect, and when</h2>
                 <p className="mb-6">
-                  We only collect personal data that you type into a form yourself. There are two places on this site
-                  where that happens.
+                  We only collect personal data that you type into a form yourself. There are three places on this
+                  site where that happens.
                 </p>
                 <div className="space-y-6">
                   {collectionPoints.map((point) => (
@@ -155,8 +165,8 @@ export default function PrivacyPolicyPage() {
                 <h2 className="text-2xl font-bold text-slate-900 mb-4">Who else processes it</h2>
                 <ul className="space-y-4">
                   <li>
-                    <strong className="text-slate-900">EmailJS</strong> delivers both forms on this site. Everything you
-                    submit passes through EmailJS on its way to our inbox.
+                    <strong className="text-slate-900">EmailJS</strong> delivers all three forms on this site.
+                    Everything you submit passes through EmailJS on its way to our inbox.
                   </li>
                   <li>
                     <strong className="text-slate-900">Our email provider</strong> holds the resulting message, in the
@@ -179,6 +189,23 @@ export default function PrivacyPolicyPage() {
                   The contact form contains an optional email-verification step that would check an address against a
                   third-party validation service. It is switched off, and no address is sent anywhere for verification.
                   If we ever enable it, this page will say so before it goes live.
+                </p>
+              </section>
+
+              <section>
+                <h2 className="text-2xl font-bold text-slate-900 mb-4">If someone referred you to us</h2>
+                <p>
+                  The referral form lets one person pass on another person&apos;s details. We ask the referrer to
+                  confirm you already know about the introduction before they send anything, and we use what they
+                  give us only to make contact once.
+                </p>
+                <p className="mt-4">
+                  If we get in touch and you would rather we had not, tell us and we will delete your details
+                  immediately — reply to the email, or write to{' '}
+                  <a href="mailto:hello@codenest.uk" className="font-semibold text-primary-700 hover:text-primary-800 underline">
+                    hello@codenest.uk
+                  </a>
+                  . You can also ask us who referred you.
                 </p>
               </section>
 

--- a/app/refer/page.js
+++ b/app/refer/page.js
@@ -1,6 +1,7 @@
 import Navigation from '../components/Navigation'
 import Footer from '../components/Footer'
 import CopyButton from '../components/CopyButton'
+import ReferralForm from '../components/ReferralForm'
 import JsonLd from '../components/JsonLd'
 import { breadcrumbs, ORGANIZATION_ID, WEBSITE_ID } from '../../lib/schema'
 
@@ -124,7 +125,7 @@ export default function ReferralPage() {
             Referral Program
           </p>
           <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-bold mb-6">
-            Know a Founder Who<br />Needs Technical Help?
+            Know a Founder Who <br />Needs Technical Help?
           </h1>
           <p className="text-xl text-slate-300 mb-8 max-w-2xl mx-auto">
             Earn up to £2,000 for every successful introduction. Help founders get the leadership they need while getting rewarded for your network.
@@ -232,7 +233,7 @@ export default function ReferralPage() {
                 </li>
                 <li className="flex items-center gap-3 text-slate-700">
                   <span className="w-2 h-2 bg-primary-500 rounded-full"></span>
-                  Financial modeling & fundraising support
+                  Financial modelling & fundraising support
                 </li>
                 <li className="flex items-center gap-3 text-slate-700">
                   <span className="w-2 h-2 bg-primary-500 rounded-full"></span>
@@ -281,7 +282,7 @@ export default function ReferralPage() {
       <section id="refer-form" className="py-20 bg-slate-900 text-white">
         <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <h2 className="font-serif text-3xl md:text-4xl font-bold text-white mb-4">
+            <h2 id="refer-form-heading" className="font-serif text-3xl md:text-4xl font-bold text-white mb-4">
               Make a Referral
             </h2>
             <p className="text-lg text-slate-300">
@@ -292,96 +293,7 @@ export default function ReferralPage() {
             </p>
           </div>
 
-          <form className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  Your Name
-                </label>
-                <input
-                  type="text"
-                  name="referrer_name"
-                  className="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-400 focus:ring-2 focus:ring-accent-500 focus:border-transparent"
-                  placeholder="Jane Smith"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  Your Email
-                </label>
-                <input
-                  type="email"
-                  name="referrer_email"
-                  className="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-400 focus:ring-2 focus:ring-accent-500 focus:border-transparent"
-                  placeholder="jane@company.com"
-                />
-              </div>
-            </div>
-
-            <div className="border-t border-slate-700 pt-6">
-              <p className="text-sm text-slate-400 mb-4">Founder you're referring:</p>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  Founder's Name
-                </label>
-                <input
-                  type="text"
-                  name="founder_name"
-                  className="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-400 focus:ring-2 focus:ring-accent-500 focus:border-transparent"
-                  placeholder="Alex Johnson"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
-                  Founder's Email
-                </label>
-                <input
-                  type="email"
-                  name="founder_email"
-                  className="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-400 focus:ring-2 focus:ring-accent-500 focus:border-transparent"
-                  placeholder="alex@startup.com"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">
-                Company Name
-              </label>
-              <input
-                type="text"
-                name="company_name"
-                className="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-400 focus:ring-2 focus:ring-accent-500 focus:border-transparent"
-                placeholder="Startup Ltd"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">
-                What do they need help with?
-              </label>
-              <textarea
-                name="context"
-                rows={4}
-                className="w-full px-4 py-3 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-400 focus:ring-2 focus:ring-accent-500 focus:border-transparent resize-none"
-                placeholder="e.g., They're building a fintech app, need help with architecture decisions and preparing for their seed round..."
-              ></textarea>
-            </div>
-
-            <button
-              type="submit"
-              className="w-full bg-accent-400 text-primary-900 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-accent-500 transition-all shadow-gold hover:shadow-gold-lg"
-            >
-              Submit Referral
-            </button>
-
-            <p className="text-xs text-slate-400 text-center">
-              We'll reach out to them within 48 hours and keep you updated on the progress.
-            </p>
-          </form>
+          <ReferralForm />
         </div>
       </section>
 
@@ -403,7 +315,7 @@ export default function ReferralPage() {
               <hr className="border-slate-200" />
               <p>Hi [Founder Name],</p>
               <p>
-                I wanted to connect you with Ankit from Codenest. He helps startups with fractional CTO/CFO support — technical architecture, financial modeling, fundraising prep, that kind of thing.
+                I wanted to connect you with Ankit from Codenest. He helps startups with fractional CTO/CFO support — technical architecture, financial modelling, fundraising prep, that kind of thing.
               </p>
               <p>
                 Given what you mentioned about [their specific challenge], I thought it might be worth a conversation.
@@ -421,7 +333,7 @@ export default function ReferralPage() {
 
 Hi [Founder Name],
 
-I wanted to connect you with Ankit from Codenest. He helps startups with fractional CTO/CFO support — technical architecture, financial modeling, fundraising prep, that kind of thing.
+I wanted to connect you with Ankit from Codenest. He helps startups with fractional CTO/CFO support — technical architecture, financial modelling, fundraising prep, that kind of thing.
 
 Given what you mentioned about [their specific challenge], I thought it might be worth a conversation.
 
@@ -474,7 +386,7 @@ I'll leave you both to connect.
                 </svg>
               </summary>
               <div className="px-6 pb-6 text-slate-600">
-                Absolutely. There's no limit to how many referrals you can make. Each successful referral earns its own fee.
+                No limit — each successful referral earns its own fee.
               </div>
             </details>
 

--- a/app/services/fractional-cfo/page.js
+++ b/app/services/fractional-cfo/page.js
@@ -40,10 +40,17 @@ const cfoBreadcrumbs = breadcrumbs([
 ])
 
 export default function FractionalCFOPage() {
+  // Each tile carries a `proof` line, and each one names where the number comes
+  // from. All four used to be figure-free while Michelle's numbers sat one screen
+  // above in the PrincipalBand — the proof was on the page and unused at the point
+  // it converts (site review, 5 Aug 2026). Dishoom figures attach to her *role*,
+  // never to Codenest as a firm (§13.15); the Series A line is the one outcome a
+  // verified client testimonial supports (§2.3).
   const benefits = [
     {
       title: "Investor-Ready Financials",
-      description: "Build financial models and reporting that satisfy even the most demanding investors.",
+      description: "Financial models and reporting built to be tested, not admired.",
+      proof: "Michelle owned Board and investor reporting at Dishoom",
       icon: (
         <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
@@ -52,7 +59,8 @@ export default function FractionalCFOPage() {
     },
     {
       title: "Extend Your Runway",
-      description: "Optimize cash flow and burn rate to give yourself more time to hit milestones.",
+      description: "Cash flow and burn under a forecast you can act on, months before the decision lands.",
+      proof: "Rolling forecasts accurate to ±3% at Dishoom",
       icon: (
         <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -61,7 +69,8 @@ export default function FractionalCFOPage() {
     },
     {
       title: "Close Rounds Faster",
-      description: "Prepared data rooms and polished financials help you close fundraising rounds with confidence.",
+      description: "A data room and a model that answer the questions before an investor has to ask them.",
+      proof: "Series A closed on our models and data room (client, name withheld)",
       icon: (
         <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
@@ -70,7 +79,8 @@ export default function FractionalCFOPage() {
     },
     {
       title: "Board-Level Reporting",
-      description: "Professional financial reporting that builds confidence with your board and investors.",
+      description: "A close that lands on time, so the board pack is not assembled the night before.",
+      proof: "Month-end close cut from 14 days to 8 at Dishoom",
       icon: (
         <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -80,8 +90,8 @@ export default function FractionalCFOPage() {
   ]
 
   const services = [
-    "Financial modeling and forecasting",
-    "Cash flow management and optimization",
+    "Financial modelling and forecasting",
+    "Cash flow management and optimisation",
     "Unit economics analysis",
     "Data room creation and management",
     "Investor presentation support",
@@ -96,7 +106,7 @@ export default function FractionalCFOPage() {
   const faqs = [
     {
       question: "What's the difference between FP&A and accounting?",
-      answer: "Accountants handle historical compliance and bookkeeping. FP&A is forward-looking: financial modeling, forecasting, unit economics, pricing strategy, and investor communications. We provide strategic finance leadership, not bookkeeping."
+      answer: "Accountants handle historical compliance and bookkeeping. FP&A is forward-looking: financial modelling, forecasting, unit economics, pricing strategy, and investor communications. We provide strategic finance leadership, not bookkeeping."
     },
     {
       question: "How many hours per week do you typically work?",
@@ -104,15 +114,35 @@ export default function FractionalCFOPage() {
     },
     {
       question: "When should a startup invest in FP&A?",
-      answer: "Ideal timing is when you're preparing to raise funding, need to optimize runway, or want to professionalize your financial operations. Typically pre-seed through Series A — and we stay on as you scale."
+      answer: "Ideal timing is when you're preparing to raise funding, need to optimise runway, or want to professionalise your financial operations. Typically pre-seed through Series A — and we stay on as you scale."
     },
     {
       question: "Can you help us prepare for due diligence?",
-      answer: "Absolutely. Due diligence preparation is one of our core strengths. We ensure your financials, projections, and data room are investor-ready and can withstand scrutiny."
+      answer: "Yes. We build the model, the data room and the supporting schedules, then work the questions an investor will actually ask against them. Michelle has been through investor due diligence from the inside, which is the fastest way to learn what it tests."
     },
     {
       question: "Can you help with fundraising?",
-      answer: "Yes. We prepare financial models, data rooms, and due diligence materials. We've supported raises from pre-seed through Series A across fintech, healthtech, and B2B SaaS."
+      answer: "Yes. Financial models, data rooms and due diligence materials, plus the investor conversations that run off them. What we will not do is put a number on your raise before we have seen your numbers."
+    },
+    {
+      question: "Do we still need a bookkeeper or an accountant?",
+      answer: "Yes, and we are not a replacement for either. A bookkeeper records what happened and an accountant files it. A Fractional CFO decides what to do next: pricing, hiring, runway, the shape of the raise. We work alongside whoever already does your compliance."
+    },
+    {
+      question: "Can you work with the finance team we already have?",
+      answer: "Yes. Michelle built and led a 20+ person finance function, so working through a team is the normal case rather than the exception. We set the reporting, the controls and the forecast rhythm, and your team runs them."
+    },
+    {
+      question: "We are not raising. Is a Fractional CFO still worth it?",
+      answer: "Often, yes. Fundraising is one use of the seat, not the point of it. Pricing, margin, month-end close, cash management, budgeting and Board reporting are the operational half, and they are what makes the next raise straightforward when it comes."
+    },
+    {
+      question: "What does the first month look like?",
+      answer: "We start with what exists: the numbers, how they are produced, and where they are argued about. From that comes a working model, an agreed reporting pack, and a short list of the decisions that need a number attached to them. No 90-day discovery phase."
+    },
+    {
+      question: "Can you help us hire a permanent finance lead?",
+      answer: "Yes. Part of the job is making the seat unnecessary: defining the role, sitting in on interviews, and handing over a function that runs without us. The same applies on the technical side with the Fractional CTO."
     },
   ]
 
@@ -135,7 +165,7 @@ export default function FractionalCFOPage() {
     '@context': 'https://schema.org',
     '@type': 'Service',
     name: 'Fractional CFO Services',
-    description: 'Part-time financial leadership for startups. FP&A, financial modeling, and fundraising support.',
+    description: 'Part-time financial leadership for startups. FP&A, financial modelling, and fundraising support.',
     // Reference the root layout's ProfessionalService by @id rather than
     // restating it: a second, differently-shaped Organization node for the same
     // business invites Google to treat them as two companies.
@@ -176,7 +206,7 @@ export default function FractionalCFOPage() {
                 Fractional CFO Services
               </h1>
               <p className="text-xl text-slate-600 mb-4 leading-relaxed">
-                FP&A, financial modeling, and investor-ready reporting from a part-time CFO. The financial discipline of a high-growth company — without the overhead.
+                FP&A, financial modelling, and investor-ready reporting from a part-time CFO. The financial discipline of a high-growth company — without the overhead.
               </p>
               <p className="text-sm font-medium text-slate-700 mb-8">
                 Retained monthly engagements, scoped to your stage &middot; typically 60-80% less than a full-time CFO
@@ -243,6 +273,11 @@ export default function FractionalCFOPage() {
                 </div>
                 <h3 className="text-xl font-bold text-slate-900 mb-3">{benefit.title}</h3>
                 <p className="text-slate-600">{benefit.description}</p>
+                {benefit.proof && (
+                  <p className="mt-4 pt-4 border-t border-slate-200 text-sm font-semibold text-accent-700">
+                    {benefit.proof}
+                  </p>
+                )}
               </div>
             ))}
           </div>
@@ -256,7 +291,7 @@ export default function FractionalCFOPage() {
             <div>
               <h2 className="font-serif text-4xl font-bold text-slate-900 mb-6">What We Do</h2>
               <p className="text-xl text-slate-600 mb-8">
-                Comprehensive financial leadership covering strategy, systems implementation, and operational excellence.
+                What the seat covers: the plan, the systems that produce the numbers, and the discipline that keeps them true.
               </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 {services.map((service, index) => (
@@ -287,7 +322,7 @@ export default function FractionalCFOPage() {
                   </span>
                   <div>
                     <p className="font-semibold text-slate-900">Founders needing financial discipline</p>
-                    <p className="text-slate-600 text-sm">Want to optimize runway and understand unit economics</p>
+                    <p className="text-slate-600 text-sm">Want to optimise runway and understand unit economics</p>
                   </div>
                 </li>
                 <li className="flex items-start">
@@ -346,7 +381,7 @@ export default function FractionalCFOPage() {
               </Link>{' '}
               — or read{' '}
               <Link href="/blog/financial-modeling-seed-stage-startups/" className="font-semibold text-accent-700 hover:text-accent-800 underline">
-                our financial modeling guide
+                our financial modelling guide
               </Link>.
             </p>
           </div>

--- a/app/services/fractional-cto/page.js
+++ b/app/services/fractional-cto/page.js
@@ -128,7 +128,7 @@ export default function FractionalCTOPage() {
     },
     {
       question: "What's the difference between a fractional CTO and a consultant?",
-      answer: "A fractional CTO is embedded in your team and takes ownership of technical outcomes. Unlike consultants who provide advice and leave, we're accountable for execution and stay engaged as your technical leader."
+      answer: "A consultant hands you a recommendation and leaves. A fractional CTO is in your standups and your Slack, owns the technical outcome, and is still there when the decision has to survive contact with production."
     },
     {
       question: "How many hours per week do you typically work?",
@@ -144,11 +144,11 @@ export default function FractionalCTOPage() {
     },
     {
       question: "Do you work with non-technical founders?",
-      answer: "Absolutely. Many of our clients are first-time founders without technical backgrounds. We excel at translating complex concepts into clear business terms."
+      answer: "Yes, and it is a large part of the job. The work is translation as much as architecture: what a decision costs, what it forecloses, and what you are actually buying when an engineer recommends something. You should never have to take a technical answer on trust."
     },
     {
       question: "What's your tech stack expertise?",
-      answer: "We specialize in cloud-native architectures (AWS, GCP), Kubernetes, Terraform, Python, Java, Postgres/MySQL, GitOps, and agentic AI stacks: LLM orchestration, retrieval, evaluation and guardrails. But our real value is in architectural thinking — we choose the right tools for your specific needs."
+      answer: "We specialise in cloud-native architectures (AWS, GCP), Kubernetes, Terraform, Python, Java, Postgres/MySQL, GitOps, and agentic AI stacks: LLM orchestration, retrieval, evaluation and guardrails. But our real value is in architectural thinking — we choose the right tools for your specific needs."
     },
     {
       question: "What makes you different from a dev shop?",
@@ -156,7 +156,7 @@ export default function FractionalCTOPage() {
     },
     {
       question: "Do you offer ongoing support after delivery?",
-      answer: "Yes. We offer retainer arrangements for post-launch support, scaling assistance, and continued technical leadership. Many clients transition from intensive builds to lighter advisory after launch."
+      answer: "Yes. A build usually steps down into a lighter retainer once it is live: scaling questions, hiring, and the architecture decisions that only surface under real load. The step down is planned, not improvised at the end."
     },
   ]
 
@@ -254,7 +254,7 @@ export default function FractionalCTOPage() {
         role="Fractional CTO"
         accent="primary"
         credentials={['AWS Certified', '15+ years engineering', 'Kubernetes & Cloud', 'Agentic AI']}
-        bio="Fifteen years building and scaling technology platforms: consumer-scale Java at Rated People and Rightmove, then leading engineering at Rungway, then a decade of regulated delivery through Codenest across government, banking, pharma and payments. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
+        bio="Fifteen years building and scaling technology platforms: consumer-scale Java at Rated People and Rightmove, then leading engineering at Rungway, then regulated delivery through Codenest since 2017 across government, banking, pharma and payments. He has sat on the receiving end of technical due diligence, which is the fastest way to learn what it actually tests."
         highlights={[
           'Leads the Regeno engagement, a current Codenest client: a company brain over their own records, and an AI factory that drives a ticket to a merged pull request unattended',
           'Led engineering teams from 5 to 50+ across fintech and healthtech',
@@ -297,7 +297,7 @@ export default function FractionalCTOPage() {
             <div>
               <h2 className="font-serif text-4xl font-bold text-slate-900 mb-6">What We Do</h2>
               <p className="text-xl text-slate-600 mb-8">
-                Comprehensive technical leadership covering strategy, architecture, team, and execution.
+                What the seat covers: strategy, architecture, the team, and the delivery of both.
               </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 {services.map((service, index) => (

--- a/app/services/page.js
+++ b/app/services/page.js
@@ -129,7 +129,7 @@ const services =
       track: "technical"
     },
     {
-      title: "Financial Modeling",
+      title: "Financial Modelling",
       benefit: "Know your numbers before investors ask",
       description: "3-statement models, unit economics, and scenario planning. Financial models that stand up to due diligence scrutiny.",
       outcomes: ["3-statement models", "Unit economics analysis", "Scenario planning"],

--- a/app/tools/runway-calculator/RunwayCalculator.js
+++ b/app/tools/runway-calculator/RunwayCalculator.js
@@ -311,7 +311,7 @@ export default function RunwayCalculator() {
           <div className="bg-accent-50 rounded-2xl p-8 border border-accent-200">
             <h3 className="text-lg font-bold text-slate-900 mb-2">Email me my 12-month projection</h3>
             <p className="text-sm text-slate-600 mb-4">
-              We&apos;ll send this summary to your inbox — and if you want help extending your runway, our fractional CFO service covers burn-rate optimisation and cash management.
+              We&apos;ll send this summary to your inbox — and if you want help extending your runway, our Fractional CFO service covers burn-rate optimisation and cash management.
             </p>
             {emailStatus.state === 'sent' ? (
               <p className="text-sm font-medium text-green-700">{emailStatus.message}</p>

--- a/app/tools/runway-calculator/page.js
+++ b/app/tools/runway-calculator/page.js
@@ -162,7 +162,7 @@ export default function RunwayCalculatorPage() {
             Need Help Extending Your Runway?
           </h2>
           <p className="text-xl text-primary-100 mb-8">
-            Our fractional CFO services help startups optimize burn rate, build financial models, and prepare for fundraising.
+            Our Fractional CFO service helps startups optimise burn rate, build financial models, and prepare for fundraising.
           </p>
           <a
             href="/contact/"

--- a/content/blog/financial-modeling-seed-stage-startups.md
+++ b/content/blog/financial-modeling-seed-stage-startups.md
@@ -1,16 +1,16 @@
 ---
-title: 'Financial Modeling for Seed-Stage Startups: A Practical Guide'
-seoTitle: 'Financial Modeling for Seed-Stage Startups'
+title: 'Financial Modelling for Seed-Stage Startups: A Practical Guide'
+seoTitle: 'Financial Modelling for Seed-Stage Startups'
 description: 'What investors actually want to see in your financial model—revenue projections, unit economics, and scenario planning that builds confidence.'
 date: '2025-10-15'
 author: 'Michelle Rana'
 readTime: '8 min read'
-tags: ['Financial Modeling', 'Startup Finance']
+tags: ['Financial Modelling', 'Startup Finance']
 ---
 
-# Financial Modeling for Seed-Stage Startups: A Practical Guide
+# Financial Modelling for Seed-Stage Startups: A Practical Guide
 
-You're preparing to raise your seed round. An investor asks: "Walk me through your financial model." If that question makes you nervous, you're not alone. Most first-time founders struggle with financial modeling—not because it's impossibly complex, but because no one teaches you what investors actually want to see.
+You're preparing to raise your seed round. An investor asks: "Walk me through your financial model." If that question makes you nervous, you're not alone. Most first-time founders struggle with financial modelling—not because it's impossibly complex, but because no one teaches you what investors actually want to see.
 
 This guide breaks down exactly how to build a financial model that satisfies investors while helping you run your business better.
 
@@ -180,7 +180,7 @@ Based on conversations with seed and Series A investors, here's what they focus 
 
 They're not looking for perfect predictions—they're assessing whether you understand your business drivers and can think clearly about the future.
 
-## Tools for Financial Modeling
+## Tools for Financial Modelling
 
 | Tool | Best For | Cost |
 |------|----------|------|
@@ -213,7 +213,7 @@ A well-organised model typically has these tabs:
 3. **Update monthly:** A model is only useful if it reflects current reality
 4. **Get feedback:** Have a CFO or financial advisor review before investor meetings
 
-Financial modeling is a skill that improves with practice. Your first model won't be perfect—but building it will force you to think rigorously about your business, and that clarity is valuable whether or not you raise funding.
+Financial modelling is a skill that improves with practice. Your first model won't be perfect—but building it will force you to think rigorously about your business, and that clarity is valuable whether or not you raise funding.
 
 ---
 

--- a/content/blog/fractional-cto-vs-full-time-cto-uk-startups.md
+++ b/content/blog/fractional-cto-vs-full-time-cto-uk-startups.md
@@ -66,7 +66,7 @@ A good fractional CTO provides:
 - **Technical Strategy** — Architecture decisions, build vs buy, technology selection
 - **Team Leadership** — Hiring support, engineering culture, developer mentorship
 - **Investor Readiness** — Technical due diligence prep, CTO-in-meetings for fundraising
-- **Vendor Management** — Contract negotiation, AWS/GCP optimization, tool selection
+- **Vendor Management** — Contract negotiation, AWS/GCP optimisation, tool selection
 - **Risk Mitigation** — Security architecture, compliance guidance, disaster recovery
 
 The difference from a consultant? A fractional CTO has accountability for outcomes, not just advice. They're in your Slack, your standups, your board meetings.

--- a/content/blog/seis-eis-tax-benefits-startup-investors.md
+++ b/content/blog/seis-eis-tax-benefits-startup-investors.md
@@ -183,7 +183,7 @@ Apply before you start fundraising. Having HMRC confirmation makes investor conv
 If raising more than £250k, structure as SEIS for the first £250k, then EIS for the rest. This maximizes investor tax benefits.
 
 ### 3. Work with Experienced Advisors
-SEIS/EIS has nuances and traps. Use a lawyer and accountant who specialize in startup fundraising to ensure compliance.
+SEIS/EIS has nuances and traps. Use a lawyer and accountant who specialise in startup fundraising to ensure compliance.
 
 ### 4. Document Everything
 Keep clear records of:

--- a/content/blog/startup-unit-economics-explained.md
+++ b/content/blog/startup-unit-economics-explained.md
@@ -294,4 +294,4 @@ Track them monthly. Improve them systematically. Present them honestly to invest
 
 ---
 
-*Need help building your financial model and unit economics? Our [fractional CFO services](/services/fractional-cfo/) include metrics analysis and investor-ready financial modeling.*
+*Need help building your financial model and unit economics? Our [fractional CFO services](/services/fractional-cfo/) include metrics analysis and investor-ready financial modelling.*


### PR DESCRIPTION
Full site review of 5 August 2026 — journey, branding, trust, SEO, accessibility — plus every fix that did not need owner input. The report is added as `WEBSITE_REVIEW_2026-08-05.md`; it does not repeat the two earlier reports.

## What the review found

The August remediation work landed. Verified rather than assumed: **zero contrast failures** on any rendered text node across 13 pages, no broken internal links in the 41-page build, correct canonicals/OG/titles/FAQPage schema throughout, the sticky-CTA-over-submit bug genuinely fixed at 375px, privacy notices at both live collection points.

Two things were holding the site back, and neither was what the earlier reviews were about.

### 1. `/refer` lost business and leaked personal data

`app/refer/page.js` was a server component whose `<form>` had no `action` and no submit handler. Exercised in the browser, pressing **Submit Referral** did a GET back to the same page:

```
/refer/?referrer_name=TESTNAME&referrer_email=&founder_name=&founder_email=founder%40example.com&company_name=&context=
```

The referral was silently lost, and both parties' names and email addresses landed in browser history, server logs and the `Referer` header of every subsequent request. No privacy notice at the point of collection, and `/privacy` did not list the form at all. The page promised a £2,000 bounty and a 48-hour callback against a mechanism that could deliver neither — while carrying 40 sitewide footer links, the same internal-link footprint as either service page.

### 2. The unsourced claims survived on `/case-studies`

The claims stripped from the homepage under BRANDING §2.2 were still live on the page an investor reads hardest — "maintaining 100% uptime", "contributed to 10% revenue increase" (a revenue claim about a third party), "accelerated delivery by 40%", "cut deployment errors by 30%" — four figures with no denominator and no source, sitting directly **above** the Regeno study that prints *"outcome figures go up once they are measured"*. The same page argued both positions.

The Rungway study also described the client as needing "fractional CTO support", reintroducing the exact mislabel §13.15 exists to prevent: the title was Lead Software Engineer, a month before the firm's August 2017 boundary.

## What this PR changes

| # | Change |
|---|---|
| C1 | New `ReferralForm` client component sending through the **existing** EmailJS template (`engagement: 'referral'`), the same approach `RunwayCalculator` already uses — no new template needed. Submits properly, prints a real success/error state, puts nothing in the URL. The referred founder's email is now optional behind an explicit "they know about this introduction" confirmation. Privacy line at the point of collection; `/privacy` gains the form as a third collection point plus an "If someone referred you to us" section covering the Art. 14 position. |
| H1 | Five unsupported claims removed from `/case-studies`, each replaced by a named artefact or a bounded fact. A comment on the data array records the rule and lists what was removed. |
| H2 | Rungway reframed: "Ankit joined as Lead Software Engineer, with the scope of a CTO, a year before Codenest existed." |
| H3 | Each CFO benefit tile gains an attributed `proof` line (±3% forecasts, 14→8 day close, Board and investor reporting, the testimonial-backed Series A). FAQs 5 → 10, exact parity with the CTO page. Dishoom figures stay attached to Michelle's role per §13.15. |
| H6 | Contact form's error state prints `hello@codenest.uk` as a live mailto; success message matches the 24-hour promise under the button; status region gains `role="status"`/`aria-live`. |
| M1 | "Absolutely", "we excel at", "many of our clients", "comprehensive" and the unsupported sector claim rewritten across both service pages and `/refer`. |
| M2 | "A decade of regulated delivery" → "since 2017" (the boundary is August 2017; that is nine years). |
| M3 | Duplicate "How We Work" block deleted from `/about`; the homepage keeps the canonical four. |
| M4 | British English across `app/` and `content/`. |
| M5 | Footer labels aligned to the nav: About, Blog, How We Work. |
| M7 | `width`/`height` on all seven client logos and the nav logo; `loading="lazy"` on the strip. |
| M8 | Footer tap targets 17px → 32px at 375px (WCAG 2.2 AA 2.5.8). |
| Low | Space before `<br />` in five headings; explicit `robots: noindex, nofollow` on the 404; dead `.cta-bounce` infinite animation removed; "Fractional CFO service" capitalised; blog `h1` → "Fractional CTO & CFO Insights"; `/about` eyebrow → "Meet Your Fractional CTO & CFO"; "Michelle Rana FCCA" on the `/about` card. |

### Two deliberate exceptions to the spelling sweep

- The blog slug `financial-modeling-seed-stage-startups` stays US-spelled — changing it breaks a live URL GitHub Pages cannot redirect.
- The client testimonial quote in `Testimonials.js` is left verbatim. §13.12 bars rewording those, and that includes spelling.

## Verification

Clean `npm run build` (45 pages, exported). Re-checked after the changes: zero contrast failures across seven pages, no broken internal links, freshness gate green, no console errors, no horizontal overflow at 375px. The referral form was submitted in the browser to confirm it sends and that the URL stays clean.

## For the reviewer

- **The permission checkbox on the referral form is a judgement call, not a requested change.** The alternative reading is that cold-approaching someone on a stranger's say-so is a PECR question a tickbox should not paper over. Worth a decision either way.
- A **test referral email** was sent to the inbox during verification (referrer "Jane Smith / jane@example.com", founder "Alex Johnson") — safe to delete.

## Still open, all four needing the owner

1. Michelle has **no Codenest row** on the `/about` timeline — under a heading reading "Two Careers, One Practice", the practice appears in only one career. Needs her Codenest dates, or a statement of when the seat starts.
2. Founder photographs — `/about` still shows letter avatars, which BRANDING §5 bars in production.
3. Photography at ≥1600px: five slots still ship 800px images.
4. **One CFO case study.** Dishoom framed as pedigree with dates needs no client permission and closes the largest remaining gap on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)