### PR TITLE
Require a visual on every blog post, and make the agent docs load lazily

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,22 +8,27 @@ Next.js site for GitHub Pages deployment.
 - **Deploy**: `output: 'export'` in next.config.js, `.nojekyll` file
 - **Audience**: Startup founders (0→1 journey)
 - **Tone**: Professional, technical, no emojis
-- **Brand**: Read `BRANDING.md` (repo root) BEFORE any copy, design, metadata, or
-  component change — it is the canonical brand law (service naming, taglines, voice,
-  colour/contrast rules, CTA label, claims policy). Services are always named
-  "Fractional CTO" and "Fractional CFO".
+- **Brand**: `BRANDING.md` (repo root) is the canonical brand law — service naming,
+  taglines, voice, colour/contrast rules, CTA label, claims policy. Read its section
+  index, then the sections you need, BEFORE any copy, design, metadata, or component
+  change. Services are always named "Fractional CTO" and "Fractional CFO".
+- **Blog**: every post carries at least one visual, and it should be a diagram, not a
+  photograph (BRANDING §7). Read `.claude/docs/blog-authoring.md` BEFORE writing or
+  editing a post — it holds the diagram mechanism, the frontmatter date contract, and
+  the traps that fail silently.
 
-## Agent Routing
+## Fails Silently
 
-| Task | Agent |
-|------|-------|
-| Content/SEO | `cmo` |
-| UI/UX | `frontend-engineer` or `ui-designer` |
-| Deploy | `devops-engineer` |
+Nothing below errors — it ships looking wrong:
+
+- Raw HTML/SVG in `content/blog/*.md` is **stripped** (no `rehype-raw`).
+- Page `title` must NOT contain "| Codenest" — the template appends it.
+- Canonicals and sitemap URLs carry a trailing slash (`trailingSlash: true`).
+- A stale `lastVerified` in a post **fails the build** via `prebuild`.
 
 ## Definition of Done
 
-- [ ] `npm run build` passes
-- [ ] Lighthouse > 90
-- [ ] Mobile responsive
-- [ ] Meta tags + OG tags present
+- [ ] `npm run build` passes (runs the freshness gate, regenerates OG cards)
+- [ ] No horizontal overflow at 375px
+- [ ] Text contrast ≥ 4.5:1 (3:1 for large text and graphics)
+- [ ] One h1 carrying the page's target term; meta + OG tags present

--- a/.claude/docs/blog-authoring.md
+++ b/.claude/docs/blog-authoring.md
@@ -1,0 +1,68 @@
+# Writing and editing blog posts
+
+Read this before writing or editing anything in `content/blog/`. Brand law is
+`BRANDING.md` (repo root): §2 voice, §7 imagery, §8 blog metadata, §12 content
+strategy.
+
+## Every post carries at least one visual
+
+A prose-only post ships incomplete. Default to a **diagram**, not a photograph:
+BRANDING §7 reserves photography for the hero and case studies, and there is no real
+photograph of a blog post. Never buy an abstract-technology stock image for one.
+
+The diagram must carry **that post's own argument** — the mechanism the prose is
+explaining. If it only restates a table already on the page, cut it and write a better
+one. Place it in the section it explains, not at the end as decoration.
+
+### Adding one
+
+Write the marker on its own line, **with a blank line either side**:
+
+```
+[diagram:cac-payback]
+```
+
+Names are `[a-z0-9-]+` and must exist in `app/components/diagrams/registry.js`. An
+unknown name **fails the build** — there is no silent fallback.
+
+A new diagram is *data*, not markup. Add a registry entry using one of the six shapes
+in `app/components/diagrams/shapes.js` — `Flow`, `Cycle`, `Stack`, `Split`, `Timeline`,
+`Curve`. Never hand-draw an SVG: the shapes hold the brand rules (stroke 2, brand
+colours, one type scale) and emit the `role`/`title`/`desc` an SVG needs to be
+announced as anything at all.
+
+**Colour is meaning, not variety.** `trackName` is `technical` (charcoal) or
+`financial` (gold) and matches the post's track. Inside a `Split`, only the
+recommended column takes `emphasis: true`; the rest stay neutral. Colouring columns
+decoratively once put gold — the financial accent — on "AWS CDK" in a technical post,
+which asserts something untrue.
+
+## Frontmatter
+
+| Field | Meaning |
+|---|---|
+| `date` | First published. **Write once** — bumping it destroys the publication date. |
+| `updated` | Optional. Drives `dateModified` and the visible "Updated" line. |
+| `lastVerified` | When a human checked the facts against source. Never rendered. |
+| `verifyEvery` | Months before re-checking (default 12). Never rendered. |
+| `tags` | Route the post's CTA **and** its OG card colour to the CTO or CFO track. |
+
+OG cards are generated per post from the slug in `prebuild` — a new post gets one
+automatically; a retitled post needs a rebuild so its card is not stale.
+
+## Fails silently — nothing errors, it just renders wrong
+
+- **Raw HTML or SVG in a `.md` file is stripped.** There is no `rehype-raw` in the
+  pipeline, so `<img>`, `<svg>` and `<div>` vanish without a warning. This is why
+  diagrams are markers, not markup.
+- **A marker without blank lines around it renders as the literal text
+  `[diagram:foo]`.** It has to be its own paragraph.
+- **Overwriting `date`** silently loses the publication date; only git history has it.
+- **A stale `lastVerified` fails the build** through the `prebuild` freshness gate.
+
+## Before you finish
+
+- `npm run build` — runs the freshness gate and regenerates every OG card.
+- British English throughout (modelling, organise, optimise) — but **never reword a
+  client testimonial**, spelling included (BRANDING §13.12).
+- Claims need attribution or they come out (BRANDING §2).

