### PR TITLE
Separate published, updated and verified dates on blog posts

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -265,6 +265,16 @@ Assemble pages from these; don't invent parallel patterns:
 - **Blog:** meta description = frontmatter `description`; post CTA is tag-aware
   (finance tags → Fractional CFO CTA, technical tags → Fractional CTO CTA);
   evergreen titles carry no year unless the content is genuinely refreshed annually.
+- **Three blog date fields, and they are not interchangeable** (5 Aug 2026):
+  `date` is when the post was **first** published — write it once, never move it,
+  not for a typo and not for a rewrite; it is `datePublished`. `updated` is when
+  the content last substantively changed; it is `dateModified` and it is what a
+  rewrite moves. `lastVerified` is when a human last checked the post's expiring
+  facts against source; it drives the freshness gate only and never reaches the
+  page. `date` used to absorb all three: six posts had it overwritten on rewrite,
+  which left ten of twenty sharing two dates, published a 2025 post as today's,
+  and dropped the index sort into `readdir` order for half the page. The index
+  sorts on `updated || date` and breaks ties on slug.
 - **Pricing:** **Codenest publishes no prices of its own** (owner, 4 Aug 2026). The
   £3k/£2.5k-per-month anchors are retired from pages, metadata, guides and posts.
   Engagements are described as "scoped to your stage"; the quote comes on the call.

--- a/app/blog/[slug]/page.js
+++ b/app/blog/[slug]/page.js
@@ -5,7 +5,8 @@ import rehypeHighlight from 'rehype-highlight'
 import Navigation from '../../components/Navigation'
 import Footer from '../../components/Footer'
 import CusdisComments from '../../components/CusdisComments'
-import { getBlogPost, getAllBlogSlugs } from '../../../lib/blog'
+import { getBlogPost, getAllBlogSlugs, modifiedAt } from '../../../lib/blog'
+import { formatDate } from '../../../lib/formatDate'
 import 'highlight.js/styles/github-dark.css'
 
 export function generateStaticParams() {
@@ -33,6 +34,7 @@ export async function generateMetadata({ params }) {
       description: description,
       type: 'article',
       publishedTime: post.date,
+      modifiedTime: post.updated || post.date,
       authors: [post.author],
       tags: post.tags,
       url: `https://codenest.uk/blog/${slug}/`,
@@ -125,7 +127,10 @@ export default async function BlogPost({ params }) {
     },
     image: 'https://codenest.uk/img/og-default.png',
     datePublished: post.date,
-    dateModified: post.updated || post.date,
+    // `updated` when the content changed, otherwise the publication date. This
+    // read `post.updated` before the field existed on any post, so dateModified
+    // was always a copy of datePublished (site review, 5 Aug 2026).
+    dateModified: modifiedAt(post),
     mainEntityOfPage: {
       '@type': 'WebPage',
       '@id': `https://codenest.uk/blog/${slug}/`
@@ -195,22 +200,30 @@ export default async function BlogPost({ params }) {
             ))}
           </div>
 
-          <h1 className="text-4xl md:text-5xl font-bold text-slate-900 mb-6">
+          {/* font-serif: BRANDING §4 reserves the display face for h1 and section
+              h2. The blog index h1 was corrected for this and the article template
+              was missed, which left every post — the site's main organic entry
+              points — with an off-brand headline. */}
+          <h1 className="font-serif text-4xl md:text-5xl font-bold text-slate-900 mb-6">
             {post.title}
           </h1>
 
-          <div className="flex items-center gap-4 text-slate-600">
-            <time dateTime={post.date}>
-              {new Date(post.date).toLocaleDateString('en-US', {
-                month: 'long',
-                day: 'numeric',
-                year: 'numeric'
-              })}
-            </time>
-            <span>•</span>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-slate-600">
+            <time dateTime={post.date}>{formatDate(post.date)}</time>
+            <span aria-hidden="true">•</span>
             <span>{post.readTime}</span>
-            <span>•</span>
+            <span aria-hidden="true">•</span>
             <span>{post.author}</span>
+            {/* Only when the content actually changed. `lastVerified` is a
+                fact-check date and deliberately never shown here. */}
+            {post.updated && (
+              <>
+                <span aria-hidden="true">•</span>
+                <span className="text-slate-500">
+                  Updated <time dateTime={post.updated}>{formatDate(post.updated)}</time>
+                </span>
+              </>
+            )}
           </div>
         </header>
 

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { getAllBlogPosts } from '../../lib/blog'
+import { formatDate } from '../../lib/formatDate'
 import Navigation from '../components/Navigation'
 import Footer from '../components/Footer'
 import JsonLd from '../components/JsonLd'
@@ -108,6 +109,18 @@ export default function BlogPage() {
                       {post.description}
                     </p>
                   </div>
+
+                  {/* The index carried no date at all, which is a gap on a blog
+                      and is also what hid ten posts sharing two dates. */}
+                  <p className="mt-4 pt-3 border-t border-slate-100 text-xs text-slate-500">
+                    <time dateTime={post.date}>{formatDate(post.date)}</time>
+                    {post.updated && (
+                      <>
+                        {' · updated '}
+                        <time dateTime={post.updated}>{formatDate(post.updated)}</time>
+                      </>
+                    )}
+                  </p>
                 </article>
               </Link>
             ))}