--- a/BRANDING.md
+++ b/BRANDING.md
@@ -19,6 +19,25 @@ editorial voice for headlines, and claims you could defend in a due-diligence ro
 - Sitewide metadata + JSON-LD: `app/layout.js`
 - Logo assets: `public/img/companylogo.svg` (light bg), `companylogo-light.svg` (dark bg)
 
+**Section index** — this file is long. Read the sections your change touches rather
+than the whole thing; §13 is the law and settles conflicts.
+
+| § | Covers |
+|---|--------|
+| 1 | Brand essence: name, the two seats, taglines, ICP, the two principals |
+| 2 | Voice & tone: person, banned words, claims and substantiation policy |
+| 3 | Colour: palette, approved pairings, contrast |
+| 4 | Typography: fonts, type scale, serif/sans split |
+| 5 | Layout & surfaces: spacing, containers, overflow rules |
+| 6 | Components: section grammar, CTAs, trust chips, FAQ |
+| 7 | Iconography & imagery: icons, alt text, diagrams vs photography |
+| 8 | Metadata & SEO: titles, schema, canonicals, OG, blog conventions |
+| 9 | Logo: variants and clear space |
+| 10 | Accessibility & quality bar |
+| 11 | Implementation notes: build, export, deploy constraints |
+| 12 | Content strategy guardrails |
+| 13 | Standing rules (the law, with dates) |
+
 ---
 
 ## 1. Brand essence
@@ -241,6 +260,21 @@ Assemble pages from these; don't invent parallel patterns:
   panel is anchored by a label at top and a footnote at bottom with the stack centred
   between them. If a future layout looks stretched or hollow, add content to the
   layers — never let a connector grow without a cap.
+- **Every blog post carries at least one visual, and it should be a diagram.** A
+  prose-only post ships incomplete; a stock photograph on a blog post is never the
+  answer (photography stays on the hero and case studies). A post writes
+  `[diagram:name]` on its own line and the renderer resolves it against
+  `app/components/diagrams/registry.js`, whose entries are *data* passed to the six
+  shapes in `shapes.js` — `Flow`, `Cycle`, `Stack`, `Split`, `Timeline`, `Curve`. An
+  unknown name fails the build; raw SVG in a `.md` file is silently stripped, which is
+  why the marker exists at all. **The diagram carries the post's own argument** — if it
+  restates a table already on the page, it is padding, so diagram the mechanism behind
+  the table instead. **Colour is meaning, not variety:** `trackName` follows the post's
+  track, and inside a `Split` only the recommended column takes `emphasis` — colouring
+  columns decoratively once put gold, the financial accent, on "AWS CDK" in a technical
+  post, which asserts something untrue. Authoring detail: `.claude/docs/blog-authoring.md`.
+  (5 Aug 2026: all twenty posts had no images whatsoever; every one now has a diagram
+  and its own 1200×630 OG card, generated per slug in `prebuild`.)
 
 ## 8. Metadata & SEO conventions
 

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -4,10 +4,16 @@ import matter from 'gray-matter'
 
 const blogDirectory = path.join(process.cwd(), 'content/blog')
 
+// A post is a lowercase-kebab .md file, because its filename becomes the URL slug.
+// A bare `.md` filter publishes anything else dropped in here — a README, a notes
+// file — as a live post with no title and no date, onto the index, the sitemap and
+// the RSS feed, without erroring.
+export const isPostFile = (fileName) => /^[a-z0-9-]+\.md$/.test(fileName)
+
 export function getAllBlogSlugs() {
   const fileNames = fs.readdirSync(blogDirectory)
   return fileNames
-    .filter(fileName => fileName.endsWith('.md'))
+    .filter(isPostFile)
     .map(fileName => fileName.replace(/\.md$/, ''))
 }
 