--- a/app/feed.xml/route.js
+++ b/app/feed.xml/route.js
@@ -1,4 +1,4 @@
-import { getAllBlogPosts } from '../../lib/blog'
+import { getAllBlogPosts, modifiedAt } from '../../lib/blog'
 import { BASE_URL } from '../../lib/schema'
 
 // Required for static export (GitHub Pages) — same reason as app/sitemap.js.
@@ -15,7 +15,12 @@ function escapeXml(value) {
 
 export function GET() {
   const posts = getAllBlogPosts()
-  const lastBuild = posts.length ? new Date(posts[0].date) : new Date(0)
+  // The newest activity, not the newest publication: posts sort on
+  // `updated || date`, so reading `.date` off the first one would report a 2025
+  // publication date as the channel's last build and march backwards whenever an
+  // older post is revised. `pubDate` below stays the publication date, which is
+  // what RSS means by it.
+  const lastBuild = posts.length ? new Date(modifiedAt(posts[0])) : new Date(0)
 
   const items = posts
     .map((post) => {

--- a/content/blog/gitops-startup-deployment-github-actions.md
+++ b/content/blog/gitops-startup-deployment-github-actions.md
@@ -2,7 +2,8 @@
 title: 'GitOps for Startups: Is Automating Your Deployments Worth It?'
 seoTitle: 'GitOps for Startups: Is It Worth the Setup?'
 description: 'A non-technical guide to deployment automation: what manual deploys really cost, when automating pays back, and the questions to ask before approving the work.'
-date: '2026-08-05'
+date: '2025-11-07'
+updated: '2026-08-05'
 author: 'Ankit Rana'
 readTime: '8 min read'
 tags: ['GitOps', 'DevOps', 'Non-Technical Founders']

--- a/content/blog/how-much-does-fractional-cto-cost-uk.md
+++ b/content/blog/how-much-does-fractional-cto-cost-uk.md
@@ -2,7 +2,8 @@
 title: 'How Much Does a Fractional CTO Cost in the UK? 2026 Pricing Guide'
 seoTitle: 'How Much Does a Fractional CTO Cost in the UK?'
 description: 'UK pricing for fractional CTO services in 2026: retainer costs, engagement levels, and how to budget for part-time technical leadership.'
-date: '2026-08-04'
+date: '2025-01-06'
+updated: '2026-08-04'
 author: 'Ankit Rana'
 readTime: '7 min read'
 tags: ['Fractional CTO', 'Pricing', 'Budgeting']

--- a/content/blog/infrastructure-as-code-for-startups.md
+++ b/content/blog/infrastructure-as-code-for-startups.md
@@ -2,7 +2,8 @@
 title: 'Infrastructure as Code for Startups: Why It Matters for Your Next Raise'
 seoTitle: 'Infrastructure as Code for Startups'
 description: 'Why "we click around in the AWS console" is a red flag in due diligence, what investors ask, and how to fix it in the months before you open a round.'
-date: '2026-08-05'
+date: '2025-11-07'
+updated: '2026-08-05'
 author: 'Ankit Rana'
 readTime: '8 min read'
 tags: ['Infrastructure', 'Due Diligence', 'Non-Technical Founders']

--- a/content/blog/kubernetes-startups-overkill-essential.md
+++ b/content/blog/kubernetes-startups-overkill-essential.md
@@ -2,7 +2,8 @@
 title: "Kubernetes for Startups: When It Makes Sense (And When It Doesn't)"
 seoTitle: 'Kubernetes for Startups: Overkill or Essential?'
 description: 'A non-technical guide to the Kubernetes decision: what it costs in engineer time, the cheaper options your team may have skipped, and when it pays off.'
-date: '2026-08-05'
+date: '2025-11-07'
+updated: '2026-08-05'
 author: 'Ankit Rana'
 readTime: '8 min read'
 tags: ['Kubernetes', 'Infrastructure', 'Non-Technical Founders']

--- a/content/blog/non-technical-founder-hiring-developers.md
+++ b/content/blog/non-technical-founder-hiring-developers.md
@@ -2,7 +2,8 @@
 title: "Non-Technical Founder's Guide to Hiring Developers in 2026"
 seoTitle: 'Hiring Developers as a Non-Technical Founder'
 description: "How to hire developers when you are not technical yourself. Practical guide covering where to find developers, how to evaluate them, and what to pay."
-date: '2026-08-04'
+date: '2025-01-02'
+updated: '2026-08-04'
 author: 'Ankit Rana'
 readTime: '11 min read'
 tags: ['Hiring', 'Team Building', 'Non-Technical Founders']

--- a/content/blog/terraform-aws-infrastructure-as-code.md
+++ b/content/blog/terraform-aws-infrastructure-as-code.md
@@ -2,7 +2,8 @@
 title: 'AWS Infrastructure for Startups: What Founders Actually Need to Decide'
 seoTitle: 'AWS Infrastructure for Startups: Founder Guide'
 description: 'A non-technical guide to infrastructure decisions: what to spend at each stage, which tool your team should pick, and the five questions to ask your engineers.'
-date: '2026-08-05'
+date: '2025-11-07'
+updated: '2026-08-05'
 author: 'Ankit Rana'
 readTime: '9 min read'
 tags: ['AWS', 'Infrastructure', 'Non-Technical Founders']

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -29,12 +29,40 @@ export function getBlogPost(slug) {
   }
 }
 
+// Three date fields, three different jobs. They are not interchangeable, and
+// conflating them is how the index ended up ordering itself alphabetically.
+//
+//   date         When the post was FIRST published. Write it once. Never move it
+//                — not for a typo, not for a rewrite. It is `datePublished`.
+//   updated      When the content was last substantively changed. Optional. It is
+//                `dateModified`, and it is what a rewrite moves.
+//   lastVerified When a human last checked the post's expiring facts against
+//                source (see scripts/check-content-freshness.js). It is neither
+//                of the above and never reaches the page: re-checking a tax rate
+//                is not a content change.
+//
+// `date` used to absorb all three. Six posts had it overwritten on rewrite —
+// gitops, infrastructure-as-code, kubernetes and terraform all went 2025-11-07 →
+// 2026-08-05 — which left ten of twenty posts sharing two dates, told Google a
+// 2025 post was published today, and made the sort below a tie for half the
+// index. (Site review, 5 Aug 2026.)
+export function publishedAt(post) {
+  return post.date
+}
+
+export function modifiedAt(post) {
+  return post.updated || post.date
+}
+
 export function getAllBlogPosts() {
   const slugs = getAllBlogSlugs()
   const posts = slugs.map(slug => getBlogPost(slug))
 
-  // Sort posts by date (newest first)
+  // Newest activity first, so a substantive rewrite resurfaces. Ties break on
+  // slug rather than falling through to readdir order — which is what actually
+  // decided the top of the index while ten posts shared two dates.
   return posts.sort((a, b) => {
-    return new Date(b.date) - new Date(a.date)
+    const delta = new Date(modifiedAt(b)) - new Date(modifiedAt(a))
+    return delta !== 0 ? delta : a.slug.localeCompare(b.slug)
   })
 }

--- a/lib/formatDate.js
+++ b/lib/formatDate.js
@@ -1,0 +1,13 @@
+// One date format for the whole site: "5 August 2026".
+//
+// The article template used to call toLocaleDateString('en-US'), which rendered
+// "August 5, 2026" on a site whose style guide is British English (§2.7) and
+// whose /privacy page writes the British form two clicks away. Shared here so the
+// index and the article cannot drift apart again.
+export function formatDate(value) {
+  return new Date(value).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}


### PR DESCRIPTION
Follows the blog review. `date` was absorbing three different meanings, and rewrites overwrote it.

## What was wrong

Six posts lost their real publication date. From git history:

| Post | Published | Overwritten to |
|---|---|---|
| `gitops-startup-deployment-github-actions` | 2025-11-07 | 2026-08-05 |
| `infrastructure-as-code-for-startups` | 2025-11-07 | 2026-08-05 |
| `kubernetes-startups-overkill-essential` | 2025-11-07 | 2026-08-05 |
| `terraform-aws-infrastructure-as-code` | 2025-11-07 | 2026-08-05 |
| `how-much-does-fractional-cto-cost-uk` | 2025-01-06 | 2026-08-04 |
| `non-technical-founder-hiring-developers` | 2025-01-02 | 2026-08-04 |

Three consequences:

1. **The index ordered itself alphabetically.** Ten of twenty posts shared two dates, so `getAllBlogPosts` sorted on a tie for half the page and fell through to `fs.readdirSync` order. The first five cards were gitops, how-cfos, infrastructure-as-code, kubernetes, terraform — alphabetical, not editorial.
2. **The schema claimed a false publication date.** `datePublished` and `article:published_time` told Google a 2025 post was published today.
3. **`dateModified` was dead code.** It read `post.updated`, a field *no post had* — zero of twenty — so it was always a copy of `datePublished`. `app/sitemap.js` read the same missing field, so its blog `lastModified` was equally inert.

## The fix

Three fields, three jobs, documented in `lib/blog.js` and recorded in BRANDING §8:

- **`date`** — first published. Written once. Never moved, not for a typo and not for a rewrite. It is `datePublished`.
- **`updated`** — content last substantively changed. It is `dateModified`, and it is what a rewrite moves.
- **`lastVerified`** — when a human last checked the post's expiring facts against source. Drives the freshness gate only and never reaches the page, because re-checking a tax rate is not a content change. (This is why `dateModified` is *not* wired to it — `scripts/check-content-freshness.js` says so explicitly in its header.)

The six overwritten dates are restored from git history, with the rewrite recorded as `updated`. The index now sorts on `updated || date` and breaks ties on slug rather than directory order, so a substantive rewrite still resurfaces a post without falsifying when it was written.

`feed.xml` takes `lastBuildDate` from the newest *activity* rather than `posts[0].date`, which would otherwise have marched backwards whenever an older post was revised. `pubDate` stays the publication date, which is what RSS means by it.

## Also in this PR

- **Post `h1` gains `font-serif`.** BRANDING §4 reserves the display face for h1 and section h2. The blog index was corrected for this drift; the article template was missed — leaving all 20 posts, the site's main organic entry points, with an off-brand headline.
- **Dates render on the index cards.** There were none at all, which is a gap on any blog and is what hid the clustering from view.
- **One shared en-GB date helper** (`lib/formatDate.js`). The article template was calling `toLocaleDateString('en-US')` and printing "August 5, 2026" on a British-English site whose `/privacy` page writes the British form two clicks away.

## Verification

Clean build (45 pages). Rewritten post now emits `"datePublished":"2025-11-07","dateModified":"2026-08-05"`; a genuinely new post emits the same date for both. Both `h1`s computed as Playfair Display in the browser. Zero contrast failures on the index and on an article. Freshness gate green, 5 tracked posts.

Index order after the change — a real chronological tail instead of an alphabetical block:

```
 1. GitOps for Startups                   7 November 2025 · updated 5 August 2026
 2. How CFOs Can Use AI in Startup Finance          5 August 2026
 ...
11. Fractional CTO vs Full-Time CTO               13 January 2026
12. Financial Modelling for Seed-Stage Startups   15 October 2025
...
20. MVP vs MLP                                   18 December 2024
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)