--- a/scripts/check-content-freshness.js
+++ b/scripts/check-content-freshness.js
@@ -53,7 +53,10 @@ function readPosts() {
 
   return fs
     .readdirSync(BLOG_DIR)
-    .filter((file) => file.endsWith('.md'))
+    // Posts are lowercase-kebab (the filename is the slug); any other .md dropped in
+    // here is not content and must not be gated. Kept in step with `isPostFile` in
+    // lib/blog.js.
+    .filter((file) => /^[a-z0-9-]+\.md$/.test(file))
     .map((file) => {
       const { data } = matter(fs.readFileSync(path.join(BLOG_DIR, file), 'utf8'))
       return { slug: file.replace(/\.md$/, ''), frontmatter: data }

--- a/scripts/generate-og-cards.js
+++ b/scripts/generate-og-cards.js
@@ -102,7 +102,10 @@ function card({ title, track, readTime, author }) {
 
 async function main() {
   fs.mkdirSync(OUT_DIR, { recursive: true })
-  const files = fs.readdirSync(BLOG_DIR).filter((f) => f.endsWith('.md'))
+  // Posts are lowercase-kebab (the filename is the slug); any other .md dropped in
+  // here would otherwise render a card titled "undefined". Kept in step with
+  // `isPostFile` in lib/blog.js.
+  const files = fs.readdirSync(BLOG_DIR).filter((f) => /^[a-z0-9-]+\.md$/.test(f))
 
   for (const file of files) {
     const slug = file.replace(/\.md$/, '')


### PR DESCRIPTION
Every blog post got a diagram in #72, but nothing wrote that down as a rule — so the next post authored would have been prose-only again. This records the rule, and fixes three things the agent docs got wrong while I was in them.

## The rule

**Every blog post carries at least one visual, and it should be a diagram, not a photograph.** BRANDING §7 already reserves photography for the hero and case studies, and there is no real photograph of a blog post. It lands in three places, sized to how often each is read:

| File | Holds | Cost |
|---|---|---|
| `.claude/CLAUDE.md` | The rule, one line, plus a pointer | always loaded |
| `BRANDING.md` §7 | Canonical law, beside the existing "a schematic beats a stock photo" | read by section |
| `.claude/docs/blog-authoring.md` | The mechanism, frontmatter contract, silent traps | read when writing a post |

The detail file covers what an agent cannot infer from the code: the `[diagram:name]` marker needs a blank line either side, names resolve against `registry.js` and an unknown one fails the build, new diagrams are data passed to one of the six shapes rather than hand-drawn SVG, and colour is meaning — inside a `Split` only the recommended column takes `emphasis`.

## The token cost was in the wrong file

`.claude/CLAUDE.md` is ~185 tokens. It was never the problem. **`BRANDING.md` is ~8,500**, and CLAUDE.md instructed every agent to read all of it *"BEFORE any copy, design, metadata, or component change"* — which is nearly every task.

BRANDING.md now opens with a section index, and the instruction is to read the sections your change touches. A copy edit loads §2 and §13 (~600 tokens) instead of 606 lines. The file stays intact: its section numbers are referenced by code comments, review docs and prior PRs, so splitting it would break those anchors for a saving the index already gets.

Worth noting for anyone tempted: `@BRANDING.md` import syntax would be the *opposite* of lazy — imports inline eagerly into every session.

## Two things the docs got wrong

**The Agent Routing table listed four agents that do not exist.** `cmo`, `frontend-engineer`, `ui-designer`, `devops-engineer` — there is no `.claude/agents/` in this repo, and none of the four resolve at user level either (the nearest is `frontend-developer`, not `frontend-engineer`). Every row failed on use, which is worse than having no table. Deleted.

**"Lighthouse > 90" in the Definition of Done had no runner** anywhere in the repo or in CI — an unverifiable checkbox. Replaced with checks that exist: the build (which runs the freshness gate and regenerates OG cards), no horizontal overflow at 375px, and contrast ratios.

Also added a **"Fails Silently"** section, because that is this repo's characteristic failure mode — raw HTML stripped from markdown, titles double-suffixing to "| Codenest | Codenest", missing trailing slashes, the freshness gate. None are discoverable by reading code; they only surface as a wrong-looking page.

## A separate fix: `content/blog` would publish any stray `.md`

Found while placing the authoring doc — my first attempt put it *in* `content/blog/`, which would have shipped it as a 21st blog post.

All three readers globbed `content/blog/*.md`: [`lib/blog.js`](lib/blog.js), the freshness gate, and the OG card generator. A README or notes file dropped in there publishes itself as a live post with no title and no date — onto the blog index, the sitemap and the RSS feed — plus an OG card titled "undefined". Nothing errors.

Posts are now matched as lowercase-kebab, which is what the filename-is-the-slug contract already assumed everywhere else. The authoring doc lives under `.claude/docs/` regardless, so this guard is separable — it is three one-line regexes and can come out if you would rather keep the diff to documentation.

## Verification

Clean rebuild (`rm -rf .next out && npm run build`):

- Compiled successfully, `✓ Exporting (2/2)`
- **20** exported post pages, **20** OG cards
- **21** sitemap blog entries — 20 posts plus the `/blog/` index, confirmed individually
- Freshness gate: 5 tracked posts, 5 fresh, 0 overdue
- No documentation file leaked into `out/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)